### PR TITLE
Add persistent /cache mount for dependencies

### DIFF
--- a/cmd/herm/agentui.go
+++ b/cmd/herm/agentui.go
@@ -125,9 +125,11 @@ func (a *App) startAgent(userMessage string) {
 		tools = append(tools, NewWriteFileTool(a.container))
 		if a.worktreePath != "" {
 			hermDir := filepath.Join(a.worktreePath, ".herm")
+			cacheDir := filepath.Join(a.worktreePath, ".herm", "cache")
 			mounts := []MountSpec{
 				{Source: a.worktreePath, Destination: a.worktreePath},
 				{Source: a.attachmentDir(), Destination: "/attachments", ReadOnly: true},
+				{Source: cacheDir, Destination: "/cache", ReadOnly: false},
 			}
 			var projectID string
 			if repoRoot := gitRepoRoot(); repoRoot != "" {

--- a/cmd/herm/background.go
+++ b/cmd/herm/background.go
@@ -190,9 +190,13 @@ func bootContainerCmd(workspace string, sessionID string, ch chan<- any) {
 	attachDir := filepath.Join(workspace, ".herm", "attachments", sessionID)
 	_ = os.MkdirAll(attachDir, 0o755)
 
+	cacheDir := filepath.Join(workspace, ".herm", "cache")
+	_ = os.MkdirAll(cacheDir, 0o755)
+
 	mounts := []MountSpec{
 		{Source: workspace, Destination: workspace, ReadOnly: false},
 		{Source: attachDir, Destination: "/attachments", ReadOnly: true},
+		{Source: cacheDir, Destination: "/cache", ReadOnly: false},
 	}
 
 	if err := client.Start(workspace, mounts); err != nil {

--- a/prompts/content/devenv_guidelines.md
+++ b/prompts/content/devenv_guidelines.md
@@ -41,4 +41,29 @@ RUN apt-get update && apt-get install -y --no-install-recommends python3-pip pyt
 4. Missing -y flag on apt-get install.
 5. curl-pipe-to-bash setup scripts — use tarballs instead.
 
+## Persistent cache
+
+A persistent `/cache` directory is mounted read-write from the host into the container. It survives container rebuilds and restarts. Use it to avoid re-downloading dependencies and re-building artifacts across sessions.
+
+Configure tools to use `/cache` via ENV variables in the Dockerfile. Examples:
+
+```dockerfile
+# Go
+ENV GOMODCACHE=/cache/go/mod
+ENV GOCACHE=/cache/go/build
+
+# Node.js
+ENV npm_config_cache=/cache/npm
+# or for yarn:
+ENV YARN_CACHE_FOLDER=/cache/yarn
+
+# Python pip
+ENV PIP_CACHE_DIR=/cache/pip
+
+# Rust
+ENV CARGO_HOME=/cache/cargo
+```
+
+Adapt cache paths to the project's toolchain. The agent is responsible for deciding which caches to configure.
+
 **When a build fails**, read the full error. Fix only the failing step — don't rewrite the whole Dockerfile.


### PR DESCRIPTION
## Summary
- Mount `.herm/cache/` from the host to `/cache` (read-write) in the container, so downloaded dependencies and build artifacts persist across container rebuilds and restarts.
- Update devenv guidelines to document the `/cache` directory and show agents how to configure toolchain caches (Go, Node, Python, Rust) via Dockerfile ENV variables.
- The agent is fully responsible for deciding which caches to configure per project.

## Test plan
- [ ] Start herm on a project, verify `/cache` exists in the container
- [ ] Have the agent set up a Dockerfile with cache ENV vars (e.g. `GOMODCACHE=/cache/go/mod`)
- [ ] Build/install dependencies, restart herm, verify cached artifacts are still present
- [ ] Rebuild the container via devenv tool, verify `/cache` contents survive

🤖 Generated with [Claude Code](https://claude.com/claude-code)