### PR TITLE
Allow Backspace to unset project-level config fields

### DIFF
--- a/cmd/herm/configeditor.go
+++ b/cmd/herm/configeditor.go
@@ -533,6 +533,8 @@ func (a *App) buildConfigRows() []string {
 	// Help line
 	if a.cfgEditing {
 		rows = append(rows, "\033[2mEnter=confirm  Esc=cancel\033[0m")
+	} else if a.cfgTab == 2 {
+		rows = append(rows, "\033[2m←/→=tab  ↑/↓=select  Enter=edit  Backspace=unset  Esc=close  Ctrl+S=save & close\033[0m")
 	} else {
 		rows = append(rows, "\033[2m←/→=tab  ↑/↓=select  Enter=edit  Esc=close  Ctrl+S=save & close\033[0m")
 	}
@@ -656,6 +658,18 @@ func (a *App) handleConfigByte(opts handleConfigByteOptions) {
 			}
 		}
 		a.renderInput()
+
+	case ch == 127 || ch == 0x08: // Backspace - clear current project field (unset → fall back to global)
+		if a.cfgTab == 2 && a.repoRoot != "" {
+			fields := a.cfgCurrentFields()
+			if len(fields) > 0 && a.cfgCursor < len(fields) {
+				f := fields[a.cfgCursor]
+				if f.set != nil && f.get(a.cfgDraft) != "" {
+					f.set(&a.cfgDraft, "")
+					a.renderInput()
+				}
+			}
+		}
 
 	case ch == 0x13: // Ctrl+S - save and close
 		a.exitConfigMode(true)


### PR DESCRIPTION
## Summary
- On the Project tab of the config editor, pressing **Backspace** on a field clears the project override so the value falls back to the global setting.
- Skips fields with no `set` callback (e.g. Thinking, which is `*bool` toggle-only) and no-ops when the value is already empty.
- Help line on the Project tab now advertises `Backspace=unset`; other tabs are unchanged since unset→fallback semantics don't apply there.

## Test plan
- [ ] Open config editor, switch to Project tab
- [ ] Set Active Model / Exploration Model / Personality / Sub-Agent Max Turns
- [ ] Press Backspace on each — row reverts to `(global: …)` hint
- [ ] Confirm Backspace on Thinking is a no-op (no `set`)
- [ ] Confirm Backspace on API Keys / Global tabs does nothing
- [ ] Save with Ctrl+S; reopen; values stay cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)