### PR TITLE
Include go toolchain in container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN cd /build/tools/outline && go build -o /out/outline .
 
 FROM debian:bookworm-slim
 COPY --from=builder /out/edit-file /out/write-file /out/outline /usr/local/bin/
+COPY --from=builder /usr/local/go /usr/local/go
+ENV PATH="/usr/local/go/bin:${PATH}"
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git tree ca-certificates ripgrep python3 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- Copy the Go installation from the builder stage into the final image so that `go` is available at runtime
- Fixes #11

## Test plan
- [ ] Build the image: `docker build -t herm:test .`
- [ ] Run a container and verify `which go` returns a path
- [ ] Verify `go version` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)