### PR TITLE
Add CI check for Go source file length

### DIFF
--- a/.github/workflows/source-file-length.yml
+++ b/.github/workflows/source-file-length.yml
@@ -21,5 +21,5 @@ jobs:
               echo "ERROR: $f has $lines lines (max 1500)"
               failed=1
             fi
-          done < <(find . -name '*.go' -not -path './vendor/*')
+          done < <(find . -name '*.go' -not -name '*_test.go' -not -path './vendor/*')
           exit $failed

--- a/.github/workflows/source-file-length.yml
+++ b/.github/workflows/source-file-length.yml
@@ -1,0 +1,25 @@
+name: Go File Length
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  go-file-length:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check Go files are at most 1000 lines
+        run: |
+          failed=0
+          while IFS= read -r f; do
+            lines=$(wc -l < "$f")
+            if [ "$lines" -gt 1000 ]; then
+              echo "ERROR: $f has $lines lines (max 1000)"
+              failed=1
+            fi
+          done < <(find . -name '*.go' -not -path './vendor/*')
+          exit $failed

--- a/.github/workflows/source-file-length.yml
+++ b/.github/workflows/source-file-length.yml
@@ -12,13 +12,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check Go files are at most 1000 lines
+      - name: Check Go files are at most 1500 lines
         run: |
           failed=0
           while IFS= read -r f; do
             lines=$(wc -l < "$f")
-            if [ "$lines" -gt 1000 ]; then
-              echo "ERROR: $f has $lines lines (max 1000)"
+            if [ "$lines" -gt 1500 ]; then
+              echo "ERROR: $f has $lines lines (max 1500)"
               failed=1
             fi
           done < <(find . -name '*.go' -not -path './vendor/*')

--- a/.github/workflows/source-file-length.yml
+++ b/.github/workflows/source-file-length.yml
@@ -1,4 +1,4 @@
-name: Go File Length
+name: Source File Length
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Tests](https://github.com/aduermael/herm/actions/workflows/test.yml/badge.svg)](https://github.com/aduermael/herm/actions/workflows/test.yml)
 [![Prompt Length](https://github.com/aduermael/herm/actions/workflows/prompt-length.yml/badge.svg)](https://github.com/aduermael/herm/actions/workflows/prompt-length.yml)
-[![Go File Length](https://github.com/aduermael/herm/actions/workflows/source-file-length.yml/badge.svg)](https://github.com/aduermael/herm/actions/workflows/source-file-length.yml)
+[![Source File Length](https://github.com/aduermael/herm/actions/workflows/source-file-length.yml/badge.svg)](https://github.com/aduermael/herm/actions/workflows/source-file-length.yml)
 
 A coding agent CLI that's containerized by default. Every command runs inside a Docker container, nothing touches your host. No approval prompts, no "are you sure?" dialogs. Just let it work.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Tests](https://github.com/aduermael/herm/actions/workflows/test.yml/badge.svg)](https://github.com/aduermael/herm/actions/workflows/test.yml)
 [![Prompt Length](https://github.com/aduermael/herm/actions/workflows/prompt-length.yml/badge.svg)](https://github.com/aduermael/herm/actions/workflows/prompt-length.yml)
+[![Go File Length](https://github.com/aduermael/herm/actions/workflows/source-file-length.yml/badge.svg)](https://github.com/aduermael/herm/actions/workflows/source-file-length.yml)
 
 A coding agent CLI that's containerized by default. Every command runs inside a Docker container, nothing touches your host. No approval prompts, no "are you sure?" dialogs. Just let it work.
 


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow (`source-file-length.yml`) that fails if any `.go` file exceeds 1000 lines
- Runs on pushes and PRs to `main`

<img width="567" height="193" alt="Screenshot 2026-03-23 at 5 08 03 PM" src="https://github.com/user-attachments/assets/4be52143-6b4e-4934-959e-dc295a469bb7" />

## Test plan
- [ ] Verify the workflow runs successfully on this PR
- [ ] Confirm it would catch a file exceeding 1000 lines