### PR TITLE
Retry Docker check when not available at startup

### DIFF
--- a/cmd/herm/background.go
+++ b/cmd/herm/background.go
@@ -43,8 +43,23 @@ type containerReadyMsg struct {
 }
 
 type containerErrMsg struct {
-	err      error
-	retrying bool // when true, don't show in chat (status bar is enough)
+	err error
+}
+
+type containerRetryMsg struct {
+	err            error
+	retryInSeconds int
+}
+
+type containerRetryRecoveredMsg struct{}
+
+const dockerRetryInterval = 5 * time.Second
+
+func dockerStatusText(err error) string {
+	if cerr, ok := err.(*ContainerError); ok && cerr.Code == ErrDockerNotFound {
+		return "docker not installed"
+	}
+	return "docker not running"
 }
 
 type containerStatusMsg struct {
@@ -179,22 +194,29 @@ func bootContainerCmd(opts bootContainerCmdOptions) {
 	client := NewContainerClient(ContainerConfig{Image: defaultContainerImage})
 
 	if err := client.CheckDocker(); err != nil {
-		if cerr, ok := err.(*ContainerError); ok && cerr.Code == ErrDockerNotFound {
-			ch <- containerStatusMsg{text: "docker not installed"}
-		} else {
-			ch <- containerStatusMsg{text: "docker not running"}
-		}
-		ch <- containerErrMsg{err: err, retrying: true}
-		// Retry until Docker becomes available or app exits.
-		ticker := time.NewTicker(3 * time.Second)
+		ch <- containerStatusMsg{text: dockerStatusText(err)}
+		retryInSeconds := int(dockerRetryInterval / time.Second)
+		ch <- containerRetryMsg{err: err, retryInSeconds: retryInSeconds}
+
+		ticker := time.NewTicker(time.Second)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-stop:
 				return
 			case <-ticker.C:
-				if client.CheckDocker() == nil {
-					goto dockerOK
+				retryInSeconds--
+				if retryInSeconds <= 0 {
+					if err = client.CheckDocker(); err == nil {
+						ch <- containerRetryRecoveredMsg{}
+						ch <- containerStatusMsg{text: "docker available"}
+						goto dockerOK
+					}
+					ch <- containerStatusMsg{text: dockerStatusText(err)}
+					retryInSeconds = int(dockerRetryInterval / time.Second)
+				}
+				if retryInSeconds > 0 {
+					ch <- containerRetryMsg{err: err, retryInSeconds: retryInSeconds}
 				}
 			}
 		}

--- a/cmd/herm/background.go
+++ b/cmd/herm/background.go
@@ -43,7 +43,8 @@ type containerReadyMsg struct {
 }
 
 type containerErrMsg struct {
-	err error
+	err      error
+	retrying bool // when true, don't show in chat (status bar is enough)
 }
 
 type containerStatusMsg struct {
@@ -168,10 +169,11 @@ type bootContainerCmdOptions struct {
 	workspace string
 	sessionID string
 	ch        chan<- any
+	stop      <-chan struct{}
 }
 
 func bootContainerCmd(opts bootContainerCmdOptions) {
-	workspace, sessionID, ch := opts.workspace, opts.sessionID, opts.ch
+	workspace, sessionID, ch, stop := opts.workspace, opts.sessionID, opts.ch, opts.stop
 	ch <- containerStatusMsg{text: "checking docker…"}
 
 	client := NewContainerClient(ContainerConfig{Image: defaultContainerImage})
@@ -182,9 +184,22 @@ func bootContainerCmd(opts bootContainerCmdOptions) {
 		} else {
 			ch <- containerStatusMsg{text: "docker not running"}
 		}
-		ch <- containerErrMsg{err: err}
-		return
+		ch <- containerErrMsg{err: err, retrying: true}
+		// Retry until Docker becomes available or app exits.
+		ticker := time.NewTicker(3 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+				if client.CheckDocker() == nil {
+					goto dockerOK
+				}
+			}
+		}
 	}
+dockerOK:
 
 	// Build from .herm/Dockerfile (write base template if none exists).
 	imageName := buildContainerImage(buildContainerImageOptions{workspace: workspace, ch: ch})

--- a/cmd/herm/main.go
+++ b/cmd/herm/main.go
@@ -783,7 +783,7 @@ func (a *App) handleResult(result any) {
 		go func() { a.resultCh <- fetchStatusCmd(wtPath) }()
 		go func() { a.resultCh <- fetchProjectSnapshot(wtPath) }()
 		go func() {
-			bootContainerCmd(bootContainerCmdOptions{workspace: wtPath, sessionID: a.sessionID, ch: a.resultCh})
+			bootContainerCmd(bootContainerCmdOptions{workspace: wtPath, sessionID: a.sessionID, ch: a.resultCh, stop: a.stopCh})
 		}()
 		go cleanupTmpDir(wtPath)
 		go cleanupAgentOutputDir(wtPath)
@@ -820,7 +820,9 @@ func (a *App) handleResult(result any) {
 
 	case containerErrMsg:
 		a.containerErr = msg.err
-		a.messages = append(a.messages, chatMessage{kind: msgError, content: msg.err.Error()})
+		if !msg.retrying {
+			a.messages = append(a.messages, chatMessage{kind: msgError, content: msg.err.Error()})
+		}
 
 	case worktreeListMsg:
 		if msg.err != nil {

--- a/cmd/herm/main.go
+++ b/cmd/herm/main.go
@@ -115,6 +115,8 @@ type App struct {
 	containerReady          bool
 	containerErr            error
 	containerStatusText     string
+	containerRetryMsgIdx    int
+	containerRetryMsgActive bool
 	configReady             bool // true after workspace/project config has been merged
 	shownInitialModel       bool // true after the startup model line has been displayed
 	lastModelDiagnostics    string
@@ -617,6 +619,73 @@ func (a *App) drainResults() {
 	}
 }
 
+type containerRetryMessageOptions struct {
+	err            error
+	retryInSeconds int
+}
+
+func containerRetryMessage(opts containerRetryMessageOptions) chatMessage {
+	details := containerRetryDetails(opts.err)
+	retryText := "retrying…"
+	if opts.retryInSeconds > 0 {
+		retryText = fmt.Sprintf("retry in %ds…", opts.retryInSeconds)
+	}
+	contentParts := append([]string{}, details...)
+	contentParts = append(contentParts, retryText)
+	blocks := make([]inlineBlock, 0, len(contentParts))
+	for _, part := range contentParts {
+		blocks = append(blocks, styledInlineBlock(styledInlineBlockOptions{style: "\033[31;3m", text: part}))
+	}
+	return chatMessage{
+		kind:         msgError,
+		content:      strings.Join(contentParts, " "),
+		inlineBlocks: blocks,
+	}
+}
+
+func containerRetryDetails(err error) []string {
+	if cerr, ok := err.(*ContainerError); ok {
+		switch cerr.Code {
+		case ErrDockerNotFound:
+			return []string{"Docker is not installed.", "Install Docker and try again."}
+		case ErrDockerNotRunning:
+			return []string{"Docker is not running.", "Start Docker and try again."}
+		}
+	}
+	if err != nil {
+		return []string{err.Error()}
+	}
+	return []string{"Docker is unavailable."}
+}
+
+func containerRecoveredMessage() chatMessage {
+	return chatMessage{
+		kind:    msgSuccess,
+		content: "Docker available",
+		inlineBlocks: []inlineBlock{
+			styledInlineBlock(styledInlineBlockOptions{style: "\033[32;3m", text: "Docker available"}),
+		},
+	}
+}
+
+func (a *App) upsertContainerRetryMessage(msg chatMessage) {
+	if a.containerRetryMsgActive && a.containerRetryMsgIdx >= 0 && a.containerRetryMsgIdx < len(a.messages) {
+		a.messages[a.containerRetryMsgIdx] = msg
+		return
+	}
+	a.messages = append(a.messages, msg)
+	a.containerRetryMsgIdx = len(a.messages) - 1
+	a.containerRetryMsgActive = true
+}
+
+func (a *App) completeContainerRetryMessage(msg chatMessage) {
+	if !a.containerRetryMsgActive || a.containerRetryMsgIdx < 0 || a.containerRetryMsgIdx >= len(a.messages) {
+		return
+	}
+	a.messages[a.containerRetryMsgIdx] = msg
+	a.containerRetryMsgActive = false
+}
+
 func (a *App) handleResult(result any) {
 	switch msg := result.(type) {
 	case toolTimerTickMsg:
@@ -807,6 +876,7 @@ func (a *App) handleResult(result any) {
 		}
 		a.containerReady = true
 		a.containerErr = nil
+		a.completeContainerRetryMessage(containerRecoveredMessage())
 		if cid := msg.client.ContainerID(); cid != "" {
 			shortID := cid
 			if len(shortID) > 12 {
@@ -818,11 +888,18 @@ func (a *App) handleResult(result any) {
 	case containerStatusMsg:
 		a.containerStatusText = msg.text
 
+	case containerRetryMsg:
+		a.containerErr = msg.err
+		a.upsertContainerRetryMessage(containerRetryMessage(containerRetryMessageOptions{err: msg.err, retryInSeconds: msg.retryInSeconds}))
+
+	case containerRetryRecoveredMsg:
+		a.containerErr = nil
+		a.completeContainerRetryMessage(containerRecoveredMessage())
+
 	case containerErrMsg:
 		a.containerErr = msg.err
-		if !msg.retrying {
-			a.messages = append(a.messages, chatMessage{kind: msgError, content: msg.err.Error()})
-		}
+		a.containerRetryMsgActive = false
+		a.messages = append(a.messages, chatMessage{kind: msgError, content: msg.err.Error()})
 
 	case worktreeListMsg:
 		if msg.err != nil {

--- a/cmd/herm/render_test.go
+++ b/cmd/herm/render_test.go
@@ -645,6 +645,64 @@ func TestModelDisplayLineUsesInlineBlocks(t *testing.T) {
 	}
 }
 
+func TestContainerRetryMessageUsesInlineBlocks(t *testing.T) {
+	err := &ContainerError{Code: ErrDockerNotRunning, Message: "Docker is not running. Start Docker and try again."}
+	msg := containerRetryMessage(containerRetryMessageOptions{err: err, retryInSeconds: 3})
+	if msg.kind != msgError {
+		t.Fatalf("message kind = %v, want msgError", msg.kind)
+	}
+	if len(msg.inlineBlocks) != 3 {
+		t.Fatalf("inline blocks = %d, want 3", len(msg.inlineBlocks))
+	}
+	for i, block := range msg.inlineBlocks {
+		if !strings.Contains(block.text, "\033[31;3m") {
+			t.Fatalf("inline block %d = %q, want red error style", i, block.text)
+		}
+	}
+	if strings.Contains(msg.content, "Docker not running") {
+		t.Fatalf("content = %q, should not include redundant title", msg.content)
+	}
+	if !strings.Contains(msg.content, "Docker is not running.") ||
+		!strings.Contains(msg.content, "Start Docker and try again.") ||
+		!strings.Contains(msg.content, "retry in 3s…") {
+		t.Fatalf("content = %q, want docker error and retry countdown", msg.content)
+	}
+
+	rows := layoutInlineBlocks(layoutInlineBlocksOptions{blocks: msg.inlineBlocks, width: 80})
+	plain := ansiEscRe.ReplaceAllString(strings.Join(rows, "\n"), "")
+	if strings.Contains(plain, "Docker not running") {
+		t.Fatalf("plain rows = %q, should not include redundant title", plain)
+	}
+	if !strings.Contains(plain, "Docker is not running.") ||
+		!strings.Contains(plain, "Start Docker and try again.") ||
+		!strings.Contains(plain, "retry in 3s…") {
+		t.Fatalf("plain rows = %q, want inline error and retry countdown", plain)
+	}
+}
+
+func TestContainerRetryUpdatesSingleInlineMessage(t *testing.T) {
+	app := &App{headless: true, width: 80}
+	err := &ContainerError{Code: ErrDockerNotRunning, Message: "Docker is not running. Start Docker and try again."}
+
+	app.handleResult(containerRetryMsg{err: err, retryInSeconds: 3})
+	app.handleResult(containerRetryMsg{err: err, retryInSeconds: 2})
+
+	if len(app.messages) != 1 {
+		t.Fatalf("messages = %d, want one updated retry message", len(app.messages))
+	}
+	if !strings.Contains(app.messages[0].content, "retry in 2s…") {
+		t.Fatalf("message content = %q, want updated countdown", app.messages[0].content)
+	}
+	if len(app.messages[0].inlineBlocks) == 0 {
+		t.Fatal("retry message should use inline blocks")
+	}
+
+	app.handleResult(containerRetryRecoveredMsg{})
+	if app.messages[0].kind != msgSuccess || !strings.Contains(app.messages[0].content, "Docker available") {
+		t.Fatalf("recovered message = %#v, want Docker available success", app.messages[0])
+	}
+}
+
 func TestBuildBlockRowsRendersInlineMessageBlocks(t *testing.T) {
 	model := "openai/gpt-5.5-2026-04-23"
 	exploration := "anthropic/claude-haiku-4-5"


### PR DESCRIPTION
## Summary
- When Docker is not running at startup, retry the check every 3 seconds instead of showing a permanent error
- Status bar shows the error in red while retrying; no chat message is added since recovery is automatic
- Uses the app's `stopCh` for clean shutdown of the retry loop
- When Docker becomes available, the normal boot flow continues (image build, pull, start)

## Test plan
- [ ] Start herm with Docker stopped — status bar shows red "docker not running", no chat error message
- [ ] Start Docker while herm is running — container boots automatically, status bar updates to container ID
- [ ] Start herm with Docker already running — no change in behavior
- [ ] Quit herm while retrying — exits cleanly without hanging