### PR TITLE
Fix image drag-and-drop in Zed's terminal

### DIFF
--- a/cmd/herm/attachment_test.go
+++ b/cmd/herm/attachment_test.go
@@ -222,6 +222,26 @@ func TestIsFilePath_DoubleQuotedMultiline(t *testing.T) {
 	}
 }
 
+func TestIsFilePath_UnicodeEscapes(t *testing.T) {
+	// Zed's terminal escapes non-ASCII characters in dropped paths as \u{XXXX}.
+	// e.g. the narrow no-break space (U+202F) in macOS screenshot filenames.
+	dir := t.TempDir()
+	// Create a file with U+202F (narrow no-break space) in the name.
+	tmp := filepath.Join(dir, "Screenshot 2026-03-31 at 8.02.54\u202fPM.png")
+	if err := os.WriteFile(tmp, []byte("img"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Simulate Zed's drag-drop: double-quoted path with \u{202f} escape.
+	input := `"` + filepath.Join(dir, `Screenshot 2026-03-31 at 8.02.54\u{202f}PM.png`) + `"`
+	resolved, ok := isFilePath(input)
+	if !ok {
+		t.Fatalf("expected isFilePath to accept Zed-style Unicode-escaped path %q", input)
+	}
+	if resolved != tmp {
+		t.Fatalf("expected resolved=%q, got %q", tmp, resolved)
+	}
+}
+
 func TestIsFilePath_QuotedWithSpaces(t *testing.T) {
 	// Some terminals drop paths as: ` "/path/to/img.png " `
 	// (double quotes AND spaces on both sides).

--- a/cmd/herm/content.go
+++ b/cmd/herm/content.go
@@ -27,6 +27,9 @@ type Attachment struct {
 
 var pasteplaceholderRe = regexp.MustCompile(`\[pasted #(\d+) \| \d+ chars\]`)
 
+// unicodeEscapeRe matches \u{XXXX} escapes emitted by some terminals (e.g. Zed).
+var unicodeEscapeRe = regexp.MustCompile(`\\u\{([0-9a-fA-F]+)\}`)
+
 func expandPastes(s string, store map[int]string) string {
 	return pasteplaceholderRe.ReplaceAllStringFunc(s, func(match string) string {
 		sub := pasteplaceholderRe.FindStringSubmatch(match)
@@ -65,6 +68,19 @@ func isFilePath(s string) (string, bool) {
 	s = strings.TrimSpace(s)
 	// Unescape backslash-spaces (common in terminal drag-drop).
 	p := strings.ReplaceAll(s, "\\ ", " ")
+	// Unescape \u{XXXX} Unicode escapes (Zed's terminal uses this for
+	// non-ASCII characters in drag-and-drop paths, e.g. the narrow
+	// no-break space U+202F in macOS screenshot filenames).
+	if strings.Contains(p, `\u{`) {
+		p = unicodeEscapeRe.ReplaceAllStringFunc(p, func(match string) string {
+			hex := match[3 : len(match)-1] // strip \u{ and }
+			cp, err := strconv.ParseInt(hex, 16, 32)
+			if err != nil {
+				return match
+			}
+			return string(rune(cp))
+		})
+	}
 	// Expand tilde.
 	if strings.HasPrefix(p, "~/") {
 		if home, err := os.UserHomeDir(); err == nil {

--- a/cmd/herm/main.go
+++ b/cmd/herm/main.go
@@ -567,6 +567,38 @@ func (a *App) tryAttachFile(s string) (string, bool) {
 	return fmt.Sprintf("[File #%d]", a.attachmentCount), true
 }
 
+// tryAttachPaths checks if val is one or more file paths (e.g. from
+// drag-and-drop in terminals that don't use bracketed paste) and attaches
+// them. Returns the modified string with attachment placeholders, or the
+// original string unchanged if no paths were detected.
+func (a *App) tryAttachPaths(val string) string {
+	// Single file path.
+	if placeholder, ok := a.tryAttachFile(val); ok {
+		return placeholder
+	}
+	// Multiple newline-separated file paths.
+	lines := strings.Split(val, "\n")
+	if len(lines) <= 1 {
+		return val
+	}
+	var placeholders []string
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		p, ok := a.tryAttachFile(line)
+		if !ok {
+			return val // not all lines are file paths — return unchanged
+		}
+		placeholders = append(placeholders, p)
+	}
+	if len(placeholders) > 0 {
+		return strings.Join(placeholders, " ")
+	}
+	return val
+}
+
 // attachmentDir returns the host path for this session's attachment files.
 func (a *App) attachmentDir() string {
 	return filepath.Join(a.worktreePath, ".herm", "attachments", a.sessionID)
@@ -729,6 +761,11 @@ func (a *App) handleEnter() {
 	if a.history != nil {
 		a.history.Add(val)
 	}
+
+	// Try to attach file paths that weren't caught by bracketed paste.
+	// Some terminals (e.g. Zed) send drag-and-drop paths as regular input
+	// instead of wrapping them in paste markers.
+	val = a.tryAttachPaths(val)
 
 	if strings.HasPrefix(val, "/") {
 		a.resetInput()


### PR DESCRIPTION
## Summary
- Add submit-time file path detection (`tryAttachPaths`) as a fallback for terminals that don't wrap drag-and-drop paths in bracketed paste markers
- Unescape `\u{XXXX}` Unicode escapes in `isFilePath()` — Zed's terminal escapes non-ASCII characters this way (e.g. the narrow no-break space U+202F in macOS screenshot filenames like `Screenshot 2026-03-31 at 8.02.54 PM.png`)

## Test plan
- [x] Added `TestIsFilePath_UnicodeEscapes` covering the Zed escape format
- [ ] Drag-and-drop an image in Zed's terminal → should attach as `[Image #N]`
- [ ] Drag-and-drop an image in iTerm2/Terminal.app → should still work as before
- [ ] Paste a screenshot from clipboard → should still work as before