### PR TITLE
Add claude-opus-4-7 to model test fixtures

### DIFF
--- a/cmd/herm/config_test.go
+++ b/cmd/herm/config_test.go
@@ -723,6 +723,7 @@ func defaultTestModels() []ModelDef {
 		{Provider: ProviderAnthropic, ID: "claude-sonnet-4-6"},
 		{Provider: ProviderAnthropic, ID: "claude-haiku-4-5"},
 		{Provider: ProviderAnthropic, ID: "claude-opus-4-6"},
+		{Provider: ProviderAnthropic, ID: "claude-opus-4-7"},
 		{Provider: ProviderOpenAI, ID: "gpt-4.1-2025-04-14"},
 		{Provider: ProviderOpenAI, ID: "gpt-4.1-mini-2025-04-14"},
 		{Provider: ProviderGrok, ID: "grok-3"},

--- a/cmd/herm/models_test.go
+++ b/cmd/herm/models_test.go
@@ -205,7 +205,7 @@ func TestModelsFromCatalog(t *testing.T) {
 	catalog := &langdag.ModelCatalog{
 		Providers: map[string][]langdag.ModelPricing{
 			"anthropic": {
-				{ID: "claude-opus-4-6", InputPricePer1M: 5, OutputPricePer1M: 25, ContextWindow: 200000},
+				{ID: "claude-opus-4-7", InputPricePer1M: 5, OutputPricePer1M: 25, ContextWindow: 200000},
 			},
 			"grok": {
 				{ID: "grok-4-1-fast-reasoning", InputPricePer1M: 3, OutputPricePer1M: 15, ContextWindow: 131072},
@@ -217,8 +217,8 @@ func TestModelsFromCatalog(t *testing.T) {
 		t.Fatalf("expected 2 models, got %d", len(models))
 	}
 	// anthropic comes first in supportedProviders order
-	if models[0].ID != "claude-opus-4-6" || models[0].Provider != "anthropic" {
-		t.Errorf("first model: got %s/%s, want claude-opus-4-6/anthropic", models[0].ID, models[0].Provider)
+	if models[0].ID != "claude-opus-4-7" || models[0].Provider != "anthropic" {
+		t.Errorf("first model: got %s/%s, want claude-opus-4-7/anthropic", models[0].ID, models[0].Provider)
 	}
 	if models[0].PromptPrice != 5 || models[0].CompletionPrice != 25 {
 		t.Errorf("pricing: got %f/%f, want 5/25", models[0].PromptPrice, models[0].CompletionPrice)
@@ -264,7 +264,7 @@ func TestModelsFromCatalogNil(t *testing.T) {
 func TestModelsFromCatalogSkipsUnknownProviders(t *testing.T) {
 	catalog := &langdag.ModelCatalog{
 		Providers: map[string][]langdag.ModelPricing{
-			"anthropic":        {{ID: "claude-opus-4-6", InputPricePer1M: 5, OutputPricePer1M: 25, ContextWindow: 200000}},
+			"anthropic":        {{ID: "claude-opus-4-7", InputPricePer1M: 5, OutputPricePer1M: 25, ContextWindow: 200000}},
 			"unknown-provider": {{ID: "mystery-model", InputPricePer1M: 1, OutputPricePer1M: 2, ContextWindow: 100000}},
 		},
 	}

--- a/cmd/herm/models_test.go
+++ b/cmd/herm/models_test.go
@@ -205,6 +205,7 @@ func TestModelsFromCatalog(t *testing.T) {
 	catalog := &langdag.ModelCatalog{
 		Providers: map[string][]langdag.ModelPricing{
 			"anthropic": {
+				{ID: "claude-opus-4-6", InputPricePer1M: 5, OutputPricePer1M: 25, ContextWindow: 200000},
 				{ID: "claude-opus-4-7", InputPricePer1M: 5, OutputPricePer1M: 25, ContextWindow: 200000},
 			},
 			"grok": {
@@ -213,12 +214,12 @@ func TestModelsFromCatalog(t *testing.T) {
 		},
 	}
 	models := modelsFromCatalog(catalog)
-	if len(models) != 2 {
-		t.Fatalf("expected 2 models, got %d", len(models))
+	if len(models) != 3 {
+		t.Fatalf("expected 3 models, got %d", len(models))
 	}
 	// anthropic comes first in supportedProviders order
-	if models[0].ID != "claude-opus-4-7" || models[0].Provider != "anthropic" {
-		t.Errorf("first model: got %s/%s, want claude-opus-4-7/anthropic", models[0].ID, models[0].Provider)
+	if models[0].ID != "claude-opus-4-6" || models[0].Provider != "anthropic" {
+		t.Errorf("first model: got %s/%s, want claude-opus-4-6/anthropic", models[0].ID, models[0].Provider)
 	}
 	if models[0].PromptPrice != 5 || models[0].CompletionPrice != 25 {
 		t.Errorf("pricing: got %f/%f, want 5/25", models[0].PromptPrice, models[0].CompletionPrice)
@@ -264,7 +265,10 @@ func TestModelsFromCatalogNil(t *testing.T) {
 func TestModelsFromCatalogSkipsUnknownProviders(t *testing.T) {
 	catalog := &langdag.ModelCatalog{
 		Providers: map[string][]langdag.ModelPricing{
-			"anthropic":        {{ID: "claude-opus-4-7", InputPricePer1M: 5, OutputPricePer1M: 25, ContextWindow: 200000}},
+			"anthropic": {
+				{ID: "claude-opus-4-6", InputPricePer1M: 5, OutputPricePer1M: 25, ContextWindow: 200000},
+				{ID: "claude-opus-4-7", InputPricePer1M: 5, OutputPricePer1M: 25, ContextWindow: 200000},
+			},
 			"unknown-provider": {{ID: "mystery-model", InputPricePer1M: 1, OutputPricePer1M: 2, ContextWindow: 100000}},
 		},
 	}
@@ -555,7 +559,6 @@ func TestSortColFromName(t *testing.T) {
 	}
 }
 
-
 // --- formatTokenCount tests ---
 
 func TestFormatTokenCountSmall(t *testing.T) {
@@ -759,4 +762,3 @@ func TestSupportsServerToolsUnknownModel(t *testing.T) {
 		t.Error("unknown model should not support server tools")
 	}
 }
-


### PR DESCRIPTION
## Summary
- Add `claude-opus-4-7` alongside `claude-opus-4-6` in the default test model list (`defaultTestModels` in `config_test.go`).
- Add `claude-opus-4-7` alongside `claude-opus-4-6` in the `modelsFromCatalog` test fixtures in `models_test.go` (additive, matching the `defaultTestModels` convention).

The runtime langdag catalog fetch already picks up Claude Opus 4.7 from the Anthropic docs page; this just aligns the in-repo test fixtures with the new model. Default Anthropic active model stays on `claude-sonnet-4-6`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./cmd/herm/...`