### PR TITLE
Replace pre-commit checks with vet

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,7 +9,7 @@ unset $git_local_env
 tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/herm-pre-commit.XXXXXX")"
 trap 'rm -rf "$tmpdir"' EXIT
 
-vet_pkg="github.com/gdevillele/vet/implementations/go/cmd/vet@v0.0.0-20260622231611-d7d07ebc435d"
+vet_pkg="github.com/gdevillele/vet/implementations/go/cmd/vet@v0.0.0-20260623005521-5df86c92e16c"
 
 pids=()
 names=()

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,11 +9,7 @@ unset $git_local_env
 tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/herm-pre-commit.XXXXXX")"
 trap 'rm -rf "$tmpdir"' EXIT
 
-echo "pre-commit: building ci-check"
-if ! (cd tools/ci-check && GOWORK=off go build -o "$tmpdir/ci-check" .); then
-	echo "pre-commit: failed to build tools/ci-check"
-	exit 1
-fi
+vet_pkg="github.com/gdevillele/vet/implementations/go/cmd/vet@v0.0.0-20260622231611-d7d07ebc435d"
 
 pids=()
 names=()
@@ -32,9 +28,23 @@ start_task() {
 	logs+=("$log")
 }
 
-start_task "file-length" env GOWORK=off "$tmpdir/ci-check" file-length .
-start_task "docstring" env GOWORK=off "$tmpdir/ci-check" docstring .
-start_task "positional-params" env GOWORK=off "$tmpdir/ci-check" positional-params .
+start_task "vet" bash -c '
+	vet_pkg="$1"
+	mapfile -t files < <(
+		git ls-files -- "*.go" \
+			":(exclude)*_test.go" \
+			":(exclude)external/**" \
+			":(exclude)external-deps-workspace/**" \
+			":(exclude)vendor/**" \
+			":(exclude)node_modules/**" \
+			":(exclude)**/testdata/**" \
+			":(exclude)tools/ci-check/**"
+	)
+	if [ "${#files[@]}" -eq 0 ]; then
+		exit 0
+	fi
+	go run "$vet_pkg" --config .vet.yaml "${files[@]}"
+' _ "$vet_pkg"
 start_task "go-test-root" go test ./...
 
 for mod in tools/*/go.mod; do

--- a/.vet.yaml
+++ b/.vet.yaml
@@ -13,12 +13,15 @@ rules:
     max: 0
   function-docstring:
     policy: optional
-  indent:
-    type: language-default
-    width: 0
-  casing:
-    enabled: false
-    functions: language-default
-    variables: language-default
-    types: language-default
-    constants: language-default
+languages:
+  go:
+    rules:
+      indent:
+        type: language-default
+        width: 0
+      casing:
+        enabled: false
+        functions: language-default
+        variables: language-default
+        types: language-default
+        constants: language-default

--- a/.vet.yaml
+++ b/.vet.yaml
@@ -1,0 +1,24 @@
+version: 1
+rules:
+  max-function-parameters:
+    enabled: true
+    max: 3
+  source-file-header:
+    required: true
+    min-length: 60
+    max-length: 0
+  max-source-file-lines:
+    max: 1000
+  max-function-body-lines:
+    max: 0
+  function-docstring:
+    policy: optional
+  indent:
+    type: language-default
+    width: 0
+  casing:
+    enabled: false
+    functions: language-default
+    variables: language-default
+    types: language-default
+    constants: language-default


### PR DESCRIPTION
## Summary
- replace the custom file-length/docstring/positional-params pre-commit checks with Vet
- add .vet.yaml with global rules and Go-specific language overrides
- pin the hook to the Vet version that supports languages.<language>.rules

## Tests
- .githooks/pre-commit