### PR TITLE
Refresh branch name in periodic commit info

### DIFF
--- a/cmd/herm/background.go
+++ b/cmd/herm/background.go
@@ -430,7 +430,7 @@ func fetchCommitInfo(worktreePath string) commitInfoMsg {
 			}
 		}
 	}
-	
+
 	diffCmd := exec.Command("git", "diff", "--shortstat", "HEAD")
 	diffCmd.Dir = worktreePath
 	if out, err := diffCmd.Output(); err == nil {

--- a/cmd/herm/background.go
+++ b/cmd/herm/background.go
@@ -68,6 +68,7 @@ type statusInfoMsg struct {
 }
 
 type commitInfoMsg struct {
+	branch      string
 	behind      int
 	ahead       int
 	hasUpstream bool
@@ -414,6 +415,7 @@ func fetchStatusCmd(worktreePath string) statusInfoMsg {
 
 func fetchCommitInfo(worktreePath string) commitInfoMsg {
 	var msg commitInfoMsg
+	msg.branch = worktreeBranch(worktreePath)
 	cmd := exec.Command("git", "rev-list", "--count", "--left-right", "@{upstream}...HEAD")
 	cmd.Dir = worktreePath
 	if out, err := cmd.Output(); err == nil {
@@ -428,7 +430,7 @@ func fetchCommitInfo(worktreePath string) commitInfoMsg {
 			}
 		}
 	}
-
+	
 	diffCmd := exec.Command("git", "diff", "--shortstat", "HEAD")
 	diffCmd.Dir = worktreePath
 	if out, err := diffCmd.Output(); err == nil {

--- a/cmd/herm/main.go
+++ b/cmd/herm/main.go
@@ -976,6 +976,7 @@ func (a *App) handleResult(result any) {
 		a.status = msg.info
 
 	case commitInfoMsg:
+		a.status.Branch = msg.branch
 		a.status.HasUpstream = msg.hasUpstream
 		a.status.Behind = msg.behind
 		a.status.Ahead = msg.ahead


### PR DESCRIPTION
## Summary
- Include the branch name in the periodic `commitInfoMsg` refresh (every 15s), so the displayed branch stays up to date even after a checkout without requiring a full status refresh.

## Test plan
- [ ] Switch branches while the app is running and verify the status bar updates the branch name within 15s

🤖 Generated with [Claude Code](https://claude.com/claude-code)