### PR TITLE
fix: fail fast in headless mode when no LLM provider is configured

### DIFF
--- a/cmd/herm/headless.go
+++ b/cmd/herm/headless.go
@@ -60,6 +60,12 @@ func (a *App) waitHeadlessReady() error {
 			if a.configReady && a.langdagClient != nil && a.models != nil && backendReady {
 				return nil
 			}
+			// Fail fast on a genuinely unconfigured provider instead of waiting
+			// out the 60s timeout with a misleading message.
+			if a.langdagClient == nil && a.headlessProviderResolutionSettled() {
+				fmt.Fprintln(os.Stderr, "error: no API key configured — use herm /config to add one")
+				return fmt.Errorf("no API key configured")
+			}
 		case <-timeout:
 			if a.backend == backendCPSL && !a.cpslReady {
 				if a.cpslErr != nil {
@@ -84,6 +90,22 @@ func (a *App) waitHeadlessReady() error {
 			return nil
 		}
 	}
+}
+
+func (a *App) headlessProviderResolutionSettled() bool {
+	if !a.configReady || a.models == nil {
+		return false
+	}
+	if !a.appleFetched {
+		return false
+	}
+	if a.config.ollamaBaseURL() != "" && !a.ollamaFetched {
+		return false
+	}
+	if a.config.openRouterAPIKey() != "" && !a.openRouterFetched {
+		return false
+	}
+	return a.config.defaultLangdagProviderForModels(a.models) == ""
 }
 
 func (a *App) resolveHeadlessContinuation() error {

--- a/cmd/herm/headless_no_provider_test.go
+++ b/cmd/herm/headless_no_provider_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+// modelWithoutConfiguredProvider is a catalog model whose provider has no
+// configured deployment, so it never makes a provider resolvable on its own.
+func modelWithoutConfiguredProvider() []ModelDef {
+	return []ModelDef{{ID: "some-model", Provider: ProviderAnthropic}}
+}
+
+func TestHeadlessProviderResolutionSettled(t *testing.T) {
+	appleRuntimeModels := []ModelDef{{
+		ID:                "apple-fm-runtime",
+		Provider:          ProviderApple,
+		RuntimeDiscovered: true,
+		Deployments:       []ModelDeploymentDef{{DeploymentID: "apple-local"}},
+	}}
+
+	cases := []struct {
+		name string
+		app  *App
+		want bool
+	}{
+		{
+			name: "no provider, all discovery done",
+			app: &App{
+				config:       Config{},
+				configReady:  true,
+				models:       modelWithoutConfiguredProvider(),
+				appleFetched: true,
+			},
+			want: true,
+		},
+		{
+			name: "config not ready yet",
+			app: &App{
+				config:       Config{},
+				configReady:  false,
+				models:       modelWithoutConfiguredProvider(),
+				appleFetched: true,
+			},
+			want: false,
+		},
+		{
+			name: "model catalog not loaded yet",
+			app: &App{
+				config:       Config{},
+				configReady:  true,
+				models:       nil,
+				appleFetched: true,
+			},
+			want: false,
+		},
+		{
+			name: "apple discovery still in flight",
+			app: &App{
+				config:       Config{},
+				configReady:  true,
+				models:       modelWithoutConfiguredProvider(),
+				appleFetched: false,
+			},
+			want: false,
+		},
+		{
+			name: "ollama configured without key must not fast-fail",
+			app: &App{
+				config:        Config{Deployments: map[string]DeploymentConfig{"ollama-local": {BaseURL: "http://localhost:11434"}}},
+				configReady:   true,
+				models:        modelWithoutConfiguredProvider(),
+				appleFetched:  true,
+				ollamaFetched: true,
+			},
+			want: false,
+		},
+		{
+			name: "ollama configured but discovery still in flight",
+			app: &App{
+				config:        Config{Deployments: map[string]DeploymentConfig{"ollama-local": {BaseURL: "http://localhost:11434"}}},
+				configReady:   true,
+				models:        modelWithoutConfiguredProvider(),
+				appleFetched:  true,
+				ollamaFetched: false,
+			},
+			want: false,
+		},
+		{
+			name: "apple runtime models discovered (client refresh pending) must not fast-fail",
+			app: &App{
+				config:       Config{},
+				configReady:  true,
+				models:       appleRuntimeModels,
+				appleFetched: true,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.app.headlessProviderResolutionSettled(); got != tt.want {
+				t.Fatalf("headlessProviderResolutionSettled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestWaitHeadlessReadyNoProviderFailsFast drives waitHeadlessReady in the
+// no-provider state and asserts it returns the actionable "no API key" error
+// promptly, rather than blocking until the 60s initialization timeout.
+func TestWaitHeadlessReadyNoProviderFailsFast(t *testing.T) {
+	app := &App{
+		config:       Config{},
+		configReady:  true,
+		models:       modelWithoutConfiguredProvider(),
+		appleFetched: true,
+		backend:      backendNaked,
+		nakedReady:   true,
+		resultCh:     make(chan any, 1),
+	}
+	// Drive one loop iteration; the empty message leaves langdagClient nil so
+	// the fast-fail check fires.
+	app.resultCh <- langdagReadyMsg{}
+
+	type outcome struct{ err error }
+	done := make(chan outcome, 1)
+	go func() { done <- outcome{err: app.waitHeadlessReady()} }()
+
+	select {
+	case res := <-done:
+		if res.err == nil {
+			t.Fatal("expected error for missing provider, got nil")
+		}
+		if res.err.Error() != "no API key configured" {
+			t.Fatalf("error = %q, want %q (fast-fail, not timeout)", res.err.Error(), "no API key configured")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("waitHeadlessReady did not fail fast — it appears to have blocked on the 60s timeout")
+	}
+}


### PR DESCRIPTION
## Summary
- Headless runs (`herm -p`) with no configured LLM provider blocked for the full 60s init timeout, then printed the misleading `error: timed out waiting for initialization` — the missing provider is actually known as soon as initialization settles.
- `waitHeadlessReady` now fails fast with the actionable `error: no API key configured — use herm /config to add one` once provider resolution has settled, instead of waiting out the timer.
- Added `headlessProviderResolutionSettled`, which stays false while any async discovery path (model catalog, Apple runtime, Ollama, OpenRouter) is still in flight, so keyless-but-valid setups (Ollama, Apple runtime) and the interactive TUI are unaffected.

## Tests
- `go build ./cmd/herm`
- `go test ./cmd/herm/ -run 'HeadlessProviderResolutionSettled|WaitHeadlessReadyNoProvider'`
- ci-check (file-length / positional-param / docstring) on `cmd/herm` — clean
- `git diff --check`
