### PR TITLE
fix: clean up buildx builder container after image build

### DIFF
--- a/build-push-image.sh
+++ b/build-push-image.sh
@@ -43,6 +43,9 @@ fi
 
 # Ensure a buildx builder with multi-arch support exists
 BUILDER="herm-multiarch"
+cleanup_builder() { docker buildx rm "$BUILDER" 2>/dev/null || true; }
+trap cleanup_builder EXIT
+
 if ! docker buildx inspect "$BUILDER" &>/dev/null; then
   echo "Creating buildx builder: ${BUILDER}"
   docker buildx create --name "$BUILDER" --driver docker-container --use


### PR DESCRIPTION
## Summary
- Adds a `trap ... EXIT` handler in `build-push-image.sh` to remove the buildx builder container (`herm-multiarch`) when the script exits
- Ensures cleanup happens regardless of whether the build succeeds or fails

## Test plan
- [ ] Run `./build-push-image.sh` and verify no `herm-multiarch` container remains after the build
- [ ] Run `./build-push-image.sh --push` and verify cleanup still occurs
- [ ] Simulate a build failure and verify the builder is still cleaned up