### PR TITLE
Add clear conversation shortcuts

### DIFF
--- a/cmd/herm/commands.go
+++ b/cmd/herm/commands.go
@@ -45,6 +45,10 @@ func (a *App) handleCommand(input string) {
 
 	switch cmd {
 	case "/clear":
+		// Interrupt any in-flight agent work before wiping the conversation.
+		if a.hasCancelableAgentWork() {
+			a.requestAgentCancel()
+		}
 		a.agentNodeID = ""
 		a.streamingText = ""
 		a.pendingToolCall = ""

--- a/cmd/herm/input_keys.go
+++ b/cmd/herm/input_keys.go
@@ -118,6 +118,14 @@ func (a *App) handleByte(opts handleByteOptions) bool {
 		return false
 	}
 
+	// Ctrl+L: clear — same as /clear. Wipes the conversation and redraws a
+	// clean state (header + empty), interrupting any in-flight agent work.
+	// Standard clear-screen key (readline/bash convention).
+	if ch == 0x0c {
+		a.handleCommand("/clear")
+		return false
+	}
+
 	// Ctrl+A: home
 	if ch == 0x01 {
 		a.cursor = 0

--- a/cmd/herm/main.go
+++ b/cmd/herm/main.go
@@ -553,11 +553,18 @@ func (a *App) handleEnter() {
 		return
 	}
 
+	val := strings.TrimSpace(strings.ReplaceAll(a.inputValue(), "\r", ""))
+
+	// /clear is allowed even while the agent is running — it interrupts the
+	// in-flight work and wipes the conversation.
 	if a.agentRunning {
+		if strings.HasPrefix(val, "/") && strings.Fields(val)[0] == "/clear" {
+			a.resetInput()
+			a.handleCommand(val)
+		}
 		return
 	}
 
-	val := strings.TrimSpace(strings.ReplaceAll(a.inputValue(), "\r", ""))
 	if val == "" {
 		return
 	}


### PR DESCRIPTION
Adds Ctrl+L as a clear-conversation shortcut and allows /clear to run while the agent is active.