### PR TITLE
Grey out global model hint in project config when unselected

### DIFF
--- a/cmd/herm/configeditor.go
+++ b/cmd/herm/configeditor.go
@@ -517,13 +517,13 @@ func (a *App) buildConfigRows() []string {
 					if hint == "" {
 						hint = "not set"
 					}
-					val = fmt.Sprintf("(global: %s)", hint)
+					val = fmt.Sprintf("\033[2m(global: %s)\033[0m", hint)
 				} else {
 					val = "(not set)"
 				}
 			}
 			if i == a.cfgCursor {
-				rows = append(rows, fmt.Sprintf("\033[36;1m%s: %s ◆\033[0m", f.label, val))
+				rows = append(rows, fmt.Sprintf("\033[36;1m%s: %s\033[36;1m ◆\033[0m", f.label, val))
 			} else {
 				rows = append(rows, fmt.Sprintf("%s: %s", f.label, val))
 			}


### PR DESCRIPTION
## Summary
- Dim the `(global: ...)` hint in the project config editor so it visually reads as a fallback rather than the active value
- Keep the cursor diamond (◆) in the same cyan/bold style as the field label when a row is selected

## Before

<img width="781" height="202" alt="Screenshot 2026-04-24 at 22 28 35" src="https://github.com/user-attachments/assets/8d95a227-fb1b-42dc-bdd9-2a490b86ae4f" />

## After

<img width="883" height="199" alt="Screenshot 2026-04-24 at 22 28 52" src="https://github.com/user-attachments/assets/a31489c2-d589-4cef-b9f6-65227dbe3925" />

## Test plan
- [ ] Open the config editor, select a model field with no project-level override, and confirm the global hint renders dimmed
- [ ] Move the cursor onto that row and confirm the ◆ marker stays cyan/bold alongside the label

🤖 Generated with [Claude Code](https://claude.com/claude-code)