### PR TITLE
Refresh roadmap with current priorities

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,13 @@ You'll need an API key for at least one provider (Anthropic, OpenAI, Grok, or Ge
 
 ## Roadmap
 
-- OCI container support without Docker, using Apple's [Containerization framework](https://developer.apple.com/documentation/containerization)
-- Test and verify Windows support (WSL2 + Docker Desktop)
+Rough priority order — subject to change.
+
+1. **Credential-free third-party APIs** — let herm call any external API without ever seeing your credentials.
+2. **Benchmarks** — measure herm against Claude Code and other coding agents on standard coding tasks.
+3. **Skills & `herm.md`** — first-class skills and a project config file. Optional import from other agents' configs (e.g. `CLAUDE.md`).
+4. **PR review bot** — a herm bot that reviews pull requests.
+5. **Dynamic model list** — pick up newly released models without updating herm.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- Replaces the outdated OCI/Windows roadmap in the README with the five items we're actually planning to work on, in rough priority order.
- Priorities: credential-free third-party APIs, benchmarks, skills & `herm.md`, PR review bot, dynamic model list.

## Test plan
- [x] README renders correctly on GitHub