### PR TITLE
Fix Ghostty shifted key input

### DIFF
--- a/cmd/herm/configeditor.go
+++ b/cmd/herm/configeditor.go
@@ -726,59 +726,11 @@ func (a *App) handleConfigByte(opts handleConfigByteOptions) {
 			a.exitConfigMode(false)
 			return
 		}
-		b, ok = readByte()
+		seq, ok := readCSISequence(readByte)
 		if !ok {
 			return
 		}
-		switch b {
-		case 'A': // Up
-			if a.cfgCursor > 0 {
-				a.cfgCursor--
-			} else {
-				fields := a.cfgCurrentFields()
-				if len(fields) > 0 {
-					a.cfgCursor = len(fields) - 1
-				}
-			}
-			a.cfgTabCursor[a.cfgTab] = a.cfgCursor
-			a.renderInput()
-		case 'B': // Down
-			fields := a.cfgCurrentFields()
-			if a.cfgCursor < len(fields)-1 {
-				a.cfgCursor++
-			} else {
-				a.cfgCursor = 0
-			}
-			a.cfgTabCursor[a.cfgTab] = a.cfgCursor
-			a.renderInput()
-		case 'C': // Right - next tab
-			a.cfgTabCursor[a.cfgTab] = a.cfgCursor
-			a.cfgTab++
-			if a.cfgTab >= len(cfgTabNames) {
-				a.cfgTab = cfgTabDeployments
-			}
-			a.cfgCursor = a.cfgTabCursor[a.cfgTab]
-			a.clampConfigCursor()
-			a.renderInput()
-		case 'D': // Left - prev tab
-			a.cfgTabCursor[a.cfgTab] = a.cfgCursor
-			a.cfgTab--
-			if a.cfgTab < 0 {
-				a.cfgTab = len(cfgTabNames) - 1
-			}
-			a.cfgCursor = a.cfgTabCursor[a.cfgTab]
-			a.clampConfigCursor()
-			a.renderInput()
-		case '2': // modifyOtherKeys (Ctrl+S, Ctrl+C, etc.)
-			a.handleCSIDigit2(handleCSIDigit2Options{readByte: readByte, onPaste: func(string) {}})
-		default:
-			// Consume modified key sequences (ESC [ 1 ; mod letter)
-			if b == '1' {
-				readByte() // ;
-				readByte() // mod
-				readByte() // letter
-			}
-		}
+		a.handleConfigCSISequence(handleConfigCSISequenceOptions{seq: seq, readByte: readByte})
 
 	case ch == '\r': // Enter - toggle, picker, or start editing current field
 		if a.cfgTab == cfgTabProject && a.projectConfigRoot() == "" {
@@ -853,51 +805,11 @@ func (a *App) handleConfigEditByte(opts handleConfigEditByteOptions) {
 			a.renderInput()
 			return
 		}
-		b, ok = readByte()
+		seq, ok := readCSISequence(readByte)
 		if !ok {
 			return
 		}
-		switch b {
-		case 'C': // Right
-			if a.cfgEditCursor < len(a.cfgEditBuf) {
-				a.cfgEditCursor++
-				a.renderInput()
-			}
-		case 'D': // Left
-			if a.cfgEditCursor > 0 {
-				a.cfgEditCursor--
-				a.renderInput()
-			}
-		case 'H': // Home
-			a.cfgEditCursor = 0
-			a.renderInput()
-		case 'F': // End
-			a.cfgEditCursor = len(a.cfgEditBuf)
-			a.renderInput()
-		case '2': // Bracketed paste or modifyOtherKeys
-			a.handleCSIDigit2(handleCSIDigit2Options{readByte: readByte, onPaste: func(s string) {
-				pasted := []rune(s)
-				tail := make([]rune, len(a.cfgEditBuf[a.cfgEditCursor:]))
-				copy(tail, a.cfgEditBuf[a.cfgEditCursor:])
-				a.cfgEditBuf = append(a.cfgEditBuf[:a.cfgEditCursor], append(pasted, tail...)...)
-				a.cfgEditCursor += len(pasted)
-				a.renderInput()
-			}})
-		case '3': // Delete
-			if t, ok := readByte(); ok && t == '~' {
-				if a.cfgEditCursor < len(a.cfgEditBuf) {
-					a.cfgEditBuf = append(a.cfgEditBuf[:a.cfgEditCursor], a.cfgEditBuf[a.cfgEditCursor+1:]...)
-					a.renderInput()
-				}
-			}
-		default:
-			// consume remaining bytes of sequences
-			if b == '1' {
-				readByte()
-				readByte()
-				readByte()
-			}
-		}
+		a.handleConfigEditCSISequence(handleConfigEditCSISequenceOptions{seq: seq, readByte: readByte})
 
 	case ch == '\r': // Enter - confirm edit
 		fields := a.cfgCurrentFields()
@@ -935,15 +847,7 @@ func (a *App) handleConfigEditByte(opts handleConfigEditByteOptions) {
 
 	case ch == 0x17: // Ctrl+W - delete word backward
 		if a.cfgEditCursor > 0 {
-			i := a.cfgEditCursor - 1
-			for i > 0 && a.cfgEditBuf[i] == ' ' {
-				i--
-			}
-			for i > 0 && a.cfgEditBuf[i-1] != ' ' {
-				i--
-			}
-			a.cfgEditBuf = append(a.cfgEditBuf[:i], a.cfgEditBuf[a.cfgEditCursor:]...)
-			a.cfgEditCursor = i
+			a.deleteConfigEditWordBackward()
 			a.renderInput()
 		}
 
@@ -961,10 +865,7 @@ func (a *App) handleConfigEditByte(opts handleConfigEditByteOptions) {
 			}
 			r, _ = utf8.DecodeRune(b)
 		}
-		a.cfgEditBuf = append(a.cfgEditBuf, 0)
-		copy(a.cfgEditBuf[a.cfgEditCursor+1:], a.cfgEditBuf[a.cfgEditCursor:])
-		a.cfgEditBuf[a.cfgEditCursor] = r
-		a.cfgEditCursor++
+		a.insertConfigEditRune(r)
 		a.renderInput()
 	}
 }

--- a/cmd/herm/configeditor_input.go
+++ b/cmd/herm/configeditor_input.go
@@ -1,0 +1,182 @@
+// configeditor_input.go handles CSI and encoded-key input for the config editor.
+package main
+
+type handleConfigCSISequenceOptions struct {
+	seq      csiSequence
+	readByte func() (byte, bool)
+}
+
+func (a *App) handleConfigCSISequence(opts handleConfigCSISequenceOptions) {
+	seq, readByte := opts.seq, opts.readByte
+	if len(seq.params) > 0 && seq.final != '~' && seq.final != 'u' {
+		return
+	}
+
+	switch seq.final {
+	case 'A': // Up
+		if a.cfgCursor > 0 {
+			a.cfgCursor--
+		} else {
+			fields := a.cfgCurrentFields()
+			if len(fields) > 0 {
+				a.cfgCursor = len(fields) - 1
+			}
+		}
+		a.cfgTabCursor[a.cfgTab] = a.cfgCursor
+		a.renderInput()
+	case 'B': // Down
+		fields := a.cfgCurrentFields()
+		if a.cfgCursor < len(fields)-1 {
+			a.cfgCursor++
+		} else {
+			a.cfgCursor = 0
+		}
+		a.cfgTabCursor[a.cfgTab] = a.cfgCursor
+		a.renderInput()
+	case 'C': // Right - next tab
+		a.cfgTabCursor[a.cfgTab] = a.cfgCursor
+		a.cfgTab++
+		if a.cfgTab >= len(cfgTabNames) {
+			a.cfgTab = cfgTabDeployments
+		}
+		a.cfgCursor = a.cfgTabCursor[a.cfgTab]
+		a.clampConfigCursor()
+		a.renderInput()
+	case 'D': // Left - prev tab
+		a.cfgTabCursor[a.cfgTab] = a.cfgCursor
+		a.cfgTab--
+		if a.cfgTab < 0 {
+			a.cfgTab = len(cfgTabNames) - 1
+		}
+		a.cfgCursor = a.cfgTabCursor[a.cfgTab]
+		a.clampConfigCursor()
+		a.renderInput()
+	case '~':
+		if string(seq.params) == "200" {
+			_ = readBracketedPaste(readByte)
+		} else if mod, code, ok := parseModifyOtherKeysParams(seq.params); ok {
+			a.handleConfigEncodedKey(handleConfigEncodedKeyOptions{mod: mod, code: code})
+		}
+	case 'u':
+		code, mod, ok := parseCSIUParams(seq.params)
+		if ok {
+			a.handleConfigEncodedKey(handleConfigEncodedKeyOptions{mod: mod, code: code})
+		}
+	}
+}
+
+type handleConfigEncodedKeyOptions struct {
+	mod  int
+	code int
+}
+
+func (a *App) handleConfigEncodedKey(opts handleConfigEncodedKeyOptions) {
+	if opts.code == '\033' {
+		a.exitConfigMode(false)
+		return
+	}
+	_, _, isCtrl := decodeCSIEncodedModifier(opts.mod)
+	if isCtrl {
+		a.handleEncodedKey(handleEncodedKeyOptions{mod: opts.mod, code: opts.code})
+	}
+}
+
+type handleConfigEditCSISequenceOptions struct {
+	seq      csiSequence
+	readByte func() (byte, bool)
+}
+
+func (a *App) handleConfigEditCSISequence(opts handleConfigEditCSISequenceOptions) {
+	seq, readByte := opts.seq, opts.readByte
+	if len(seq.params) > 0 && seq.final != '~' && seq.final != 'u' {
+		return
+	}
+
+	switch seq.final {
+	case 'C': // Right
+		if a.cfgEditCursor < len(a.cfgEditBuf) {
+			a.cfgEditCursor++
+			a.renderInput()
+		}
+	case 'D': // Left
+		if a.cfgEditCursor > 0 {
+			a.cfgEditCursor--
+			a.renderInput()
+		}
+	case 'H': // Home
+		a.cfgEditCursor = 0
+		a.renderInput()
+	case 'F': // End
+		a.cfgEditCursor = len(a.cfgEditBuf)
+		a.renderInput()
+	case '~':
+		switch string(seq.params) {
+		case "200":
+			a.insertConfigEditText(readBracketedPaste(readByte))
+			a.renderInput()
+		case "3":
+			if a.cfgEditCursor < len(a.cfgEditBuf) {
+				a.cfgEditBuf = append(a.cfgEditBuf[:a.cfgEditCursor], a.cfgEditBuf[a.cfgEditCursor+1:]...)
+				a.renderInput()
+			}
+		default:
+			if mod, code, ok := parseModifyOtherKeysParams(seq.params); ok {
+				a.handleConfigEditEncodedKey(handleConfigEditEncodedKeyOptions{mod: mod, code: code})
+			}
+		}
+	case 'u':
+		code, mod, ok := parseCSIUParams(seq.params)
+		if ok {
+			a.handleConfigEditEncodedKey(handleConfigEditEncodedKeyOptions{mod: mod, code: code})
+		}
+	}
+}
+
+type handleConfigEditEncodedKeyOptions struct {
+	mod  int
+	code int
+}
+
+func (a *App) handleConfigEditEncodedKey(opts handleConfigEditEncodedKeyOptions) {
+	if opts.code == '\033' {
+		a.cfgEditing = false
+		a.cfgEditBuf = nil
+		a.renderInput()
+		return
+	}
+	a.handleEncodedKey(handleEncodedKeyOptions{
+		mod:                opts.mod,
+		code:               opts.code,
+		insertRune:         a.insertConfigEditRune,
+		deleteWordBackward: a.deleteConfigEditWordBackward,
+		render:             a.renderInput,
+	})
+}
+
+func (a *App) insertConfigEditText(s string) {
+	for _, r := range s {
+		a.insertConfigEditRune(r)
+	}
+}
+
+func (a *App) insertConfigEditRune(r rune) {
+	a.cfgEditBuf = append(a.cfgEditBuf, 0)
+	copy(a.cfgEditBuf[a.cfgEditCursor+1:], a.cfgEditBuf[a.cfgEditCursor:])
+	a.cfgEditBuf[a.cfgEditCursor] = r
+	a.cfgEditCursor++
+}
+
+func (a *App) deleteConfigEditWordBackward() {
+	if a.cfgEditCursor <= 0 {
+		return
+	}
+	i := a.cfgEditCursor - 1
+	for i > 0 && a.cfgEditBuf[i] == ' ' {
+		i--
+	}
+	for i > 0 && a.cfgEditBuf[i-1] != ' ' {
+		i--
+	}
+	a.cfgEditBuf = append(a.cfgEditBuf[:i], a.cfgEditBuf[a.cfgEditCursor:]...)
+	a.cfgEditCursor = i
+}

--- a/cmd/herm/input_keys.go
+++ b/cmd/herm/input_keys.go
@@ -1,12 +1,14 @@
 // input_keys.go handles byte/CSI/escape-sequence dispatch and paste input:
 // handleByte, handlePlainEscape, handleEscapeSequence, handleNavKey,
-// handleModifyOtherKeys, handleCSIDigit2, handleModifiedCSI, handlePaste.
+// handleModifyOtherKeys, handlePaste.
 package main
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
+	"unicode"
 	"unicode/utf8"
 )
 
@@ -357,26 +359,14 @@ func (a *App) handleEscapeSequence(opts handleEscapeSequenceOptions) bool {
 	// unknown or unexpected CSI sequences are fully consumed and never leak
 	// trailing bytes into the input buffer (e.g. mouse/scroll events from
 	// terminals like Zed that send sequences herm does not handle).
-	var params []byte
-	var final byte
-	for {
-		b, ok = readByte()
-		if !ok {
-			return false
-		}
-		if isCSIFinal(b) {
-			final = b
-			break
-		}
-		params = append(params, b)
-		if len(params) > 128 {
-			return false // safety limit for malformed sequences
-		}
+	seq, ok := readCSISequence(readByte)
+	if !ok {
+		return false
 	}
 
 	// Tilde-terminated sequences
-	if final == '~' {
-		ps := string(params)
+	if seq.final == '~' {
+		ps := string(seq.params)
 		switch {
 		case ps == "200": // Bracketed paste: ESC [ 200 ~
 			a.handlePaste(readBracketedPaste(readByte))
@@ -387,15 +377,20 @@ func (a *App) handleEscapeSequence(opts handleEscapeSequenceOptions) bool {
 			}
 		default:
 			// modifyOtherKeys: ESC [ 27 ; <mod> ; <code> ~
-			if strings.HasPrefix(ps, "27;") {
-				var mod, code int
-				if n, _ := fmt.Sscanf(ps[3:], "%d;%d", &mod, &code); n == 2 {
-					return a.handleModifyOtherKeys(handleModifyOtherKeysOptions{mod: mod, code: code})
-				}
+			if mod, code, ok := parseModifyOtherKeysParams(seq.params); ok {
+				return a.handleModifyOtherKeys(handleModifyOtherKeysOptions{mod: mod, code: code})
 			}
 			// All other tilde sequences (Insert, PgUp, etc.) silently consumed
 		}
 		return false
+	}
+
+	if seq.final == 'u' {
+		code, mod, ok := parseCSIUParams(seq.params)
+		if !ok {
+			return false
+		}
+		return a.handleModifyOtherKeys(handleModifyOtherKeysOptions{mod: mod, code: code})
 	}
 
 	if a.awaitingApproval {
@@ -403,10 +398,33 @@ func (a *App) handleEscapeSequence(opts handleEscapeSequenceOptions) bool {
 	}
 
 	// Navigation keys (arrows, Home, End) — shared by CSI and SS3
-	a.handleNavKey(handleNavKeyOptions{final: final, params: params})
+	a.handleNavKey(handleNavKeyOptions{final: seq.final, params: seq.params})
 	// Unknown final bytes (mode responses, etc.): already fully consumed by
 	// the collection loop above — silently discarded.
 	return false
+}
+
+type csiSequence struct {
+	params []byte
+	final  byte
+}
+
+func readCSISequence(readByte func() (byte, bool)) (csiSequence, bool) {
+	var seq csiSequence
+	for {
+		b, ok := readByte()
+		if !ok {
+			return csiSequence{}, false
+		}
+		if isCSIFinal(b) {
+			seq.final = b
+			return seq, true
+		}
+		seq.params = append(seq.params, b)
+		if len(seq.params) > 128 {
+			return csiSequence{}, false
+		}
+	}
 }
 
 type handleNavKeyOptions struct {
@@ -424,8 +442,7 @@ func (a *App) handleNavKey(opts handleNavKeyOptions) {
 	if i := strings.LastIndexByte(string(params), ';'); i >= 0 {
 		fmt.Sscanf(string(params[i+1:]), "%d", &mod)
 	}
-	isCtrl := mod > 0 && (mod-1)&4 != 0
-	isAlt := mod > 0 && (mod-1)&2 != 0
+	_, isAlt, isCtrl := decodeCSIEncodedModifier(mod)
 
 	switch final {
 	case 'A': // Up
@@ -534,6 +551,26 @@ type handleModifyOtherKeysOptions struct {
 // otherwise be ambiguous (e.g., Ctrl+C as CSI 27;5;99~ instead of byte 0x03).
 // We translate these back to the actions the app already handles.
 func (a *App) handleModifyOtherKeys(opts handleModifyOtherKeysOptions) bool {
+	return a.handleEncodedKey(handleEncodedKeyOptions{
+		mod:                opts.mod,
+		code:               opts.code,
+		insertRune:         a.insertInputRune,
+		deleteWordBackward: a.deleteWordBackward,
+		printableBlocked:   func() bool { return a.menuActive },
+		render:             a.renderInput,
+	})
+}
+
+type handleEncodedKeyOptions struct {
+	mod                int
+	code               int
+	insertRune         func(rune)
+	deleteWordBackward func()
+	printableBlocked   func() bool
+	render             func()
+}
+
+func (a *App) handleEncodedKey(opts handleEncodedKeyOptions) bool {
 	mod, code := opts.mod, opts.code
 	if code == '\033' {
 		return a.handlePlainEscape()
@@ -541,24 +578,136 @@ func (a *App) handleModifyOtherKeys(opts handleModifyOtherKeysOptions) bool {
 	if a.awaitingApproval {
 		return false
 	}
-	mod-- // CSI modifier encoding
-	isAlt := mod&2 != 0
-	isCtrl := mod&4 != 0
+	isShift, isAlt, isCtrl := decodeCSIEncodedModifier(mod)
 
 	switch {
 	case isAlt && code == 127: // Alt+Backspace → delete word
-		a.deleteWordBackward()
-		a.renderInput()
+		if opts.deleteWordBackward != nil {
+			opts.deleteWordBackward()
+			renderEncodedKey(opts)
+		}
 	case isAlt && code == '\r': // Alt+Enter → insert newline
-		a.insertAtCursor('\n')
-		a.renderInput()
-	case isCtrl && code >= 'a' && code <= 'z':
+		if opts.insertRune != nil {
+			opts.insertRune('\n')
+			renderEncodedKey(opts)
+		}
+	case isCtrl:
 		// Translate Ctrl+letter to traditional control byte
 		// and inject into the input channel for normal processing.
-		ctrlByte := byte(code - 'a' + 1)
-		go func() { a.stdinCh <- ctrlByte }()
+		if letter, ok := asciiLetterForCtrl(code); ok {
+			ctrlByte := byte(letter - 'a' + 1)
+			go func() { a.stdinCh <- ctrlByte }()
+		}
+	case !isAlt && !isCtrl:
+		r, ok := encodedPrintableRune(encodedPrintableRuneOptions{code: code, isShift: isShift})
+		if !ok || opts.insertRune == nil {
+			return false
+		}
+		if opts.printableBlocked != nil && opts.printableBlocked() {
+			return false
+		}
+		opts.insertRune(r)
+		renderEncodedKey(opts)
 	}
 	return false
+}
+
+func renderEncodedKey(opts handleEncodedKeyOptions) {
+	if opts.render != nil {
+		opts.render()
+	}
+}
+
+func (a *App) insertInputRune(r rune) {
+	prevVal := a.inputValue()
+	a.insertAtCursor(r)
+	if a.inputValue() != prevVal {
+		a.autocompleteIdx = 0
+	}
+}
+
+func decodeCSIEncodedModifier(mod int) (isShift, isAlt, isCtrl bool) {
+	if mod <= 0 {
+		return false, false, false
+	}
+	bits := mod - 1
+	return bits&1 != 0, bits&2 != 0, bits&4 != 0
+}
+
+type encodedPrintableRuneOptions struct {
+	code    int
+	isShift bool
+}
+
+func encodedPrintableRune(opts encodedPrintableRuneOptions) (rune, bool) {
+	code, isShift := opts.code, opts.isShift
+	if code < 0 || code > utf8.MaxRune {
+		return 0, false
+	}
+	r := rune(code)
+	if isShift && r >= 'a' && r <= 'z' {
+		r -= 'a' - 'A'
+	}
+	if !unicode.IsPrint(r) {
+		return 0, false
+	}
+	return r, true
+}
+
+func asciiLetterForCtrl(code int) (int, bool) {
+	switch {
+	case code >= 'a' && code <= 'z':
+		return code, true
+	case code >= 'A' && code <= 'Z':
+		return code + ('a' - 'A'), true
+	default:
+		return 0, false
+	}
+}
+
+func parseModifyOtherKeysParams(params []byte) (mod, code int, ok bool) {
+	ps := string(params)
+	if !strings.HasPrefix(ps, "27;") {
+		return 0, 0, false
+	}
+	if n, _ := fmt.Sscanf(ps[3:], "%d;%d", &mod, &code); n == 2 {
+		return mod, code, true
+	}
+	return 0, 0, false
+}
+
+func parseCSIUParams(params []byte) (code, mod int, ok bool) {
+	parts := strings.Split(string(params), ";")
+	if len(parts) == 0 || parts[0] == "" {
+		return 0, 0, false
+	}
+	codePart := firstCSIParamValue(parts[0])
+	parsedCode, err := strconv.Atoi(codePart)
+	if err != nil {
+		return 0, 0, false
+	}
+	parsedMod := 1
+	if len(parts) > 1 && parts[1] != "" {
+		modPart := firstCSIParamValue(parts[1])
+		parsedMod, err = strconv.Atoi(modPart)
+		if err != nil {
+			return 0, 0, false
+		}
+	}
+	if len(parts) > 2 && parts[2] != "" {
+		textPart := firstCSIParamValue(parts[2])
+		if parsedText, err := strconv.Atoi(textPart); err == nil {
+			parsedCode = parsedText
+		}
+	}
+	return parsedCode, parsedMod, true
+}
+
+func firstCSIParamValue(s string) string {
+	if i := strings.IndexByte(s, ':'); i >= 0 {
+		return s[:i]
+	}
+	return s
 }
 
 // readBracketedPaste reads paste content until the end marker ESC [ 2 0 1 ~.
@@ -604,117 +753,6 @@ func readBracketedPaste(readByte func() (byte, bool)) string {
 		}
 	}
 	return string(content)
-}
-
-type handleCSIDigit2Options struct {
-	readByte func() (byte, bool)
-	onPaste  func(string)
-}
-
-func (a *App) handleCSIDigit2(opts handleCSIDigit2Options) {
-	readByte, onPaste := opts.readByte, opts.onPaste
-	// We've read ESC [ 2, check for 0 0 ~
-	b0, ok := readByte()
-	if !ok {
-		return
-	}
-	b1, ok := readByte()
-	if !ok {
-		return
-	}
-	b2, ok := readByte()
-	if !ok {
-		return
-	}
-
-	if b0 == '0' && b1 == '0' && b2 == '~' {
-		onPaste(readBracketedPaste(readByte))
-		return
-	}
-
-	// modifyOtherKeys: ESC [ 27 ; <mod> ; <code> ~
-	// We've read ESC [ 2, b0='7', b1=';', b2=<mod digit>
-	if b0 == '7' && b1 == ';' {
-		// Read remaining: possibly more mod digits, ';', code digits, '~'
-		// Collect all remaining bytes until '~'
-		seq := []byte{b2}
-		for {
-			next, ok := readByte()
-			if !ok {
-				return
-			}
-			if next == '~' {
-				break
-			}
-			seq = append(seq, next)
-		}
-		// Parse: seq should be "<mod>;<code>" (b2 is the first byte)
-		// Full param after "27;" is string(seq), parse mod and code
-		parts := string(seq)
-		var mod, code int
-		if n, _ := fmt.Sscanf(parts, "%d;%d", &mod, &code); n == 2 {
-			a.handleModifyOtherKeys(handleModifyOtherKeysOptions{mod: mod, code: code})
-		}
-		return
-	}
-
-	// Not a bracketed paste, might be another sequence starting with 2
-	// e.g., Insert key (ESC [ 2 ~)
-	if b0 == '~' {
-		// ESC [ 2 ~ = Insert
-		return
-	}
-}
-
-func (a *App) handleModifiedCSI(readByte func() (byte, bool)) {
-	// We've read ESC [ 1, expect ; <mod> <letter>
-	semi, ok := readByte()
-	if !ok {
-		return
-	}
-	if semi != ';' {
-		return
-	}
-	modByte, ok := readByte()
-	if !ok {
-		return
-	}
-	letter, ok := readByte()
-	if !ok {
-		return
-	}
-
-	if a.awaitingApproval {
-		return
-	}
-
-	modNum := int(modByte - '0')
-	modNum-- // CSI encoding
-	isAlt := modNum&2 != 0
-	isCtrl := modNum&4 != 0
-
-	switch letter {
-	case 'C': // Right
-		if isCtrl || isAlt {
-			a.moveWordRight()
-		} else if a.cursor < len(a.input) {
-			a.cursor++
-		}
-		a.renderInput()
-	case 'D': // Left
-		if isCtrl || isAlt {
-			a.moveWordLeft()
-		} else if a.cursor > 0 {
-			a.cursor--
-		}
-		a.renderInput()
-	case 'H': // Home
-		a.cursor = 0
-		a.renderInput()
-	case 'F': // End
-		a.cursor = len(a.input)
-		a.renderInput()
-	}
 }
 
 // ─── Paste handling ───

--- a/cmd/herm/input_keys.go
+++ b/cmd/herm/input_keys.go
@@ -586,7 +586,7 @@ func (a *App) handleEncodedKey(opts handleEncodedKeyOptions) bool {
 			opts.deleteWordBackward()
 			renderEncodedKey(opts)
 		}
-	case isAlt && code == '\r': // Alt+Enter → insert newline
+	case isAlt && isEncodedEnterCode(code): // Alt+Enter → insert newline
 		if opts.insertRune != nil {
 			opts.insertRune('\n')
 			renderEncodedKey(opts)
@@ -598,6 +598,15 @@ func (a *App) handleEncodedKey(opts handleEncodedKeyOptions) bool {
 			ctrlByte := byte(letter - 'a' + 1)
 			go func() { a.stdinCh <- ctrlByte }()
 		}
+	case !isAlt && !isCtrl && isShift && isEncodedEnterCode(code):
+		if opts.insertRune == nil {
+			return false
+		}
+		if opts.printableBlocked != nil && opts.printableBlocked() {
+			return false
+		}
+		opts.insertRune('\n')
+		renderEncodedKey(opts)
 	case !isAlt && !isCtrl:
 		r, ok := encodedPrintableRune(encodedPrintableRuneOptions{code: code, isShift: isShift})
 		if !ok || opts.insertRune == nil {
@@ -652,6 +661,10 @@ func encodedPrintableRune(opts encodedPrintableRuneOptions) (rune, bool) {
 		return 0, false
 	}
 	return r, true
+}
+
+func isEncodedEnterCode(code int) bool {
+	return code == '\r' || code == '\n'
 }
 
 func asciiLetterForCtrl(code int) (int, bool) {

--- a/cmd/herm/input_keys_test.go
+++ b/cmd/herm/input_keys_test.go
@@ -146,6 +146,149 @@ func TestModifyOtherKeysEscapeCancelsAgent(t *testing.T) {
 	}
 }
 
+func newInputKeyTestApp() *App {
+	return &App{
+		width:    80,
+		headless: true,
+		resultCh: make(chan any, 4),
+		stdinCh:  make(chan byte, 4),
+	}
+}
+
+func handleCSISequenceForTest(t *testing.T, app *App, seq string) bool {
+	t.Helper()
+	stdinCh := make(chan byte, 1)
+	stdinCh <- '['
+	readIdx := 0
+
+	quit := app.handleByte(handleByteOptions{
+		ch:      '\033',
+		stdinCh: stdinCh,
+		readByte: func() (byte, bool) {
+			if readIdx >= len(seq) {
+				return 0, false
+			}
+			b := seq[readIdx]
+			readIdx++
+			return b, true
+		},
+	})
+	if readIdx != len(seq) {
+		t.Fatalf("CSI sequence consumed %d bytes, want %d", readIdx, len(seq))
+	}
+	return quit
+}
+
+func TestPlainShiftPrintableInsertsRune(t *testing.T) {
+	app := newInputKeyTestApp()
+
+	if app.handleByte(handleByteOptions{ch: 'A'}) {
+		t.Fatal("plain Shift+A byte should not quit")
+	}
+	if got := app.inputValue(); got != "A" {
+		t.Fatalf("input after plain Shift+A byte = %q, want %q", got, "A")
+	}
+}
+
+func TestEncodedShiftPrintableInsertsRune(t *testing.T) {
+	tests := []struct {
+		name string
+		seq  string
+		want string
+	}{
+		{name: "modifyOtherKeys uppercase", seq: "27;2;65~", want: "A"},
+		{name: "modifyOtherKeys lowercase with shift", seq: "27;2;97~", want: "A"},
+		{name: "CSI u uppercase", seq: "65;2u", want: "A"},
+		{name: "CSI u kitty alternate", seq: "97:65;2u", want: "A"},
+		{name: "CSI u kitty associated text", seq: "97;2;65u", want: "A"},
+		{name: "CSI u shifted punctuation", seq: "49;2;33u", want: "!"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := newInputKeyTestApp()
+
+			if handleCSISequenceForTest(t, app, tt.seq) {
+				t.Fatalf("%s sequence should not quit", tt.name)
+			}
+			if got := app.inputValue(); got != tt.want {
+				t.Fatalf("input after %s = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEncodedCtrlShiftLetterUsesCtrlShortcut(t *testing.T) {
+	app := newInputKeyTestApp()
+	app.input = []rune("abc")
+	app.cursor = len(app.input)
+
+	if handleCSISequenceForTest(t, app, "27;6;65~") {
+		t.Fatal("Ctrl+Shift+A modifyOtherKeys sequence should not quit")
+	}
+	ch := <-app.stdinCh
+	if ch != 0x01 {
+		t.Fatalf("Ctrl+Shift+A injected byte = %#x, want Ctrl+A", ch)
+	}
+	if got := app.inputValue(); got != "abc" {
+		t.Fatalf("Ctrl+Shift+A should not insert text, got input %q", got)
+	}
+}
+
+func TestEncodedShiftPrintableInConfigEditInsertsRune(t *testing.T) {
+	tests := []struct {
+		name string
+		seq  string
+	}{
+		{name: "modifyOtherKeys", seq: "27;2;65~"},
+		{name: "CSI u", seq: "65;2u"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := newInputKeyTestApp()
+			app.cfgActive = true
+			app.cfgEditing = true
+			app.cfgEditBuf = []rune("x")
+			app.cfgEditCursor = len(app.cfgEditBuf)
+
+			if handleCSISequenceForTest(t, app, tt.seq) {
+				t.Fatalf("%s sequence should not quit", tt.name)
+			}
+			if got := string(app.cfgEditBuf); got != "xA" {
+				t.Fatalf("config edit input after %s = %q, want %q", tt.name, got, "xA")
+			}
+			if got := app.inputValue(); got != "" {
+				t.Fatalf("config edit should not insert into chat input, got %q", got)
+			}
+		})
+	}
+}
+
+func TestEncodedShiftPrintableInConfigModeIsConsumed(t *testing.T) {
+	app := newInputKeyTestApp()
+	app.cfgActive = true
+
+	if handleCSISequenceForTest(t, app, "65;2u") {
+		t.Fatal("Shift+A CSI u config sequence should not quit")
+	}
+	if got := app.inputValue(); got != "" {
+		t.Fatalf("config mode should ignore printable key outside edit mode, got chat input %q", got)
+	}
+}
+
+func TestBracketedPasteInConfigModeIsConsumed(t *testing.T) {
+	app := newInputKeyTestApp()
+	app.cfgActive = true
+
+	if handleCSISequenceForTest(t, app, "200~ignored\033[201~") {
+		t.Fatal("bracketed paste in config mode should not quit")
+	}
+	if got := app.inputValue(); got != "" {
+		t.Fatalf("config mode should ignore pasted text outside edit mode, got chat input %q", got)
+	}
+}
+
 func TestOldEscapeExpiryDoesNotClearNewHint(t *testing.T) {
 	app, _ := newInterruptTestApp()
 	app.escHint = true

--- a/cmd/herm/input_keys_test.go
+++ b/cmd/herm/input_keys_test.go
@@ -218,6 +218,44 @@ func TestEncodedShiftPrintableInsertsRune(t *testing.T) {
 	}
 }
 
+func TestEncodedShiftEnterInsertsNewline(t *testing.T) {
+	tests := []struct {
+		name string
+		seq  string
+	}{
+		{name: "modifyOtherKeys CR", seq: "27;2;13~"},
+		{name: "CSI u CR", seq: "13;2u"},
+		{name: "CSI u LF", seq: "10;2u"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := newInputKeyTestApp()
+			app.input = []rune("a")
+			app.cursor = len(app.input)
+
+			if handleCSISequenceForTest(t, app, tt.seq) {
+				t.Fatalf("%s sequence should not quit", tt.name)
+			}
+			if got := app.inputValue(); got != "a\n" {
+				t.Fatalf("input after %s = %q, want %q", tt.name, got, "a\n")
+			}
+		})
+	}
+}
+
+func TestEncodedShiftEnterBlockedByMenu(t *testing.T) {
+	app := newInputKeyTestApp()
+	app.menuActive = true
+
+	if handleCSISequenceForTest(t, app, "13;2u") {
+		t.Fatal("Shift+Enter CSI u sequence should not quit")
+	}
+	if got := app.inputValue(); got != "" {
+		t.Fatalf("menu should block encoded Shift+Enter, got input %q", got)
+	}
+}
+
 func TestEncodedCtrlShiftLetterUsesCtrlShortcut(t *testing.T) {
 	app := newInputKeyTestApp()
 	app.input = []rune("abc")


### PR DESCRIPTION
## Summary
- decode Ghostty/xterm encoded shifted printable keys and CSI-u key reports
- route encoded keys correctly in the config editor
- support encoded Shift+Enter as a newline

## Tests
- go test ./...
- pre-commit hook passed