### PR TITLE
Fix goreleaser archives.format deprecation warning

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,7 +21,7 @@ builds:
       - -s -w -X main.Version={{.Version}}
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:


### PR DESCRIPTION
## Summary
- Rename `archives.format: tar.gz` to `archives.formats: [tar.gz]` in `.goreleaser.yml` to silence the deprecation warning emitted during the v0.6.1 release run.
- Deprecated since GoReleaser v2.6 — see https://goreleaser.com/deprecations#archivesformat.

Note: the separate `brews` → `homebrew_casks` deprecation is not addressed here; it requires a coordinated change in the `homebrew-herm` tap repo and will be handled in a follow-up PR.

## Test plan
- [ ] Next tag push triggers the release workflow without the `archives.format` deprecation warning.
- [ ] Release artifacts still produced as `herm_<version>_<os>_<arch>.tar.gz`.