### PR TITLE
Wrap render frames in DEC mode 2026 to remove cursor flicker

### DIFF
--- a/cmd/herm/render.go
+++ b/cmd/herm/render.go
@@ -783,6 +783,7 @@ func (a *App) render() {
 	}
 
 	var buf strings.Builder
+	buf.WriteString("\033[?2026h") // begin synchronized update (atomic frame)
 
 	if newScrollShift > 0 && a.scrollShift > 0 && newScrollShift >= a.scrollShift {
 		// Content overflows and grew or stayed same: write only visible portion.
@@ -809,6 +810,7 @@ func (a *App) render() {
 	a.scrollShift = newScrollShift
 
 	a.positionCursor(&buf)
+	buf.WriteString("\033[?2026l") // end synchronized update
 	os.Stdout.WriteString(buf.String())
 }
 
@@ -850,6 +852,7 @@ func (a *App) renderInput() {
 	}
 
 	var buf strings.Builder
+	buf.WriteString("\033[?2026h") // begin synchronized update (atomic frame)
 	writeRows(writeRowsOptions{buf: &buf, rows: inputRows, from: screenSepRow})
 	buf.WriteString("\033[0m\033[J") // clear remaining lines
 
@@ -857,5 +860,6 @@ func (a *App) renderInput() {
 	a.prevRowCount = totalRows
 
 	a.positionCursor(&buf)
+	buf.WriteString("\033[?2026l") // end synchronized update
 	os.Stdout.WriteString(buf.String())
 }


### PR DESCRIPTION
## Summary
- Each `render()` / `renderInput()` frame now opens with `\033[?2026h` (Begin Synchronized Update) and closes with `\033[?2026l` (End Synchronized Update), so supporting terminals commit the frame atomically.
- Fixes the cursor visibly walking through intermediate row positions in the middle of the screen during ticker-driven repaints (agent status, tool timer, streaming output).
- Terminals without DEC 2026 support ignore the sequences harmlessly — behavior matches today.

## Test plan
- [ ] Run `herm` in a terminal that supports DEC 2026 (iTerm2, WezTerm, kitty, Ghostty, modern Alacritty, recent Terminal.app, tmux ≥ 3.4) and confirm no cursor flicker mid-screen while an agent is running.
- [ ] Run `herm` in a terminal that does *not* support DEC 2026 and confirm no regression vs. current behavior.
- [ ] Resize the terminal mid-session and confirm the input cursor lands correctly on the next frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)