### PR TITLE
Improve secret key display and Delete key behavior in config editor

### DIFF
--- a/cmd/herm/config_test.go
+++ b/cmd/herm/config_test.go
@@ -515,6 +515,26 @@ func TestMaskKey(t *testing.T) {
 	}
 }
 
+func TestSecretEditDisplay(t *testing.T) {
+	cases := []struct {
+		val  string
+		want string
+	}{
+		{"", ""},
+		{"a", "*"},
+		{"abc", "***"},
+		{"abcdef", "******"},
+		{"abcdefg", "ab***fg"},
+		{"abcdefghijkl", "ab********kl"},
+		{"abcdefghijklmnop", "abcd********mnop"},
+	}
+	for _, tc := range cases {
+		if got := secretEditDisplay(tc.val); got != tc.want {
+			t.Errorf("secretEditDisplay(%q) = %q, want %q", tc.val, got, tc.want)
+		}
+	}
+}
+
 func TestDeploymentTabFieldsWriteDeploymentConfig(t *testing.T) {
 	var cfg Config
 	deploymentFieldByLabel(t, cfgAPIKeyFields, "OpenAI API Key").set(&cfg, "sk-openai")
@@ -928,6 +948,62 @@ func TestDeleteClearsSecretField(t *testing.T) {
 	}
 	if a.cfgEditCursor != 0 {
 		t.Fatalf("cursor should be 0 after Delete on secret field, got %d", a.cfgEditCursor)
+	}
+}
+
+func newSecretFieldApp() *App {
+	a := &App{
+		cfgTab:   cfgTabDeployments,
+		cfgDraft: Config{Deployments: map[string]DeploymentConfig{"openai-direct": {APIKey: "sk-old"}}},
+	}
+	fields := a.cfgCurrentFields()
+	idx := -1
+	for i, f := range fields {
+		if f.secret {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		panic("no secret field found")
+	}
+	a.cfgCursor = idx
+	a.cfgEditing = true
+	a.cfgEditBuf = []rune("sk-new-key-to-replace")
+	a.cfgEditCursor = 5
+	return a
+}
+
+func TestCtrlUClearsSecretField(t *testing.T) {
+	a := newSecretFieldApp()
+	a.handleConfigEditByte(handleConfigEditByteOptions{ch: 0x15})
+	if len(a.cfgEditBuf) != 0 {
+		t.Fatalf("Ctrl+U should clear secret field buffer, got %q", string(a.cfgEditBuf))
+	}
+	if a.cfgEditCursor != 0 {
+		t.Fatalf("cursor should be 0 after Ctrl+U on secret field, got %d", a.cfgEditCursor)
+	}
+}
+
+func TestCtrlKClearsSecretField(t *testing.T) {
+	a := newSecretFieldApp()
+	a.handleConfigEditByte(handleConfigEditByteOptions{ch: 0x0b})
+	if len(a.cfgEditBuf) != 0 {
+		t.Fatalf("Ctrl+K should clear secret field buffer, got %q", string(a.cfgEditBuf))
+	}
+	if a.cfgEditCursor != 0 {
+		t.Fatalf("cursor should be 0 after Ctrl+K on secret field, got %d", a.cfgEditCursor)
+	}
+}
+
+func TestCtrlWClearsSecretField(t *testing.T) {
+	a := newSecretFieldApp()
+	a.handleConfigEditByte(handleConfigEditByteOptions{ch: 0x17})
+	if len(a.cfgEditBuf) != 0 {
+		t.Fatalf("Ctrl+W should clear secret field buffer, got %q", string(a.cfgEditBuf))
+	}
+	if a.cfgEditCursor != 0 {
+		t.Fatalf("cursor should be 0 after Ctrl+W on secret field, got %d", a.cfgEditCursor)
 	}
 }
 

--- a/cmd/herm/config_test.go
+++ b/cmd/herm/config_test.go
@@ -493,6 +493,28 @@ func TestProjectTabFieldGetSet(t *testing.T) {
 	}
 }
 
+func TestMaskKey(t *testing.T) {
+	cases := []struct {
+		key  string
+		want string
+	}{
+		{"", "(not set)"},
+		{"a", "*"},
+		{"ab", "**"},
+		{"abc", "a...c"},
+		{"abcd", "a...d"},
+		{"abcde", "ab...de"},
+		{"abcdefgh", "ab...gh"},
+		{"123456789", "1234...6789"},
+		{"sk-openai-secret", "sk-o...cret"},
+	}
+	for _, tc := range cases {
+		if got := maskKey(tc.key); got != tc.want {
+			t.Errorf("maskKey(%q) = %q, want %q", tc.key, got, tc.want)
+		}
+	}
+}
+
 func TestDeploymentTabFieldsWriteDeploymentConfig(t *testing.T) {
 	var cfg Config
 	deploymentFieldByLabel(t, cfgAPIKeyFields, "OpenAI API Key").set(&cfg, "sk-openai")
@@ -875,6 +897,38 @@ func TestBuildConfigRowsDeploymentValueStyling(t *testing.T) {
 		}
 	}
 	t.Fatalf("OpenAI Base URL row not found: %v", rows)
+}
+
+func TestDeleteClearsSecretField(t *testing.T) {
+	a := &App{
+		cfgTab:   cfgTabDeployments,
+		cfgDraft: Config{Deployments: map[string]DeploymentConfig{"openai-direct": {APIKey: "sk-old"}}},
+	}
+	fields := a.cfgCurrentFields()
+	idx := -1
+	for i, f := range fields {
+		if f.secret {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		t.Fatal("no secret field found")
+	}
+	a.cfgCursor = idx
+	a.cfgEditing = true
+	a.cfgEditBuf = []rune("sk-new-key-to-replace")
+	a.cfgEditCursor = 5
+
+	seq := csiSequence{params: []byte("3"), final: '~'}
+	a.handleConfigEditCSISequence(handleConfigEditCSISequenceOptions{seq: seq, readByte: nil})
+
+	if len(a.cfgEditBuf) != 0 {
+		t.Fatalf("Delete should clear secret field buffer, got %q", string(a.cfgEditBuf))
+	}
+	if a.cfgEditCursor != 0 {
+		t.Fatalf("cursor should be 0 after Delete on secret field, got %d", a.cfgEditCursor)
+	}
 }
 
 func TestEnterConfigModeSetsPreferredAPIKeyCursorFromEffectiveProvider(t *testing.T) {

--- a/cmd/herm/configeditor.go
+++ b/cmd/herm/configeditor.go
@@ -843,16 +843,33 @@ func (a *App) handleConfigEditByte(opts handleConfigEditByteOptions) {
 		a.renderInput()
 
 	case ch == 0x15: // Ctrl+U - kill to start
-		a.cfgEditBuf = a.cfgEditBuf[a.cfgEditCursor:]
-		a.cfgEditCursor = 0
+		fields := a.cfgCurrentFields()
+		if a.cfgCursor < len(fields) && fields[a.cfgCursor].secret {
+			a.cfgEditBuf = nil
+			a.cfgEditCursor = 0
+		} else {
+			a.cfgEditBuf = a.cfgEditBuf[a.cfgEditCursor:]
+			a.cfgEditCursor = 0
+		}
 		a.renderInput()
 
 	case ch == 0x0b: // Ctrl+K - kill to end
-		a.cfgEditBuf = a.cfgEditBuf[:a.cfgEditCursor]
+		fields := a.cfgCurrentFields()
+		if a.cfgCursor < len(fields) && fields[a.cfgCursor].secret {
+			a.cfgEditBuf = nil
+			a.cfgEditCursor = 0
+		} else {
+			a.cfgEditBuf = a.cfgEditBuf[:a.cfgEditCursor]
+		}
 		a.renderInput()
 
 	case ch == 0x17: // Ctrl+W - delete word backward
-		if a.cfgEditCursor > 0 {
+		fields := a.cfgCurrentFields()
+		if a.cfgCursor < len(fields) && fields[a.cfgCursor].secret {
+			a.cfgEditBuf = nil
+			a.cfgEditCursor = 0
+			a.renderInput()
+		} else if a.cfgEditCursor > 0 {
 			a.deleteConfigEditWordBackward()
 			a.renderInput()
 		}

--- a/cmd/herm/configeditor.go
+++ b/cmd/herm/configeditor.go
@@ -618,9 +618,11 @@ func (a *App) buildConfigRows() []string {
 			continue
 		}
 		if a.cfgEditing && i == a.cfgCursor {
-			// Show editable text input with underline
 			editStr := string(a.cfgEditBuf)
-			rows = append(rows, fmt.Sprintf("%s \033[4;1m%s\033[0m %s", styledConfigFieldLabel(styledConfigFieldLabelOptions{label: label + ":", selected: true}), editStr, styledConfigCursor("◆")))
+			if f.secret {
+				editStr = secretEditDisplay(editStr)
+			}
+			rows = append(rows, fmt.Sprintf("%s \033[1m%s\033[0m %s", styledConfigFieldLabel(styledConfigFieldLabelOptions{label: label + ":", selected: true}), editStr, styledConfigCursor("◆")))
 		} else {
 			val := ""
 			if f.display != nil {
@@ -822,11 +824,15 @@ func (a *App) handleConfigEditByte(opts handleConfigEditByteOptions) {
 		a.renderInput()
 
 	case ch == 127 || ch == 0x08: // Backspace
-		if a.cfgEditCursor > 0 {
+		fields := a.cfgCurrentFields()
+		if a.cfgCursor < len(fields) && fields[a.cfgCursor].secret {
+			a.cfgEditBuf = nil
+			a.cfgEditCursor = 0
+		} else if a.cfgEditCursor > 0 {
 			a.cfgEditCursor--
 			a.cfgEditBuf = append(a.cfgEditBuf[:a.cfgEditCursor], a.cfgEditBuf[a.cfgEditCursor+1:]...)
-			a.renderInput()
 		}
+		a.renderInput()
 
 	case ch == 0x01: // Ctrl+A
 		a.cfgEditCursor = 0

--- a/cmd/herm/configeditor_deployments.go
+++ b/cmd/herm/configeditor_deployments.go
@@ -12,10 +12,33 @@ func maskKey(key string) string {
 	if key == "" {
 		return "(not set)"
 	}
-	if len(key) <= 8 {
-		return "****"
+	switch n := len(key); {
+	case n <= 2:
+		return strings.Repeat("*", n)
+	case n <= 4:
+		return key[:1] + "..." + key[n-1:]
+	case n <= 8:
+		return key[:2] + "..." + key[n-2:]
+	default:
+		return key[:4] + "..." + key[n-4:]
 	}
-	return key[:4] + "..." + key[len(key)-4:]
+}
+
+// secretEditDisplay returns a masked display for a secret field in edit mode,
+// showing the first and last characters with asterisks in between.
+func secretEditDisplay(val string) string {
+	n := len(val)
+	if n == 0 {
+		return ""
+	}
+	if n <= 6 {
+		return strings.Repeat("*", n)
+	}
+	show := 4
+	if n <= 12 {
+		show = 2
+	}
+	return val[:show] + strings.Repeat("*", n-show*2) + val[n-show:]
 }
 
 var cfgAPIKeyFields = deploymentFieldsFromSpecs(deploymentFieldsFromSpecsOptions{

--- a/cmd/herm/configeditor_input.go
+++ b/cmd/herm/configeditor_input.go
@@ -115,10 +115,14 @@ func (a *App) handleConfigEditCSISequence(opts handleConfigEditCSISequenceOption
 			a.insertConfigEditText(readBracketedPaste(readByte))
 			a.renderInput()
 		case "3":
-			if a.cfgEditCursor < len(a.cfgEditBuf) {
+			fields := a.cfgCurrentFields()
+			if a.cfgCursor < len(fields) && fields[a.cfgCursor].secret {
+				a.cfgEditBuf = nil
+				a.cfgEditCursor = 0
+			} else if a.cfgEditCursor < len(a.cfgEditBuf) {
 				a.cfgEditBuf = append(a.cfgEditBuf[:a.cfgEditCursor], a.cfgEditBuf[a.cfgEditCursor+1:]...)
-				a.renderInput()
 			}
+			a.renderInput()
 		default:
 			if mod, code, ok := parseModifyOtherKeysParams(seq.params); ok {
 				a.handleConfigEditEncodedKey(handleConfigEditEncodedKeyOptions{mod: mod, code: code})


### PR DESCRIPTION
## Summary
- `maskKey` now always shows start/end chars for all key lengths instead of "****" for short keys
- Delete key clears the entire edit buffer when editing a secret field, making it easy to replace long API keys in one shot
- Added `TestMaskKey` (9 cases) and `TestDeleteClearsSecretField` tests

## Test plan
- [x] `go build ./cmd/herm/` passes
- [x] `TestMaskKey` — 9 edge cases pass
- [x] `TestDeleteClearsSecretField` — verifies buffer cleared for secret fields
- [x] All existing deployment tests still pass