### PR TITLE
(docs) Document submodule checkout for source installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ tools/edit-file/edit-file
 # OS
 .DS_Store
 .claude/worktrees/
+
+# IDEs
+.idea

--- a/CLI_QUICK_START.md
+++ b/CLI_QUICK_START.md
@@ -3,13 +3,15 @@
 ## Installation
 
 ```bash
-git clone https://github.com/aduermael/herm
+git clone --recurse-submodules https://github.com/aduermael/herm
 cd herm
 go build -o herm ./cmd/herm
 ./herm
 ```
 
 **Requirements:** Go 1.24+, Docker
+
+If you already cloned without submodules, run `git submodule update --init --recursive` before building.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -43,10 +43,16 @@ brew install herm
 Requires Go 1.24+.
 
 ```sh
-git clone https://github.com/aduermael/herm
+git clone --recurse-submodules https://github.com/aduermael/herm
 cd herm
 go build -o herm ./cmd/herm
 ./herm
+```
+
+If you already cloned without submodules, run this before building:
+
+```sh
+git submodule update --init --recursive
 ```
 
 ## Quick Start

--- a/docs/index.html
+++ b/docs/index.html
@@ -959,9 +959,9 @@
             </div>
             <div class="install-row">
                 <span class="install-label">source</span>
-                <code class="install-cmd"><span class="c-bin">git clone</span> <span class="c-url">https://github.com/aduermael/herm</span>
+                <code class="install-cmd"><span class="c-bin">git clone</span> <span class="c-flag">--recurse-submodules</span> <span class="c-url">https://github.com/aduermael/herm</span>
 <span class="c-op">&amp;&amp;</span> <span class="c-bin">cd</span> herm <span class="c-op">&amp;&amp;</span> <span class="c-bin">go build</span> <span class="c-flag">-o</span> herm ./cmd/herm</code>
-                <button class="install-copy" onclick="copyInstall(this, 'git clone https://github.com/aduermael/herm && cd herm && go build -o herm ./cmd/herm')" aria-label="Copy">
+                <button class="install-copy" onclick="copyInstall(this, 'git clone --recurse-submodules https://github.com/aduermael/herm && cd herm && go build -o herm ./cmd/herm')" aria-label="Copy">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
                 </button>
             </div>


### PR DESCRIPTION
## Problem
- A fresh clone followed by `go build -o herm ./cmd/herm` fails because `go.work` includes `./external/langdag`, because plain `git clone` leaves that submodule uninitialised

<img width="1894" height="86" alt="image" src="https://github.com/user-attachments/assets/5f2671da-667f-48a7-a391-8a9f353471ea" />


## Fix 
- Update documentation to include git cloning with submodules: `git clone --recurse-submodules https://github.com/aduermael/herm`

## Summary
- Updates source install commands to use `git clone --recurse-submodules`
- Adds the recovery command for users who already cloned without submodules
- Updates the docs site source install command to match
- I use Goland which has .idea files that needs to be ignored. I have add this to the .`gitignore`

## Testing

  - Tests pass (just a docs change)
  
<img width="648" height="112" alt="image" src="https://github.com/user-attachments/assets/f26bd749-34bb-4042-acdb-e2f05860ddeb" />

