### PR TITLE
Move prompt-length check to its own workflow

### DIFF
--- a/.github/workflows/prompt-length.yml
+++ b/.github/workflows/prompt-length.yml
@@ -1,0 +1,25 @@
+name: Prompt Length
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  prompt-length:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check prompt files are at most 100 lines
+        run: |
+          failed=0
+          for f in prompts/*.md; do
+            lines=$(wc -l < "$f")
+            if [ "$lines" -gt 100 ]; then
+              echo "ERROR: $f has $lines lines (max 100)"
+              failed=1
+            fi
+          done
+          exit $failed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,20 +18,3 @@ jobs:
 
       - name: Run tests
         run: go test ./...
-
-  prompt-length:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Check prompt files are at most 100 lines
-        run: |
-          failed=0
-          for f in prompts/*.md; do
-            lines=$(wc -l < "$f")
-            if [ "$lines" -gt 100 ]; then
-              echo "ERROR: $f has $lines lines (max 100)"
-              failed=1
-            fi
-          done
-          exit $failed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # herm
 
 [![Tests](https://github.com/aduermael/herm/actions/workflows/test.yml/badge.svg)](https://github.com/aduermael/herm/actions/workflows/test.yml)
+[![Prompt Length](https://github.com/aduermael/herm/actions/workflows/prompt-length.yml/badge.svg)](https://github.com/aduermael/herm/actions/workflows/prompt-length.yml)
 
 A coding agent CLI that's containerized by default. Every command runs inside a Docker container, nothing touches your host. No approval prompts, no "are you sure?" dialogs. Just let it work.
 


### PR DESCRIPTION
## Summary
- Extract the prompt-length CI job from `test.yml` into a dedicated `prompt-length.yml` workflow
- Add a Prompt Length badge to the README

## Test plan
- [ ] Verify the new `prompt-length.yml` workflow runs on push/PR to main
- [ ] Verify the `test.yml` workflow no longer includes the prompt-length job
- [ ] Confirm the README badge links to the correct workflow