### PR TITLE
Distinguish Docker not installed from not running

### DIFF
--- a/cmd/herm/background.go
+++ b/cmd/herm/background.go
@@ -147,10 +147,13 @@ func bootContainerCmd(workspace string, sessionID string, ch chan<- any) {
 
 	client := NewContainerClient(ContainerConfig{Image: defaultContainerImage})
 
-	if !client.IsAvailable() {
-		ch <- containerStatusMsg{text: "docker not running"}
-		ch <- containerErrMsg{err: fmt.Errorf(
-			"Docker is not running. Please start Docker Desktop and try again.")}
+	if err := client.CheckDocker(); err != nil {
+		if cerr, ok := err.(*ContainerError); ok && cerr.Code == ErrDockerNotFound {
+			ch <- containerStatusMsg{text: "docker not installed"}
+		} else {
+			ch <- containerStatusMsg{text: "docker not running"}
+		}
+		ch <- containerErrMsg{err: err}
 		return
 	}
 

--- a/cmd/herm/container.go
+++ b/cmd/herm/container.go
@@ -17,11 +17,12 @@ import (
 
 // Container error codes.
 const (
-	ErrDockerNotFound = "DockerNotFound"
-	ErrStartFailed    = "StartFailed"
-	ErrExecFailed     = "ExecFailed"
-	ErrStopFailed     = "StopFailed"
-	ErrNotRunning     = "NotRunning"
+	ErrDockerNotFound    = "DockerNotFound"
+	ErrDockerNotRunning  = "DockerNotRunning"
+	ErrStartFailed       = "StartFailed"
+	ErrExecFailed        = "ExecFailed"
+	ErrStopFailed        = "StopFailed"
+	ErrNotRunning        = "NotRunning"
 )
 
 // ContainerError is a typed error from the container client.
@@ -31,7 +32,7 @@ type ContainerError struct {
 }
 
 func (e *ContainerError) Error() string {
-	return fmt.Sprintf("container %s: %s", e.Code, e.Message)
+	return e.Message
 }
 
 // ContainerConfig holds configuration for the Docker container.
@@ -61,6 +62,9 @@ type ContainerStatus struct {
 // dockerCommand is a function variable for exec.CommandContext, replaceable in tests.
 var dockerCommand = exec.CommandContext
 
+// lookPath is a function variable for exec.LookPath, replaceable in tests.
+var lookPath = exec.LookPath
+
 // ContainerClient manages a Docker container lifecycle.
 type ContainerClient struct {
 	config      ContainerConfig
@@ -74,12 +78,26 @@ func NewContainerClient(config ContainerConfig) *ContainerClient {
 	return &ContainerClient{config: config}
 }
 
-// IsAvailable returns true if Docker is installed and running.
-func (c *ContainerClient) IsAvailable() bool {
+// CheckDocker verifies that the Docker CLI is installed and the daemon is
+// reachable. It returns nil when everything is fine, or a *ContainerError
+// with code ErrDockerNotFound / ErrDockerNotRunning.
+func (c *ContainerClient) CheckDocker() error {
+	if _, err := lookPath("docker"); err != nil {
+		return &ContainerError{
+			Code:    ErrDockerNotFound,
+			Message: "Docker is not installed. Install Docker and try again.",
+		}
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	cmd := dockerCommand(ctx, "docker", "info")
-	return cmd.Run() == nil
+	if err := cmd.Run(); err != nil {
+		return &ContainerError{
+			Code:    ErrDockerNotRunning,
+			Message: "Docker is not running. Start Docker and try again.",
+		}
+	}
+	return nil
 }
 
 // Start runs a Docker container with the given workspace and mounts.

--- a/cmd/herm/container_test.go
+++ b/cmd/herm/container_test.go
@@ -81,10 +81,12 @@ func fakeDockerCommandWithStdin(handler func(args []string) (string, string, int
 	}
 }
 
-func TestContainerClient_IsAvailable_DockerRunning(t *testing.T) {
-	orig := dockerCommand
-	defer func() { dockerCommand = orig }()
+func TestContainerClient_CheckDocker_OK(t *testing.T) {
+	origCmd := dockerCommand
+	origPath := lookPath
+	defer func() { dockerCommand = origCmd; lookPath = origPath }()
 
+	lookPath = func(file string) (string, error) { return "/usr/bin/docker", nil }
 	dockerCommand = fakeDockerCommand(func(args []string) (string, string, int) {
 		if len(args) >= 2 && args[1] == "info" {
 			return "", "", 0
@@ -93,22 +95,54 @@ func TestContainerClient_IsAvailable_DockerRunning(t *testing.T) {
 	})
 
 	c := NewContainerClient(ContainerConfig{Image: "alpine:latest"})
-	if !c.IsAvailable() {
-		t.Error("expected IsAvailable to return true when docker info succeeds")
+	if err := c.CheckDocker(); err != nil {
+		t.Errorf("expected no error, got %v", err)
 	}
 }
 
-func TestContainerClient_IsAvailable_DockerNotRunning(t *testing.T) {
-	orig := dockerCommand
-	defer func() { dockerCommand = orig }()
+func TestContainerClient_CheckDocker_NotInstalled(t *testing.T) {
+	origPath := lookPath
+	defer func() { lookPath = origPath }()
 
+	lookPath = func(file string) (string, error) {
+		return "", &exec.Error{Name: file, Err: exec.ErrNotFound}
+	}
+
+	c := NewContainerClient(ContainerConfig{Image: "alpine:latest"})
+	err := c.CheckDocker()
+	if err == nil {
+		t.Fatal("expected error when docker is not installed")
+	}
+	cerr, ok := err.(*ContainerError)
+	if !ok {
+		t.Fatalf("expected *ContainerError, got %T", err)
+	}
+	if cerr.Code != ErrDockerNotFound {
+		t.Errorf("expected code %s, got %s", ErrDockerNotFound, cerr.Code)
+	}
+}
+
+func TestContainerClient_CheckDocker_DaemonNotRunning(t *testing.T) {
+	origCmd := dockerCommand
+	origPath := lookPath
+	defer func() { dockerCommand = origCmd; lookPath = origPath }()
+
+	lookPath = func(file string) (string, error) { return "/usr/bin/docker", nil }
 	dockerCommand = fakeDockerCommand(func(args []string) (string, string, int) {
 		return "", "Cannot connect to the Docker daemon", 1
 	})
 
 	c := NewContainerClient(ContainerConfig{Image: "alpine:latest"})
-	if c.IsAvailable() {
-		t.Error("expected IsAvailable to return false when docker info fails")
+	err := c.CheckDocker()
+	if err == nil {
+		t.Fatal("expected error when daemon is not running")
+	}
+	cerr, ok := err.(*ContainerError)
+	if !ok {
+		t.Fatalf("expected *ContainerError, got %T", err)
+	}
+	if cerr.Code != ErrDockerNotRunning {
+		t.Errorf("expected code %s, got %s", ErrDockerNotRunning, cerr.Code)
 	}
 }
 
@@ -137,9 +171,8 @@ func TestContainerClient_StopIdempotent(t *testing.T) {
 
 func TestContainerError_Format(t *testing.T) {
 	err := &ContainerError{Code: ErrDockerNotFound, Message: "not found"}
-	expected := "container DockerNotFound: not found"
-	if err.Error() != expected {
-		t.Errorf("expected %q, got %q", expected, err.Error())
+	if err.Error() != "not found" {
+		t.Errorf("expected %q, got %q", "not found", err.Error())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replace `IsAvailable() bool` with `CheckDocker() error` on `ContainerClient`
- Return typed `ContainerError` with `ErrDockerNotFound` (CLI missing) or `ErrDockerNotRunning` (daemon unreachable) for distinct status messages
- Simplify `ContainerError.Error()` to return the message directly

## Test plan
- [x] Updated existing tests and added `TestContainerClient_CheckDocker_NotInstalled` and `TestContainerClient_CheckDocker_DaemonNotRunning`