### PR TITLE
fix: restrict config file permissions to owner (0o600)

### DIFF
--- a/cmd/herm/config_storage.go
+++ b/cmd/herm/config_storage.go
@@ -321,7 +321,7 @@ func saveConfig(cfg Config) error {
 		return fmt.Errorf("marshaling config: %w", err)
 	}
 
-	return os.WriteFile(configPath(), data, 0o644)
+	return os.WriteFile(configPath(), data, 0o600)
 }
 
 // saveConfigToOptions is the parameter bundle for saveConfigTo.
@@ -344,7 +344,7 @@ func saveConfigTo(opts saveConfigToOptions) error {
 		return fmt.Errorf("marshaling config: %w", err)
 	}
 
-	return os.WriteFile(filepath.Join(cfgDir, configFile), data, 0o644)
+	return os.WriteFile(filepath.Join(cfgDir, configFile), data, 0o600)
 }
 
 // loadProjectConfig reads project-level overrides from <repoRoot>/.herm/config.json.
@@ -487,5 +487,5 @@ func saveProjectConfig(opts saveProjectConfigOptions) error {
 	if err != nil {
 		return fmt.Errorf("marshaling project config: %w", err)
 	}
-	return os.WriteFile(projectConfigPath(repoRoot), data, 0o644)
+	return os.WriteFile(projectConfigPath(repoRoot), data, 0o600)
 }


### PR DESCRIPTION
Config files store API keys in plaintext. Writing with 0o644 makes them world-readable — any user on the system can read credentials for all configured providers.

Changed the three os.WriteFile calls in cmd/herm/config_storage.go to use 0o600 (owner read/write only), matching the standard convention for credential files like ~/.ssh/id_rsa.