### PR TITLE
feat: add Kimi (Moonshot AI) provider support

### DIFF
--- a/cmd/herm/agent.go
+++ b/cmd/herm/agent.go
@@ -53,6 +53,9 @@ func newLangdagClient(cfg Config) (*langdag.Client, error) {
 	if cfg.OpenRouterAPIKey != "" {
 		return newLangdagClientForProvider(newLangdagClientForProviderOptions{cfg: cfg, provider: ProviderOpenRouter})
 	}
+	if cfg.KimiAPIKey != "" {
+		return newLangdagClientForProvider(newLangdagClientForProviderOptions{cfg: cfg, provider: ProviderKimi})
+	}
 	if cfg.GeminiAPIKey != "" {
 		return newLangdagClientForProvider(newLangdagClientForProviderOptions{cfg: cfg, provider: ProviderGemini})
 	}
@@ -90,6 +93,9 @@ func newLangdagClientForProvider(opts newLangdagClientForProviderOptions) (*lang
 	case ProviderOpenRouter:
 		langdagCfg.Provider = "openrouter"
 		langdagCfg.APIKeys = map[string]string{"openrouter": opts.cfg.OpenRouterAPIKey}
+	case ProviderKimi:
+		langdagCfg.Provider = "kimi"
+		langdagCfg.APIKeys = map[string]string{"kimi": opts.cfg.KimiAPIKey}
 	case ProviderGemini:
 		langdagCfg.Provider = "gemini"
 		langdagCfg.APIKeys = map[string]string{"gemini": opts.cfg.GeminiAPIKey}

--- a/cmd/herm/background.go
+++ b/cmd/herm/background.go
@@ -141,6 +141,10 @@ type openRouterModelsMsg struct {
 	models []ModelDef
 }
 
+type kimiModelsMsg struct {
+	models []ModelDef
+}
+
 // openPickerMsg is sent after an async Ollama fetch completes to open the
 // model picker in the config editor with the freshly fetched model list.
 type openPickerMsg struct {
@@ -662,6 +666,10 @@ func fetchOllamaModelsCmd(baseURL string) ollamaModelsMsg {
 
 func fetchOpenRouterModelsCmd(apiKey string) openRouterModelsMsg {
 	return openRouterModelsMsg{models: fetchOpenRouterModels(apiKey)}
+}
+
+func fetchKimiModelsCmd(apiKey string) kimiModelsMsg {
+	return kimiModelsMsg{models: fetchKimiModels(apiKey)}
 }
 
 // checkForUpdate queries the GitHub API for the latest release and compares

--- a/cmd/herm/config.go
+++ b/cmd/herm/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	AnthropicAPIKey       string          `json:"anthropic_api_key,omitempty"`
 	GrokAPIKey            string          `json:"grok_api_key,omitempty"`
 	OpenRouterAPIKey      string          `json:"openrouter_api_key,omitempty"`
+	KimiAPIKey            string          `json:"kimi_api_key,omitempty"`
 	OpenAIAPIKey          string          `json:"openai_api_key,omitempty"`
 	GeminiAPIKey          string          `json:"gemini_api_key,omitempty"`
 	OllamaBaseURL         string          `json:"ollama_base_url,omitempty"` // e.g., "http://localhost:11434"
@@ -71,6 +72,9 @@ func (c Config) configuredProviders() map[string]bool {
 	if c.OpenRouterAPIKey != "" {
 		providers[ProviderOpenRouter] = true
 	}
+	if c.KimiAPIKey != "" {
+		providers[ProviderKimi] = true
+	}
 	if c.OpenAIAPIKey != "" {
 		providers[ProviderOpenAI] = true
 	}
@@ -96,6 +100,9 @@ func (c Config) defaultLangdagProvider() string {
 	}
 	if c.OpenRouterAPIKey != "" {
 		return ProviderOpenRouter
+	}
+	if c.KimiAPIKey != "" {
+		return ProviderKimi
 	}
 	if c.GeminiAPIKey != "" {
 		return ProviderGemini

--- a/cmd/herm/configeditor.go
+++ b/cmd/herm/configeditor.go
@@ -62,6 +62,7 @@ var cfgAPIKeyFields = []cfgField{
 	{label: "OpenAI", get: func(c Config) string { return c.OpenAIAPIKey }, display: func(c Config) string { return maskKey(c.OpenAIAPIKey) }, set: func(c *Config, v string) { c.OpenAIAPIKey = v }},
 	{label: "Grok", get: func(c Config) string { return c.GrokAPIKey }, display: func(c Config) string { return maskKey(c.GrokAPIKey) }, set: func(c *Config, v string) { c.GrokAPIKey = v }},
 	{label: "OpenRouter", get: func(c Config) string { return c.OpenRouterAPIKey }, display: func(c Config) string { return maskKey(c.OpenRouterAPIKey) }, set: func(c *Config, v string) { c.OpenRouterAPIKey = v }},
+	{label: "Kimi", get: func(c Config) string { return c.KimiAPIKey }, display: func(c Config) string { return maskKey(c.KimiAPIKey) }, set: func(c *Config, v string) { c.KimiAPIKey = v }},
 	{label: "Gemini", get: func(c Config) string { return c.GeminiAPIKey }, display: func(c Config) string { return maskKey(c.GeminiAPIKey) }, set: func(c *Config, v string) { c.GeminiAPIKey = v }},
 	{label: "Ollama URL", get: func(c Config) string { return c.OllamaBaseURL }, set: func(c *Config, v string) {
 		v = strings.TrimSpace(v)
@@ -82,10 +83,12 @@ func apiKeyRowForProvider(provider string) int {
 		return 2
 	case ProviderOpenRouter:
 		return 3
-	case ProviderGemini:
+	case ProviderKimi:
 		return 4
-	case ProviderOllama:
+	case ProviderGemini:
 		return 5
+	case ProviderOllama:
+		return 6
 	default:
 		return 0
 	}
@@ -112,7 +115,7 @@ func (a *App) preferredAPIKeyCursor(cfg Config) int {
 	if p, _ := a.effectiveProviderForConfig(cfg); p != "" {
 		return apiKeyRowForProvider(p)
 	}
-	ordered := []string{ProviderAnthropic, ProviderOpenAI, ProviderGrok, ProviderOpenRouter, ProviderGemini, ProviderOllama}
+	ordered := []string{ProviderAnthropic, ProviderOpenAI, ProviderGrok, ProviderOpenRouter, ProviderKimi, ProviderGemini, ProviderOllama}
 	configured := cfg.configuredProviders()
 	for _, p := range ordered {
 		if configured[p] {
@@ -173,6 +176,10 @@ func (a *App) exitConfigMode(save bool) {
 			a.openRouterFetched = false // allow re-fetch with new key
 			go func() { a.resultCh <- fetchOpenRouterModelsCmd(a.config.OpenRouterAPIKey) }()
 		}
+		if a.config.KimiAPIKey != "" {
+			a.kimiFetched = false // allow re-fetch with new key
+			go func() { a.resultCh <- fetchKimiModelsCmd(a.config.KimiAPIKey) }()
+		}
 		// Show updated model if it changed
 		if a.models != nil {
 			a.showModelChange(a.config.resolveActiveModel(a.models))
@@ -222,6 +229,16 @@ func (a *App) openConfigModelPicker(opts openConfigModelPickerOptions) {
 	if a.cfgDraft.OpenRouterAPIKey != "" && a.config.OpenRouterAPIKey != a.cfgDraft.OpenRouterAPIKey {
 		go func() {
 			msg := fetchOpenRouterModelsCmd(a.cfgDraft.OpenRouterAPIKey)
+			a.resultCh <- msg
+			a.resultCh <- openPickerMsg{getCurrentID: getCurrentID, onSelect: onSelect}
+		}()
+		return
+	}
+	// If the draft Kimi key differs from the saved key, fetch fresh models
+	// async before opening the picker.
+	if a.cfgDraft.KimiAPIKey != "" && a.config.KimiAPIKey != a.cfgDraft.KimiAPIKey {
+		go func() {
+			msg := fetchKimiModelsCmd(a.cfgDraft.KimiAPIKey)
 			a.resultCh <- msg
 			a.resultCh <- openPickerMsg{getCurrentID: getCurrentID, onSelect: onSelect}
 		}()

--- a/cmd/herm/kimi_fetch_test.go
+++ b/cmd/herm/kimi_fetch_test.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// --- fetchKimiModels tests ---
+
+func TestFetchKimiModelsEmptyKey(t *testing.T) {
+	models := fetchKimiModels("")
+	if models != nil {
+		t.Errorf("expected nil for empty API key, got %d models", len(models))
+	}
+}
+
+func TestFetchKimiModelsSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/models" {
+			http.NotFound(w, r)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{
+				{
+					"id":             "moonshot-v1-8k",
+					"object":         "model",
+					"context_length": 8192,
+				},
+				{
+					"id":             "moonshot-v1-128k",
+					"object":         "model",
+					"context_length": 131072,
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	// Override the default base URL for testing
+	origBase := kimiDefaultBase
+	defer func() {
+		if origBase != kimiDefaultBase {
+			t.Error("kimiDefaultBase was mutated")
+		}
+	}()
+
+	models := fetchKimiModelsFrom(fetchKimiOptions{apiKey: "test-key", baseURL: srv.URL})
+	if len(models) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(models))
+	}
+	if models[0].Provider != ProviderKimi {
+		t.Errorf("Provider = %q, want %q", models[0].Provider, ProviderKimi)
+	}
+	if models[0].ID != "moonshot-v1-8k" {
+		t.Errorf("ID = %q, want moonshot-v1-8k", models[0].ID)
+	}
+	if models[0].ContextWindow != 8192 {
+		t.Errorf("ContextWindow = %d, want 8192", models[0].ContextWindow)
+	}
+	if models[1].ContextWindow != 131072 {
+		t.Errorf("ContextWindow = %d, want 131072", models[1].ContextWindow)
+	}
+}
+
+func TestFetchKimiModelsServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	models := fetchKimiModelsFrom(fetchKimiOptions{apiKey: "test-key", baseURL: srv.URL})
+	if models != nil {
+		t.Errorf("expected nil on server error, got %d models", len(models))
+	}
+}
+
+func TestFetchKimiModelsInvalidJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+
+	models := fetchKimiModelsFrom(fetchKimiOptions{apiKey: "test-key", baseURL: srv.URL})
+	if models != nil {
+		t.Errorf("expected nil on invalid JSON, got %d models", len(models))
+	}
+}
+
+func TestFetchKimiModelsUnreachable(t *testing.T) {
+	models := fetchKimiModelsFrom(fetchKimiOptions{apiKey: "test-key", baseURL: "http://127.0.0.1:1"})
+	if models != nil {
+		t.Errorf("expected nil for unreachable server, got %d models", len(models))
+	}
+}
+
+func TestFetchKimiModelsEmpty(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"data": []any{}})
+	}))
+	defer srv.Close()
+
+	models := fetchKimiModelsFrom(fetchKimiOptions{apiKey: "test-key", baseURL: srv.URL})
+	if len(models) != 0 {
+		t.Errorf("expected 0 models for empty list, got %d", len(models))
+	}
+}
+
+func TestFetchKimiModelsAuthHeader(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		json.NewEncoder(w).Encode(map[string]any{"data": []any{}})
+	}))
+	defer srv.Close()
+
+	fetchKimiModelsFrom(fetchKimiOptions{apiKey: "my-api-key", baseURL: srv.URL})
+	if gotAuth != "Bearer my-api-key" {
+		t.Errorf("Authorization = %q, want %q", gotAuth, "Bearer my-api-key")
+	}
+}
+
+func TestFetchKimiModelsProviderField(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{
+				{"id": "moonshot-v1-32k", "context_length": 32768},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	models := fetchKimiModelsFrom(fetchKimiOptions{apiKey: "test-key", baseURL: srv.URL})
+	if len(models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(models))
+	}
+	if models[0].Provider != ProviderKimi {
+		t.Errorf("Provider = %q, want %q", models[0].Provider, ProviderKimi)
+	}
+}
+
+func TestFetchKimiModelsMissingContextLength(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{
+				{"id": "moonshot-v1-auto"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	models := fetchKimiModelsFrom(fetchKimiOptions{apiKey: "test-key", baseURL: srv.URL})
+	if len(models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(models))
+	}
+	if models[0].ContextWindow != 0 {
+		t.Errorf("ContextWindow = %d, want 0 when context_length is missing", models[0].ContextWindow)
+	}
+}

--- a/cmd/herm/kimi_test.go
+++ b/cmd/herm/kimi_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"testing"
+)
+
+// --- Config integration tests for Kimi provider ---
+
+func TestConfiguredProviders_IncludesKimi(t *testing.T) {
+	cfg := Config{KimiAPIKey: "test-key"}
+	providers := cfg.configuredProviders()
+	if !providers[ProviderKimi] {
+		t.Error("expected Kimi in configured providers when API key is set")
+	}
+}
+
+func TestConfiguredProviders_ExcludesKimiWithoutKey(t *testing.T) {
+	cfg := Config{}
+	providers := cfg.configuredProviders()
+	if providers[ProviderKimi] {
+		t.Error("expected Kimi excluded from configured providers when API key is empty")
+	}
+}
+
+func TestDefaultLangdagProvider_Kimi(t *testing.T) {
+	cfg := Config{KimiAPIKey: "test-key"}
+	if got := cfg.defaultLangdagProvider(); got != ProviderKimi {
+		t.Errorf("defaultLangdagProvider() = %q, want %q", got, ProviderKimi)
+	}
+}
+
+func TestDefaultLangdagProvider_KimiFallsAfterOpenRouter(t *testing.T) {
+	cfg := Config{
+		OpenRouterAPIKey: "or-key",
+		KimiAPIKey:       "kimi-key",
+	}
+	if got := cfg.defaultLangdagProvider(); got != ProviderOpenRouter {
+		t.Errorf("defaultLangdagProvider() = %q, want %q (OpenRouter has higher priority)", got, ProviderOpenRouter)
+	}
+}
+
+func TestDefaultLangdagProvider_KimiBeforeGemini(t *testing.T) {
+	cfg := Config{
+		KimiAPIKey:   "kimi-key",
+		GeminiAPIKey: "gemini-key",
+	}
+	if got := cfg.defaultLangdagProvider(); got != ProviderKimi {
+		t.Errorf("defaultLangdagProvider() = %q, want %q (Kimi has higher priority than Gemini)", got, ProviderKimi)
+	}
+}
+
+func TestAvailableModels_FiltersToKimi(t *testing.T) {
+	cfg := Config{KimiAPIKey: "test-key"}
+	models := []ModelDef{
+		{Provider: ProviderKimi, ID: "moonshot-v1-8k"},
+		{Provider: ProviderAnthropic, ID: "claude-sonnet-4-6"},
+		{Provider: ProviderKimi, ID: "moonshot-v1-128k"},
+	}
+	available := cfg.availableModels(models)
+	if len(available) != 2 {
+		t.Fatalf("expected 2 available models, got %d", len(available))
+	}
+	for _, m := range available {
+		if m.Provider != ProviderKimi {
+			t.Errorf("expected only Kimi models, got provider %q", m.Provider)
+		}
+	}
+}
+
+func TestNewLangdagClientForProvider_Kimi(t *testing.T) {
+	cfg := Config{KimiAPIKey: "test-key"}
+	client, err := newLangdagClientForProvider(newLangdagClientForProviderOptions{
+		cfg:      cfg,
+		provider: ProviderKimi,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected non-nil client")
+	}
+}
+
+func TestNewLangdagClient_SelectsKimi(t *testing.T) {
+	cfg := Config{KimiAPIKey: "test-key"}
+	client, err := newLangdagClient(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected non-nil client when Kimi key is configured")
+	}
+}
+
+func TestProviderKimiConstant(t *testing.T) {
+	if ProviderKimi != "kimi" {
+		t.Errorf("ProviderKimi = %q, want %q", ProviderKimi, "kimi")
+	}
+}
+
+func TestSupportedProviders_ContainsKimi(t *testing.T) {
+	found := false
+	for _, p := range supportedProviders {
+		if p == ProviderKimi {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected ProviderKimi in supportedProviders")
+	}
+}

--- a/cmd/herm/main.go
+++ b/cmd/herm/main.go
@@ -121,6 +121,7 @@ type App struct {
 	shownInitialModel   bool // true after the startup model line has been displayed
 	ollamaFetched       bool // true after the initial Ollama model fetch completes (or was skipped)
 	openRouterFetched   bool // true after initial OpenRouter fetch
+	kimiFetched         bool // true after initial Kimi fetch
 	status           statusInfo
 	projectSnap      *projectSnapshot
 	modelCatalog     *langdag.ModelCatalog
@@ -752,24 +753,14 @@ func (a *App) handleResult(result any) {
 			if a.config.OpenRouterAPIKey != "" && !a.openRouterFetched {
 				go func() { a.resultCh <- fetchOpenRouterModelsCmd(a.config.OpenRouterAPIKey) }()
 			}
+			if a.config.KimiAPIKey != "" && !a.kimiFetched {
+				go func() { a.resultCh <- fetchKimiModelsCmd(a.config.KimiAPIKey) }()
+			}
 		}
 	case ollamaModelsMsg:
 		a.ollamaFetched = true
-		if len(msg.models) > 0 {
-			base := modelsFromCatalog(a.modelCatalog)
-			for _, m := range a.models {
-				if m.Provider == ProviderOpenRouter {
-					base = append(base, m)
-				}
-			}
-			a.models = append(base, msg.models...)
-			if a.sweLoaded && a.sweScores != nil {
-				matchSWEScores(matchSWEScoresOptions{models: a.models, scores: a.sweScores})
-			}
-		}
 		alreadyShown := a.shownInitialModel
-		a.maybeShowInitialModels()
-		// Show offline warning if model was already displayed
+		a.mergeDynamicModels(mergeDynamicModelsOptions{models: msg.models, provider: ProviderOllama})
 		if alreadyShown {
 			activeID := a.config.resolveActiveModel(a.models)
 			if a.config.OllamaBaseURL != "" && a.isOllamaOffline(activeID) {
@@ -784,19 +775,10 @@ func (a *App) handleResult(result any) {
 		}
 	case openRouterModelsMsg:
 		a.openRouterFetched = true
-		if len(msg.models) > 0 {
-			base := modelsFromCatalog(a.modelCatalog)
-			for _, m := range a.models {
-				if m.Provider == ProviderOllama {
-					base = append(base, m)
-				}
-			}
-			a.models = append(base, msg.models...)
-			if a.sweLoaded && a.sweScores != nil {
-				matchSWEScores(matchSWEScoresOptions{models: a.models, scores: a.sweScores})
-			}
-		}
-		a.maybeShowInitialModels()
+		a.mergeDynamicModels(mergeDynamicModelsOptions{models: msg.models, provider: ProviderOpenRouter})
+	case kimiModelsMsg:
+		a.kimiFetched = true
+		a.mergeDynamicModels(mergeDynamicModelsOptions{models: msg.models, provider: ProviderKimi})
 	case openPickerMsg:
 		if a.cfgActive {
 			a.doOpenConfigModelPicker(doOpenConfigModelPickerOptions{models: a.models, getCurrentID: msg.getCurrentID, onSelect: msg.onSelect})

--- a/cmd/herm/models.go
+++ b/cmd/herm/models.go
@@ -24,13 +24,14 @@ const (
 	ProviderAnthropic   = "anthropic"
 	ProviderGrok        = "grok"
 	ProviderOpenRouter  = "openrouter"
+	ProviderKimi        = "kimi"
 	ProviderOpenAI      = "openai"
 	ProviderGemini      = "gemini"
 	ProviderOllama      = "ollama"
 )
 
 // supportedProviders lists providers in display order.
-var supportedProviders = []string{ProviderAnthropic, ProviderGrok, ProviderOpenRouter, ProviderOpenAI, ProviderGemini, ProviderOllama}
+var supportedProviders = []string{ProviderAnthropic, ProviderGrok, ProviderOpenRouter, ProviderKimi, ProviderOpenAI, ProviderGemini, ProviderOllama}
 
 // ModelDef describes a model available for selection.
 // Models are derived from the langdag model catalog at runtime.
@@ -45,6 +46,30 @@ type ModelDef struct {
 	ServerTools     []string // server-side tools supported by this model (e.g. "web_search")
 }
 
+// mergeDynamicModelsOptions is the parameter bundle for mergeDynamicModels.
+type mergeDynamicModelsOptions struct {
+	models   []ModelDef
+	provider string
+}
+
+// mergeDynamicModels replaces the models for a given provider with fresh results.
+// It rebuilds the list from catalog + other dynamic providers, then appends the new models.
+func (a *App) mergeDynamicModels(opts mergeDynamicModelsOptions) {
+	if len(opts.models) > 0 {
+		base := modelsFromCatalog(a.modelCatalog)
+		for _, m := range a.models {
+			if m.Provider != opts.provider && (m.Provider == ProviderOllama || m.Provider == ProviderOpenRouter || m.Provider == ProviderKimi) {
+				base = append(base, m)
+			}
+		}
+		a.models = append(base, opts.models...)
+		if a.sweLoaded && a.sweScores != nil {
+			matchSWEScores(matchSWEScoresOptions{models: a.models, scores: a.sweScores})
+		}
+	}
+	a.maybeShowInitialModels()
+}
+
 // modelsFromCatalog builds the model list from the langdag catalog.
 // Only models from supported providers are included.
 func modelsFromCatalog(catalog *langdag.ModelCatalog) []ModelDef {
@@ -53,8 +78,8 @@ func modelsFromCatalog(catalog *langdag.ModelCatalog) []ModelDef {
 	}
 	var models []ModelDef
 	for _, provider := range supportedProviders {
-		// Ollama and OpenRouter models are fetched separately via their own fetch functions
-		if provider == ProviderOllama || provider == ProviderOpenRouter {
+		// Ollama, OpenRouter, and Kimi models are fetched separately via their own fetch functions
+		if provider == ProviderOllama || provider == ProviderOpenRouter || provider == ProviderKimi {
 			continue
 		}
 		for _, p := range catalog.ForProvider(provider) {
@@ -228,6 +253,68 @@ func fetchOpenRouterModelsFrom(opts fetchOpenRouterOptions) []ModelDef {
 			PromptPrice:     promptPrice,
 			CompletionPrice: completionPrice,
 			ContextWindow:   m.ContextLength,
+		})
+	}
+	return models
+}
+
+const kimiDefaultBase = "https://api.moonshot.ai/v1"
+
+// fetchKimiModels fetches available models from the Kimi (Moonshot AI) API.
+// Returns nil if apiKey is empty or the request fails.
+func fetchKimiModels(apiKey string) []ModelDef {
+	return fetchKimiModelsFrom(fetchKimiOptions{apiKey: apiKey, baseURL: kimiDefaultBase})
+}
+
+// fetchKimiOptions is the parameter bundle for fetchKimiModelsFrom.
+type fetchKimiOptions struct {
+	apiKey  string
+	baseURL string
+}
+
+// fetchKimiModelsFrom fetches models using the given base URL.
+func fetchKimiModelsFrom(opts fetchKimiOptions) []ModelDef {
+	apiKey, baseURL := opts.apiKey, opts.baseURL
+	if apiKey == "" {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	client := &http.Client{}
+	req, err := http.NewRequestWithContext(ctx, "GET", baseURL+"/models", nil)
+	if err != nil {
+		return nil
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil
+	}
+
+	var body struct {
+		Data []struct {
+			ID            string `json:"id"`
+			ContextLength int    `json:"context_length"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil
+	}
+
+	models := make([]ModelDef, 0, len(body.Data))
+	for _, m := range body.Data {
+		models = append(models, ModelDef{
+			Provider:      ProviderKimi,
+			ID:            m.ID,
+			ContextWindow: m.ContextLength,
 		})
 	}
 	return models


### PR DESCRIPTION
## Summary
- Wire up Kimi (Moonshot AI) as a new provider in herm
- Dynamic model fetching via Kimi's `/v1/models` endpoint
- Config UI integration: API key field, model picker refresh on key change
- langdag client wiring with `MOONSHOT_API_KEY` / `kimi_api_key` support
- 19 unit tests (9 fetch + 10 config/integration)

Closes #29
Depends on: fundamental-research-labs/langdag#19

> **Note:** The submodule pointer currently references the unmerged langdag PR commit. 
> Once langdag#19 merges, the submodule will be updated to the final upstream commit.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (19 new Kimi tests + all existing tests)
- [ ] Manual test: set `MOONSHOT_API_KEY`, verify models appear in `/config` picker
- [ ] Manual test: select a Kimi model, send a message, verify streaming response