### PR TITLE
(feat): Add doctor command to ensure the users environment is configured correctly

### DIFF
--- a/cmd/herm/commands.go
+++ b/cmd/herm/commands.go
@@ -17,7 +17,19 @@ import (
 
 // ─── Commands and autocomplete ───
 
-var commands = []string{"/branches", "/clear", "/compact", "/config", "/model", "/session", "/shell", "/update", "/usage", "/worktrees"}
+var commands = []string{
+	"/branches",
+	"/clear",
+	"/compact",
+	"/config",
+	"/model",
+	"/session",
+	"/shell",
+	"/update",
+	"/usage",
+	"/worktrees",
+	"/doctor",
+}
 var sessionSubcommands = []string{"/session list", "/session load", "/session show"}
 
 func filterCommands(prefix string) []string {
@@ -212,6 +224,9 @@ func (a *App) handleCommand(input string) {
 
 	case "/update":
 		a.handleUpdateCommand()
+
+	case "/doctor":
+		a.handleDoctorCommand()
 
 	default:
 		a.messages = append(a.messages, chatMessage{kind: msgError, content: fmt.Sprintf("Unknown command: %s", cmd)})

--- a/cmd/herm/doctor.go
+++ b/cmd/herm/doctor.go
@@ -1,3 +1,4 @@
+// Package main implements the doctor command to diagnose the local environment.
 package main
 
 import (

--- a/cmd/herm/doctor.go
+++ b/cmd/herm/doctor.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"sort"
 	"strings"
 	"time"
 )
@@ -77,55 +78,60 @@ func doctorEnvironmentChecks() []doctorCheck {
 	return checks
 }
 
-// doctorCheckApiKey verifies at least one supported LLM provider key is
+// doctorCheckApiKey verifies at least one supported LLM provider route is
 // configured. Herm can run with any one of these providers.
 func (a *App) doctorCheckApiKey() []doctorCheck {
-	var checks []doctorCheck
-	if a.config.AnthropicAPIKey == "" &&
-		a.config.OpenAIAPIKey == "" &&
-		a.config.GrokAPIKey == "" &&
-		a.config.OpenRouterAPIKey == "" &&
-		a.config.GeminiAPIKey == "" {
-		return append(checks, doctorCheck{
+	providers := a.config.configuredProviders()
+	if len(providers) == 0 {
+		return []doctorCheck{{
 			name:   "API keys",
 			status: doctorStatusFail,
-			detail: "no API key found",
-			fix:    "Set an API key with /config",
-		})
+			detail: "no configured provider found",
+			fix:    "Set provider credentials or a model endpoint with /config",
+		}}
 	}
-	return append(checks, doctorCheck{
+
+	names := make([]string, 0, len(providers))
+	for provider := range providers {
+		names = append(names, provider)
+	}
+	sort.Strings(names)
+	return []doctorCheck{{
 		name:   "API keys",
 		status: doctorStatusOK,
-		detail: "API key found",
-	})
+		detail: "configured providers: " + strings.Join(names, ", "),
+	}}
 }
 
 // doctorRuntimeChecks validates host runtime dependencies that need active
-// services, currently Docker daemon reachability.
+// services, currently Docker daemon reachability and startup state.
 func (a *App) doctorRuntimeChecks() []doctorCheck {
-	container := a.container
-	if container == nil {
-		return []doctorCheck{{
-			name:   "docker daemon",
-			status: doctorStatusFail,
-			detail: "Unreachable",
-			fix:    "Run docker daemon",
-		}}
+	checks := make([]doctorCheck, 0, 2)
+	if !a.containerReady && a.container == nil && a.containerErr == nil && a.containerStatusText != "" {
+		checks = append(checks, doctorCheck{
+			name:   "container startup",
+			status: doctorStatusWarn,
+			detail: a.containerStatusText,
+			fix:    "Wait for the background container to finish starting",
+		})
 	}
 
+	container := NewContainerClient(ContainerConfig{Image: defaultContainerImage})
 	if err := container.CheckDocker(); err != nil {
-		return []doctorCheck{{
+		checks = append(checks, doctorCheck{
 			name:   "docker daemon",
 			status: doctorStatusFail,
 			detail: err.Error(),
-		}}
+		})
+		return checks
 	}
 
-	return []doctorCheck{{
+	checks = append(checks, doctorCheck{
 		name:   "docker daemon",
 		status: doctorStatusOK,
 		detail: "reachable",
-	}}
+	})
+	return checks
 }
 
 // doctorGitChecks verifies the current working directory is inside a Git

--- a/cmd/herm/doctor.go
+++ b/cmd/herm/doctor.go
@@ -1,0 +1,270 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type doctorStatus string
+
+// Doctor check statuses are intentionally small string values because they are
+// rendered directly in the human-readable report.
+const (
+	doctorStatusOK   doctorStatus = "ok"
+	doctorStatusWarn doctorStatus = "warn"
+	doctorStatusFail doctorStatus = "fail"
+)
+
+// doctorCheck is one individual diagnostic result within a report section.
+// Detail explains what was observed; Fix is optional user-facing remediation.
+type doctorCheck struct {
+	name   string
+	detail string
+	fix    string
+	status doctorStatus
+}
+
+// doctorSection groups related checks so the rendered output is easier to read.
+type doctorSection struct {
+	Name   string
+	Checks []doctorCheck
+}
+
+// doctorReport is the complete output of /doctor before it is rendered to chat.
+// Summary is calculated from all checks after sections are assembled.
+type doctorReport struct {
+	Summary  string
+	Sections []doctorSection
+}
+
+// handleDoctorCommand runs the diagnostics, appends the formatted report to the
+// chat, and forces a render so the user sees the result immediately.
+func (a *App) handleDoctorCommand() {
+	report := a.runDoctorReport()
+	a.messages = append(a.messages, chatMessage{kind: msgAssistant, content: report.textString()})
+	a.render()
+}
+
+// runDoctorReport executes each diagnostic group and computes the final summary
+// from the combined check results.
+func (a *App) runDoctorReport() doctorReport {
+	report := doctorReport{
+		Sections: []doctorSection{
+			{Name: "Environment", Checks: doctorEnvironmentChecks()},
+			{Name: "API Keys", Checks: a.doctorCheckApiKey()},
+			{Name: "Runtime", Checks: a.doctorRuntimeChecks()},
+			{Name: "Git Workspace", Checks: doctorGitChecks()},
+		},
+	}
+	report.Summary = getChecksSummaryResults(&report)
+	return report
+}
+
+// ─── Doctor checks by report section ───
+
+// doctorEnvironmentChecks verifies required local executables are available on
+// PATH before Herm tries to use them elsewhere.
+func doctorEnvironmentChecks() []doctorCheck {
+	checks := []doctorCheck{
+		checkExecutable("docker"),
+		checkExecutable("git"),
+	}
+	return checks
+}
+
+// doctorCheckApiKey verifies at least one supported LLM provider key is
+// configured. Herm can run with any one of these providers.
+func (a *App) doctorCheckApiKey() []doctorCheck {
+	var checks []doctorCheck
+	if a.config.AnthropicAPIKey == "" &&
+		a.config.OpenAIAPIKey == "" &&
+		a.config.GrokAPIKey == "" &&
+		a.config.OpenRouterAPIKey == "" &&
+		a.config.GeminiAPIKey == "" {
+		return append(checks, doctorCheck{
+			name:   "API keys",
+			status: doctorStatusFail,
+			detail: "no API key found",
+			fix:    "Set an API key with /config",
+		})
+	}
+	return append(checks, doctorCheck{
+		name:   "API keys",
+		status: doctorStatusOK,
+		detail: "API key found",
+	})
+}
+
+// doctorRuntimeChecks validates host runtime dependencies that need active
+// services, currently Docker daemon reachability.
+func (a *App) doctorRuntimeChecks() []doctorCheck {
+	container := a.container
+	if container == nil {
+		return []doctorCheck{{
+			name:   "docker daemon",
+			status: doctorStatusFail,
+			detail: "Unreachable",
+			fix:    "Run docker daemon",
+		}}
+	}
+
+	if err := container.CheckDocker(); err != nil {
+		return []doctorCheck{{
+			name:   "docker daemon",
+			status: doctorStatusFail,
+			detail: err.Error(),
+		}}
+	}
+
+	return []doctorCheck{{
+		name:   "docker daemon",
+		status: doctorStatusOK,
+		detail: "reachable",
+	}}
+}
+
+// doctorGitChecks verifies the current working directory is inside a Git
+// worktree. Herm still works outside Git, but some workspace features are weaker.
+func doctorGitChecks() []doctorCheck {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "rev-parse", "--is-inside-work-tree")
+
+	if err := cmd.Run(); err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return []doctorCheck{{
+				name:   "git workspace",
+				status: doctorStatusFail,
+				detail: "git command timed out",
+			}}
+		}
+
+		return []doctorCheck{{
+			name:   "git workspace",
+			status: doctorStatusWarn,
+			detail: "not a git repository",
+			fix:    "Run 'git init' to leverage full version tracking and hermetic environment branching.",
+		}}
+	}
+
+	return []doctorCheck{{
+		name:   "git workspace",
+		status: doctorStatusOK,
+		detail: "valid repository",
+	}}
+}
+
+// checkExecutable returns a single diagnostic for whether a binary is available
+// in the current PATH.
+func checkExecutable(name string) doctorCheck {
+	if _, err := exec.LookPath(name); err != nil {
+		return doctorCheck{
+			name:   name,
+			status: doctorStatusFail,
+			detail: "not found on PATH",
+			fix:    "Download " + name + " software from their official website",
+		}
+	}
+	return doctorCheck{
+		name:   name,
+		status: doctorStatusOK,
+		detail: "found on PATH",
+	}
+}
+
+// textString renders the report in the same plain-text style as other Herm chat
+// messages, including colored status labels and optional fix hints.
+func (r doctorReport) textString() string {
+	var b strings.Builder
+	b.WriteString("\n")
+	b.WriteString(styledSuccess("Herm doctor 💊"))
+	b.WriteString("\n")
+	b.WriteString("\n")
+	b.WriteString("Summary: ")
+	switch {
+	case strings.Contains(r.Summary, "failed"):
+		b.WriteString(styledError(r.Summary))
+	case strings.Contains(r.Summary, "warnings"):
+		b.WriteString(styledInfo(r.Summary))
+	default:
+		b.WriteString(styledSuccess(r.Summary))
+	}
+	b.WriteString("\n")
+	for _, section := range r.Sections {
+		b.WriteString("\n")
+		b.WriteString(section.Name)
+		b.WriteString("\n")
+		for _, check := range section.Checks {
+			b.WriteString("  [")
+			b.WriteString(styledDoctorStatus(check.status))
+			b.WriteString("] ")
+			b.WriteString(check.name)
+			if check.detail != "" {
+				b.WriteString(": ")
+				b.WriteString(check.detail)
+			}
+			if check.fix != "" {
+				b.WriteString(". Fix: ")
+				b.WriteString(check.fix)
+			}
+			b.WriteString("\n")
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// getChecksSummaryResults counts all check statuses and returns the one-line
+// summary displayed at the top of the report.
+func getChecksSummaryResults(report *doctorReport) string {
+	total, bad, warn := 0, 0, 0
+	for _, check := range report.checks() {
+		total++
+		switch check.status {
+		case doctorStatusFail:
+			bad++
+		case doctorStatusWarn:
+			warn++
+		}
+	}
+	switch {
+	case bad > 0:
+		return fmt.Sprintf("%d checks, %d failed, %d warnings", total, bad, warn)
+	case warn > 0:
+		return fmt.Sprintf("%d checks, %d warnings", total, warn)
+	}
+	return fmt.Sprintf("%d checks, all passed", total)
+}
+
+// checks flattens every section's checks into one slice for summary counting.
+func (r doctorReport) checks() []doctorCheck {
+	var count int
+	for _, s := range r.Sections {
+		count += len(s.Checks)
+	}
+
+	out := make([]doctorCheck, 0, count)
+	for _, section := range r.Sections {
+		out = append(out, section.Checks...)
+	}
+	return out
+}
+
+// styledDoctorStatus maps a diagnostic status to the existing Herm color
+// helpers. Unknown statuses are dimmed instead of treated as failures.
+func styledDoctorStatus(status doctorStatus) string {
+	switch status {
+	case doctorStatusOK:
+		return styledSuccess(string(status))
+	case doctorStatusWarn:
+		return styledInfo(string(status))
+	case doctorStatusFail:
+		return styledError(string(status))
+	default:
+		return "\033[2m" + string(status) + "\033[0m"
+	}
+}

--- a/cmd/herm/doctor_test.go
+++ b/cmd/herm/doctor_test.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"context"
+	"net"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestGetChecksSummaryResults(t *testing.T) {
+	tests := []struct {
+		name     string
+		checks   []doctorCheck
+		expected string
+	}{
+		{
+			name: "all passed",
+			checks: []doctorCheck{
+				{status: doctorStatusOK},
+				{status: doctorStatusOK},
+			},
+			expected: "2 checks, all passed",
+		},
+		{
+			name: "some warnings",
+			checks: []doctorCheck{
+				{status: doctorStatusOK},
+				{status: doctorStatusWarn},
+			},
+			expected: "2 checks, 1 warnings",
+		},
+		{
+			name: "some failures",
+			checks: []doctorCheck{
+				{status: doctorStatusOK},
+				{status: doctorStatusFail},
+			},
+			expected: "2 checks, 1 failed, 0 warnings",
+		},
+		{
+			name: "failures and warnings",
+			checks: []doctorCheck{
+				{status: doctorStatusFail},
+				{status: doctorStatusWarn},
+				{status: doctorStatusOK},
+			},
+			expected: "3 checks, 1 failed, 1 warnings",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			report := &doctorReport{
+				Sections: []doctorSection{
+					{Checks: tt.checks},
+				},
+			}
+			got := getChecksSummaryResults(report)
+			if got != tt.expected {
+				t.Errorf("getChecksSummaryResults() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDoctorCheckApiKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   Config
+		expected doctorStatus
+	}{
+		{
+			name: "no keys",
+			config: Config{
+				AnthropicAPIKey:  "",
+				OpenAIAPIKey:     "",
+				GrokAPIKey:       "",
+				OpenRouterAPIKey: "",
+				GeminiAPIKey:     "",
+			},
+			expected: doctorStatusFail,
+		},
+		{
+			name: "anthropic key present",
+			config: Config{
+				AnthropicAPIKey: "sk-test",
+			},
+			expected: doctorStatusOK,
+		},
+		{
+			name: "openai key present",
+			config: Config{
+				OpenAIAPIKey: "sk-test",
+			},
+			expected: doctorStatusOK,
+		},
+		{
+			name: "openrouter key present",
+			config: Config{
+				OpenRouterAPIKey: "sk-test",
+			},
+			expected: doctorStatusOK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			app := &App{config: tt.config}
+			checks := app.doctorCheckApiKey()
+			if len(checks) == 0 {
+				t.Fatal("expected at least one check")
+			}
+			if checks[0].status != tt.expected {
+				t.Errorf("doctorCheckApiKey() status = %q, want %q", checks[0].status, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDoctorRuntimeChecks(t *testing.T) {
+	t.Run("container client is uninitialized", func(t *testing.T) {
+		// Leave a.container as nil to test the new defensive path
+		app := &App{container: nil}
+
+		checks := app.doctorRuntimeChecks()
+
+		if len(checks) == 0 || checks[0].status != doctorStatusFail {
+			t.Errorf("expected fail status when container client is nil, got %v", checks)
+		}
+		if !strings.Contains(checks[0].detail, "Unreachable") {
+			t.Errorf("expected detail to mention Unreachable, got %q", checks[0].detail)
+		}
+	})
+
+	t.Run("container client exists and docker daemon succeeds", func(t *testing.T) {
+		// Initialize container using your existing NewContainerClient constructor,
+		// but swap or mock the underlying check mechanism if required.
+		// Assuming NewContainerClient gives us a working instance:
+		app := &App{
+			container: NewContainerClient(ContainerConfig{Image: "test-image"}),
+		}
+
+		// Mock the global command overrides specifically for the live daemon check
+		origDockerCmd := dockerCommand
+		origLookPath := lookPath
+		defer func() {
+			dockerCommand = origDockerCmd
+			lookPath = origLookPath
+		}()
+
+		lookPath = func(path string) (string, error) { return "/usr/bin/docker", nil }
+		dockerCommand = func(ctx context.Context, name string, arg ...string) *exec.Cmd {
+			return exec.CommandContext(ctx, "true") // command succeeds
+		}
+
+		checks := app.doctorRuntimeChecks()
+		if len(checks) == 0 || checks[0].status != doctorStatusOK {
+			t.Errorf("expected success status when daemon is reachable, got %v", checks)
+		}
+	})
+
+	t.Run("container client exists but docker daemon fails", func(t *testing.T) {
+		app := &App{
+			container: NewContainerClient(ContainerConfig{Image: "test-image"}),
+		}
+
+		origDockerCmd := dockerCommand
+		origLookPath := lookPath
+		defer func() {
+			dockerCommand = origDockerCmd
+			lookPath = origLookPath
+		}()
+
+		lookPath = func(path string) (string, error) { return "/usr/bin/docker", nil }
+		dockerCommand = func(ctx context.Context, name string, arg ...string) *exec.Cmd {
+			return exec.CommandContext(ctx, "false") // command fails
+		}
+
+		checks := app.doctorRuntimeChecks()
+		if len(checks) == 0 || checks[0].status != doctorStatusFail {
+			t.Errorf("expected failure status when daemon check fails, got %v", checks)
+		}
+	})
+}
+
+func TestDoctorReport_TextString(t *testing.T) {
+	report := doctorReport{
+		Summary: "2 checks, 1 failed, 0 warnings",
+		Sections: []doctorSection{
+			{
+				Name: "Test Section",
+				Checks: []doctorCheck{
+					{name: "Check 1", status: doctorStatusOK, detail: "ok"},
+					{name: "Check 2", status: doctorStatusFail, detail: "bad", fix: "fix it"},
+				},
+			},
+		},
+	}
+	out := report.textString()
+	if !strings.Contains(out, "Herm doctor") || !strings.Contains(out, "Test Section") || !strings.Contains(out, "fix it") {
+		t.Errorf("output missing expected content: %q", out)
+	}
+}
+
+type mockConn struct {
+	net.Conn
+}
+
+func (m *mockConn) Close() error { return nil }

--- a/cmd/herm/doctor_test.go
+++ b/cmd/herm/doctor_test.go
@@ -71,14 +71,8 @@ func TestDoctorCheckApiKey(t *testing.T) {
 		expected doctorStatus
 	}{
 		{
-			name: "no keys",
-			config: Config{
-				AnthropicAPIKey:  "",
-				OpenAIAPIKey:     "",
-				GrokAPIKey:       "",
-				OpenRouterAPIKey: "",
-				GeminiAPIKey:     "",
-			},
+			name:     "no configured providers",
+			config:   Config{},
 			expected: doctorStatusFail,
 		},
 		{
@@ -102,6 +96,28 @@ func TestDoctorCheckApiKey(t *testing.T) {
 			},
 			expected: doctorStatusOK,
 		},
+		{
+			name: "ollama base url present",
+			config: Config{
+				Deployments: map[string]DeploymentConfig{
+					"ollama-local": {BaseURL: "http://localhost:11434"},
+				},
+			},
+			expected: doctorStatusOK,
+		},
+		{
+			name: "azure deployment config present",
+			config: Config{
+				Deployments: map[string]DeploymentConfig{
+					"openai-azure": {
+						APIKey:     "sk-test",
+						Endpoint:    "https://example.openai.azure.com",
+						APIVersion:  "2024-05-01",
+					},
+				},
+			},
+			expected: doctorStatusOK,
+		},
 	}
 
 	for _, tt := range tests {
@@ -118,30 +134,57 @@ func TestDoctorCheckApiKey(t *testing.T) {
 	}
 }
 
+func TestDoctorCheckApiKey_EnvFallback(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", "sk-env")
+
+	app := &App{config: Config{}}
+	checks := app.doctorCheckApiKey()
+	if len(checks) == 0 {
+		t.Fatal("expected at least one check")
+	}
+	if checks[0].status != doctorStatusOK {
+		t.Fatalf("doctorCheckApiKey() status = %q, want %q", checks[0].status, doctorStatusOK)
+	}
+	if !strings.Contains(checks[0].detail, ProviderOpenAI) {
+		t.Fatalf("expected detail to mention configured provider, got %q", checks[0].detail)
+	}
+}
+
 func TestDoctorRuntimeChecks(t *testing.T) {
-	t.Run("container client is uninitialized", func(t *testing.T) {
-		// Leave a.container as nil to test the new defensive path
+	t.Run("container still starting but docker daemon succeeds", func(t *testing.T) {
+		app := &App{
+			container:          nil,
+			containerReady:     false,
+			containerStatusText: "starting…",
+		}
+
+		origDockerCmd := dockerCommand
+		origLookPath := lookPath
+		defer func() {
+			dockerCommand = origDockerCmd
+			lookPath = origLookPath
+		}()
+
+		lookPath = func(path string) (string, error) { return "/usr/bin/docker", nil }
+		dockerCommand = func(ctx context.Context, name string, arg ...string) *exec.Cmd {
+			return exec.CommandContext(ctx, "true")
+		}
+
+		checks := app.doctorRuntimeChecks()
+		if len(checks) != 2 {
+			t.Fatalf("expected startup warning plus docker check, got %v", checks)
+		}
+		if checks[0].status != doctorStatusWarn || checks[0].name != "container startup" {
+			t.Fatalf("expected startup warning first, got %+v", checks[0])
+		}
+		if checks[1].status != doctorStatusOK || checks[1].name != "docker daemon" {
+			t.Fatalf("expected docker daemon success second, got %+v", checks[1])
+		}
+	})
+
+	t.Run("docker daemon fails even without a container client", func(t *testing.T) {
 		app := &App{container: nil}
 
-		checks := app.doctorRuntimeChecks()
-
-		if len(checks) == 0 || checks[0].status != doctorStatusFail {
-			t.Errorf("expected fail status when container client is nil, got %v", checks)
-		}
-		if !strings.Contains(checks[0].detail, "Unreachable") {
-			t.Errorf("expected detail to mention Unreachable, got %q", checks[0].detail)
-		}
-	})
-
-	t.Run("container client exists and docker daemon succeeds", func(t *testing.T) {
-		// Initialize container using your existing NewContainerClient constructor,
-		// but swap or mock the underlying check mechanism if required.
-		// Assuming NewContainerClient gives us a working instance:
-		app := &App{
-			container: NewContainerClient(ContainerConfig{Image: "test-image"}),
-		}
-
-		// Mock the global command overrides specifically for the live daemon check
 		origDockerCmd := dockerCommand
 		origLookPath := lookPath
 		defer func() {
@@ -151,35 +194,12 @@ func TestDoctorRuntimeChecks(t *testing.T) {
 
 		lookPath = func(path string) (string, error) { return "/usr/bin/docker", nil }
 		dockerCommand = func(ctx context.Context, name string, arg ...string) *exec.Cmd {
-			return exec.CommandContext(ctx, "true") // command succeeds
+			return exec.CommandContext(ctx, "false")
 		}
 
 		checks := app.doctorRuntimeChecks()
-		if len(checks) == 0 || checks[0].status != doctorStatusOK {
-			t.Errorf("expected success status when daemon is reachable, got %v", checks)
-		}
-	})
-
-	t.Run("container client exists but docker daemon fails", func(t *testing.T) {
-		app := &App{
-			container: NewContainerClient(ContainerConfig{Image: "test-image"}),
-		}
-
-		origDockerCmd := dockerCommand
-		origLookPath := lookPath
-		defer func() {
-			dockerCommand = origDockerCmd
-			lookPath = origLookPath
-		}()
-
-		lookPath = func(path string) (string, error) { return "/usr/bin/docker", nil }
-		dockerCommand = func(ctx context.Context, name string, arg ...string) *exec.Cmd {
-			return exec.CommandContext(ctx, "false") // command fails
-		}
-
-		checks := app.doctorRuntimeChecks()
-		if len(checks) == 0 || checks[0].status != doctorStatusFail {
-			t.Errorf("expected failure status when daemon check fails, got %v", checks)
+		if len(checks) == 0 || checks[len(checks)-1].status != doctorStatusFail {
+			t.Fatalf("expected failure status when daemon check fails, got %v", checks)
 		}
 	})
 }


### PR DESCRIPTION
### PR Summary: Add `/doctor` command for environment diagnostics

This PR introduces a new `/doctor` command to help users verify and troubleshoot their Herm environment setup. It provides a quick health check of the required dependencies and configurations.

### Key Changes

- New /doctor Command: Added a diagnostic tool accessible via the chat interface that scans the local environment.

- Comprehensive Health Checks:
- Environment: Verifies that docker and git binaries are installed and available on the system PATH.
- API Keys: Ensures at least one supported LLM provider key (Anthropic, OpenAI, Grok, OpenRouter, or Gemini) is configured in the app settings.

- Runtime: Checks for active connectivity to the Docker daemon.

- Git Workspace: Detects if the current working directory is within a Git worktree to ensure full feature availability.
- Actionable Reporting:

- Renders a color-coded report directly in the chat.

- Provides a high-level summary (e.g., "X checks, all passed").

- Includes specific "Fix" suggestions for failed diagnostics to guide users toward resolution.
- Testing: Added comprehensive unit tests in cmd/herm/doctor_test.go covering summary logic, API key validation, runtime checks, and report rendering.

### Files Modified

- cmd/herm/commands.go: Registered the /doctor command.

- cmd/herm/doctor.go: Implemented the diagnostic logic and report formatting.

- cmd/herm/doctor_test.go: Added unit tests for the new functionality.

### Tests
- Added new tests for `/doctor `command and all tests pass

### Screenshots
<img width="406" height="421" alt="Screenshot 2026-05-29 at 09 36 04" src="https://github.com/user-attachments/assets/fb2d101f-1234-4ded-b818-24afdddf819a" />

<img width="607" height="305" alt="Screenshot 2026-05-29 at 09 39 44" src="https://github.com/user-attachments/assets/b32e5230-18ec-418f-94aa-547dc2a2c1f4" />
<img width="341" height="321" alt="Screenshot 2026-05-29 at 01 24 35" src="https://github.com/user-attachments/assets/69046ff5-ba97-44cf-84e0-f420045bd605" />
