### PR TITLE
Make CPSL Xcode builds target and configuration aware

### DIFF
--- a/CPSL_BUILD.md
+++ b/CPSL_BUILD.md
@@ -132,18 +132,24 @@ installed:
 scripts/build-cpsl-apple-xcframework.sh
 ```
 
-This follows the same source dependency model as the host-native helper: Herm
-builds from `external/cpsl` unless `CPSL_ROOT` points at an existing checkout.
+Direct CLI use follows the same source dependency model as the host-native
+helper: Herm builds from `external/cpsl` unless `CPSL_ROOT` points at an
+existing checkout. Xcode auto-builds are stricter and always build from Herm's
+`external/cpsl` submodule, ignoring any `CPSL_ROOT` in the user's environment.
 
 The script builds CPSL's FFI crate for iOS device, iOS simulator, and macOS
-targets, then packages the dynamic libraries plus `cpsl.h` into one
-multi-platform XCFramework:
+targets by default, then packages the dynamic libraries plus `cpsl.h` into one
+XCFramework:
 
 ```text
 .herm-cpsl/artifacts/apple/
   cpsl.xcframework
   include/cpsl.h
 ```
+
+Direct CLI builds use Cargo's release profile by default. When invoked from
+Xcode, the helper follows Xcode's `CONFIGURATION`: `Debug` uses Cargo's debug
+profile and `Release` uses Cargo's release profile.
 
 Install Rust with [rustup](https://rustup.rs/), then add the Apple targets before
 building:
@@ -165,6 +171,16 @@ APPLE_PLATFORMS=ios scripts/build-cpsl-apple-xcframework.sh
 APPLE_PLATFORMS=macos scripts/build-cpsl-apple-xcframework.sh
 ```
 
+Target lists can also be narrowed explicitly. Empty target variables are
+honored, so this builds only an Apple Silicon iOS simulator slice:
+
+```sh
+APPLE_PLATFORMS=ios \
+  IOS_DEVICE_TARGETS= \
+  IOS_SIMULATOR_TARGETS=aarch64-apple-ios-sim \
+  scripts/build-cpsl-apple-xcframework.sh
+```
+
 The Apple helper builds CPSL's embedded agent FFI profile by default. That
 profile keeps the existing minimum modules and adds the pure Rust
 cross-platform utility/data modules from CPSL's broad feature set, plus `doc`
@@ -184,8 +200,10 @@ PDFium is staged next to the generated XCFramework:
 ```
 
 During Xcode builds, the `Copy CPSL PDFium` phase copies the platform-matching
-`libpdfium.dylib` into the app's Frameworks directory. The Swift app sets
-`CPSL_LIBRARY_DIR` to that directory before creating a CPSL session so
+`libpdfium.dylib` into the app's Frameworks directory. If Xcode requested only
+one simulator architecture, only the matching simulator PDFium input is
+downloaded before the staged `ios-simulator` sidecar is written. The Swift app
+sets `CPSL_LIBRARY_DIR` to that directory before creating a CPSL session so
 `doc.pdfInfo`, structural `doc.read(..., {mode="structural"})`, and other
 PDFium-backed `doc` functions can find the library at runtime.
 
@@ -205,40 +223,72 @@ APPLE_PLATFORMS=ios OUT_DIR=.herm-cpsl/artifacts/ios scripts/build-cpsl-apple-xc
 Opening `app/apple/herm.xcodeproj` in Xcode and building the `herm` target
 automatically ensures the CPSL XCFramework exists before Swift compilation.
 
-The `herm` target depends on a **Build CPSL XCFramework** aggregate target that
-runs before compilation. On every build it runs:
+The `herm` target depends on a **Build CPSL XCFramework** helper target that
+runs before Swift compilation. On every build it runs:
 
 ```sh
 "${SRCROOT}/../../scripts/link-cpsl-xcframework-for-xcode.sh"
 ```
 
 That helper calls `ensure-cpsl-apple-xcframework.sh` to build or reuse
-`.herm-cpsl/artifacts/apple/cpsl.xcframework` and its PDFium sidecar
-libraries, then links the built XCFramework into the Xcode-linked path at
-`scripts/cpsl-xcframework-placeholder/cpsl.xcframework` when that local copy is
-missing or stale.
+the configuration-scoped CPSL artifact and its PDFium sidecar libraries, then
+links the built XCFramework into the Xcode-linked path at
+`scripts/cpsl-xcframework-placeholder/cpsl.xcframework`.
 
-The phase is marked always-out-of-date so Xcode invokes the script each build,
-but the ensure script itself is cheap when nothing changed: it reuses
-`.herm-cpsl/artifacts/apple/cpsl.xcframework` when all three slices are present
-(iOS device, iOS simulator, macOS) and staleness inputs are not newer than
-`Info.plist`. It rebuilds when the artifact is missing, incomplete, or stale
-because files under `scripts/cpsl-patches/`, `scripts/build-cpsl-apple-xcframework.sh`,
-or `scripts/apply-cpsl-patches.sh` changed. The link helper also records a
-fingerprint of the copied XCFramework so repeated Xcode builds skip the
-`rm -rf`/`cp -R` relink step when the cached artifact has not changed.
+The helper target is built as a dependency of `herm`, so it receives the same
+`PLATFORM_NAME`/`SDK_NAME`, `ARCHS`, and `CONFIGURATION` values as the app
+build and finishes before `ProcessXCFramework` runs. Its declared output is a
+DerivedData stamp file so Xcode does not create a dependency cycle with the
+linked XCFramework path. It is marked always-out-of-date so Xcode invokes the
+script each build, but the ensure script itself is cheap when nothing changed:
+it reuses
+`.herm-cpsl/artifacts/apple/Debug/cpsl.xcframework` or
+`.herm-cpsl/artifacts/apple/Release/cpsl.xcframework` when it contains the
+platform and architectures selected by Xcode's `PLATFORM_NAME`/`SDK_NAME` and
+`ARCHS`, and staleness inputs are not newer than `Info.plist`. For Xcode
+auto-builds, reuse also requires the adjacent `.cpsl-source.stamp` to show that
+the artifact was built from Herm's `external/cpsl` submodule at the current
+revision and matching Cargo profile. It rebuilds when the artifact is missing,
+lacks the requested slice, was built from another CPSL checkout, revision, or
+Cargo profile, or is stale because files under `scripts/cpsl-patches/`,
+`scripts/build-cpsl-apple-xcframework.sh`, `scripts/lib/cpsl-xcframework.sh`,
+or `scripts/apply-cpsl-patches.sh` changed.
 
-Xcode builds always produce the full iOS+macOS XCFramework and PDFium sidecar
-set, even when the active destination only needs one platform.
+Xcode keeps Debug and Release CPSL artifacts separate:
+
+```text
+.herm-cpsl/artifacts/apple/Debug/
+  cpsl.xcframework
+  libs/pdfium/
+
+.herm-cpsl/artifacts/apple/Release/
+  cpsl.xcframework
+  libs/pdfium/
+```
+
+Xcode builds produce only the selected platform and architectures. For example,
+an Apple Silicon iPhone simulator build creates `aarch64-apple-ios-sim` and the
+simulator PDFium sidecar; it does not also build x86_64 simulator, iOS device,
+or macOS slices. A later build for another destination rebuilds the cached
+artifact for that destination.
 
 Xcode validates linked XCFrameworks before any target runs. A tracked bootstrap
 placeholder at `scripts/cpsl-xcframework-placeholder/cpsl.xcframework`
 satisfies that check on fresh clones. The ensure script then builds the real
-XCFramework under gitignored `.herm-cpsl/artifacts/apple/`, and the Xcode helper
-replaces the placeholder path with a local copy of that artifact when needed
-during the build. The copy step marks the tracked bootstrap files `skip-worktree` so
-`git status` stays clean while the local copy is present. Do not commit the
-local copy; only the bootstrap directory belongs in git.
+XCFramework under the gitignored configuration artifact directory. The Xcode
+helper keeps the linked path in the full bootstrap placeholder shape and
+overlays only the real slice directory requested by the current build. For
+simulator and macOS overlays, any unrequested architecture advertised by the
+placeholder (`arm64` or `x86_64`) is filled with a tiny validation stub dylib,
+not a CPSL build, so a failed build still leaves a pre-validation-safe linked
+path. After Xcode has linked and embedded the real slice, the later `Copy CPSL
+PDFium` phase restores the tracked bootstrap placeholder and removes the local
+link stamp so the next build overlays again. This keeps the source-tree linked
+path valid for later destination switches before run scripts execute, without
+building every platform up front. The temporary overlay marks the tracked
+bootstrap files `skip-worktree` so `git status` stays clean while local built
+slices are present. Do not commit the local overlay; only the bootstrap
+directory belongs in git.
 
 If a local checkout has an older broken symlink at the placeholder path, restore
 the bootstrap directory once before opening Xcode:
@@ -249,11 +299,13 @@ scripts/bootstrap-cpsl-xcframework-placeholder.sh
 
 ### First-build prerequisites
 
-The first full XCFramework build compiles five Rust targets and may take several
-minutes. You need:
+The first CPSL XCFramework build for a destination may take several minutes.
+You need:
 
 - **Full Xcode** installed and selected (Command Line Tools alone is not enough)
-- The Rust Apple targets listed in [Apple XCFramework](#apple-xcframework)
+- The Rust Apple target(s) for the selected Xcode destination, or all targets
+  listed in [Apple XCFramework](#apple-xcframework) if you want the direct CLI
+  default output
 
 Initialize Xcode from Terminal if needed:
 
@@ -282,10 +334,13 @@ early in the ensure script with a clear error before any Rust build starts.
 ### Dev launchers
 
 `scripts/dev-apple-macos.sh` and `scripts/dev-apple-ios.sh` call the same
-ensure script. Use `--skip-cpsl` to require an existing full XCFramework without
-building, or `--rebuild-cpsl` to set `HERM_CPSL_REBUILD=1` before the ensure
-step. The `--full-cpsl` flag is deprecated; the ensure script always builds the
-full framework.
+ensure script. Use `--skip-cpsl` to require an existing matching XCFramework
+without building, or `--rebuild-cpsl` to set `HERM_CPSL_REBUILD=1` before the
+ensure step. The `--full-cpsl` flag is deprecated; the ensure script builds the
+framework slices requested by its environment. These terminal launchers pass
+their selected `--configuration` into CPSL preflight, so a Debug launcher build
+uses the Debug CPSL artifact and a Release launcher build uses the Release CPSL
+artifact.
 
 ## macOS App From Terminal
 

--- a/app/apple/BuildSupport/BuildCPSLAnchor.c
+++ b/app/apple/BuildSupport/BuildCPSLAnchor.c
@@ -1,0 +1,2 @@
+// Build-order anchor for the CPSL XCFramework dependency target.
+void BuildCPSLAnchor(void) {}

--- a/app/apple/herm.xcodeproj/project.pbxproj
+++ b/app/apple/herm.xcodeproj/project.pbxproj
@@ -6,23 +6,10 @@
 	objectVersion = 77;
 	objects = {
 
-/* Begin PBXAggregateTarget section */
-		850B3BFE2FE8390F00A21FCA /* Build CPSL XCFramework */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = 850B3C012FE8390F00A21FCD /* Build configuration list for PBXAggregateTarget "Build CPSL XCFramework" */;
-			buildPhases = (
-				850B3BFD2FE8390F00A21FC9 /* Build CPSL XCFramework */,
-			);
-			dependencies = (
-			);
-			name = "Build CPSL XCFramework";
-			productName = "Build CPSL XCFramework";
-		};
-/* End PBXAggregateTarget section */
-
 /* Begin PBXBuildFile section */
 		850B3BFA2FE8390E00A21FC8 /* cpsl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 850B3BF92FE8390E00A21FC8 /* cpsl.xcframework */; };
 		850B3BFB2FE8390E00A21FC8 /* cpsl.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 850B3BF92FE8390E00A21FC8 /* cpsl.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		850B3C062FE8390F00A21FDD /* BuildCPSLAnchor.c in Sources */ = {isa = PBXBuildFile; fileRef = 850B3C052FE8390F00A21FDC /* BuildCPSLAnchor.c */; };
 		85A100012FEA000000000001 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 85A100002FEA000000000001 /* libsqlite3.tbd */; };
 		85A100052FEA000000000005 /* herm/Generated/CPSLEnvConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A100042FEA000000000004 /* herm/Generated/CPSLEnvConstants.swift */; };
 /* End PBXBuildFile section */
@@ -53,6 +40,8 @@
 
 /* Begin PBXFileReference section */
 		850B3BF92FE8390E00A21FC8 /* cpsl.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = cpsl.xcframework; path = "../../scripts/cpsl-xcframework-placeholder/cpsl.xcframework"; sourceTree = "<group>"; };
+		850B3C042FE8390F00A21FDB /* libBuildCPSL.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libBuildCPSL.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		850B3C052FE8390F00A21FDC /* BuildCPSLAnchor.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = BuildCPSLAnchor.c; sourceTree = "<group>"; };
 		85A100002FEA000000000001 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
 		85A100042FEA000000000004 /* herm/Generated/CPSLEnvConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = herm/Generated/CPSLEnvConstants.swift; sourceTree = SOURCE_ROOT; };
 		85D75D332FE62B6F0095BAB2 /* herm.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = herm.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -96,6 +85,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		850B3C082FE8390F00A21FDF /* BuildSupport */ = {
+			isa = PBXGroup;
+			children = (
+				850B3C052FE8390F00A21FDC /* BuildCPSLAnchor.c */,
+			);
+			path = BuildSupport;
+			sourceTree = "<group>";
+		};
 		10B2D4362FF5768800E04BA4 /* Generated Sources */ = {
 			isa = PBXGroup;
 			children = (
@@ -117,6 +114,7 @@
 			isa = PBXGroup;
 			children = (
 				85D75D352FE62B6F0095BAB2 /* herm */,
+				850B3C082FE8390F00A21FDF /* BuildSupport */,
 				850B3BF82FE8390E00A21FC8 /* Frameworks */,
 				85D75D342FE62B6F0095BAB2 /* Products */,
 				10B2D4362FF5768800E04BA4 /* Generated Sources */,
@@ -126,6 +124,7 @@
 		85D75D342FE62B6F0095BAB2 /* Products */ = {
 			isa = PBXGroup;
 			children = (
+				850B3C042FE8390F00A21FDB /* libBuildCPSL.a */,
 				85D75D332FE62B6F0095BAB2 /* herm.app */,
 			);
 			name = Products;
@@ -134,6 +133,22 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		850B3BFE2FE8390F00A21FCA /* Build CPSL XCFramework */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 850B3C012FE8390F00A21FCD /* Build configuration list for PBXNativeTarget "Build CPSL XCFramework" */;
+			buildPhases = (
+				85A100072FEA000000000007 /* Build CPSL XCFramework */,
+				850B3C072FE8390F00A21FDE /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Build CPSL XCFramework";
+			productName = BuildCPSL;
+			productReference = 850B3C042FE8390F00A21FDB /* libBuildCPSL.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 		85D75D322FE62B6F0095BAB2 /* herm */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 85D75D3E2FE62B6F0095BAB2 /* Build configuration list for PBXNativeTarget "herm" */;
@@ -209,7 +224,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		850B3BFD2FE8390F00A21FC9 /* Build CPSL XCFramework */ = {
+		85A100072FEA000000000007 /* Build CPSL XCFramework */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -223,7 +238,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				"$(SRCROOT)/../../scripts/cpsl-xcframework-placeholder/cpsl.xcframework/Info.plist",
+				"$(DERIVED_FILE_DIR)/cpsl-xcframework-linked.stamp",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -272,6 +287,14 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		850B3C072FE8390F00A21FDE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				850B3C062FE8390F00A21FDD /* BuildCPSLAnchor.c in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		85D75D2F2FE62B6F0095BAB2 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -295,7 +318,12 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				MACOSX_DEPLOYMENT_TARGET = 26.5;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = BuildCPSL;
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 			};
 			name = Debug;
 		};
@@ -303,7 +331,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				MACOSX_DEPLOYMENT_TARGET = 26.5;
+				PRODUCT_NAME = BuildCPSL;
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
 			};
 			name = Release;
 		};
@@ -530,7 +562,7 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		850B3C012FE8390F00A21FCD /* Build configuration list for PBXAggregateTarget "Build CPSL XCFramework" */ = {
+		850B3C012FE8390F00A21FCD /* Build configuration list for PBXNativeTarget "Build CPSL XCFramework" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				850B3C022FE8390F00A21FCE /* Debug */,

--- a/scripts/build-cpsl-apple-xcframework.sh
+++ b/scripts/build-cpsl-apple-xcframework.sh
@@ -24,7 +24,8 @@ Builds one CPSL XCFramework for Apple app targets.
 
 By default this script builds CPSL from Herm's external/cpsl submodule,
 matching scripts/build-cpsl-image.sh. The output is one Apple-consumable
-XCFramework containing iOS device, iOS simulator, and macOS slices.
+XCFramework containing the requested iOS device, iOS simulator, and/or macOS
+slices.
 
 Options:
   --apple-app Build the expanded iOS/macOS app profile. This is the default.
@@ -35,12 +36,17 @@ Environment:
   CPSL_ROOT                Existing CPSL checkout to use instead of external/cpsl.
   CPSL_WORK_DIR            Gitignored work/artifact root. Defaults to HERM_ROOT/.herm-cpsl.
   CPSL_TARGET_DIR          Cargo target directory. Defaults to CPSL_WORK_DIR/cargo-target.
-  OUT_DIR                  Artifact directory. Defaults to CPSL_WORK_DIR/artifacts/apple.
+  OUT_DIR                  Artifact directory. Defaults to CPSL_WORK_DIR/artifacts/apple,
+                           or CPSL_WORK_DIR/artifacts/apple/CONFIGURATION for Xcode builds.
+  CONFIGURATION            Xcode configuration. Debug uses Cargo debug; Release uses Cargo release.
   APPLE_PLATFORMS          Platforms to include. Defaults to "ios macos".
   IOS_DEPLOYMENT_TARGET    Minimum iOS version. Defaults to 17.0.
   MACOSX_DEPLOYMENT_TARGET Minimum macOS version. Defaults to 14.0.
+  IOS_DEVICE_TARGETS       Rust device targets. Defaults to aarch64 iOS.
   IOS_SIMULATOR_TARGETS    Rust simulator targets. Defaults to arm64 and x86_64 simulator.
   MACOS_TARGETS            Rust macOS targets. Defaults to arm64 and x86_64 macOS.
+  HERM_CPSL_FORCE_SUBMODULE=1
+                           Ignore CPSL_ROOT and build from Herm's external/cpsl submodule.
   PDFIUM_VERSION           PDFium build number. Defaults to CPSL's downloader default.
 EOF
 }
@@ -71,6 +77,7 @@ done
 script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd -P)
 herm_root=$(CDPATH= cd "$script_dir/.." && pwd -P)
 . "$script_dir/lib/host-path.sh"
+. "$script_dir/lib/cpsl-xcframework.sh"
 herm_ensure_rust_path
 
 [ "$(uname -s)" = Darwin ] || die "Apple XCFramework builds require macOS with Xcode"
@@ -80,42 +87,27 @@ mkdir -p "$work_dir"
 work_dir=$(CDPATH= cd "$work_dir" && pwd -P)
 default_cpsl_root="$herm_root/external/cpsl"
 target_dir=${CPSL_TARGET_DIR:-"$work_dir/cargo-target"}
-out_dir=${OUT_DIR:-"$work_dir/artifacts/apple"}
-apple_platforms=${APPLE_PLATFORMS:-"ios macos"}
+cargo_profile=$(cpsl_apple_cargo_profile_from_environment) || die "failed to resolve CPSL Cargo profile"
+out_dir=${OUT_DIR:-$(cpsl_apple_default_artifact_dir "$work_dir")}
 ios_deployment_target=${IOS_DEPLOYMENT_TARGET:-17.0}
 macos_deployment_target=${MACOSX_DEPLOYMENT_TARGET:-14.0}
-ios_device_target=aarch64-apple-ios
-ios_simulator_targets=${IOS_SIMULATOR_TARGETS:-"aarch64-apple-ios-sim x86_64-apple-ios"}
-macos_targets=${MACOS_TARGETS:-"aarch64-apple-darwin x86_64-apple-darwin"}
 lib_name=libcpsl.dylib
 pdfium_lib_name=libpdfium.dylib
 xcframework_name=cpsl.xcframework
 
-[ -n "$apple_platforms" ] || die "APPLE_PLATFORMS must not be empty"
+request_assignments=$(cpsl_apple_request_from_environment) || die "failed to resolve CPSL Apple build targets"
+eval "$request_assignments"
+apple_platforms=$APPLE_PLATFORMS
+ios_device_targets=$IOS_DEVICE_TARGETS
+ios_simulator_targets=$IOS_SIMULATOR_TARGETS
+macos_targets=$MACOS_TARGETS
 
-include_ios=0
+include_ios_device=0
+include_ios_simulator=0
 include_macos=0
-for platform in $apple_platforms; do
-	case "$platform" in
-	ios)
-		include_ios=1
-		;;
-	macos)
-		include_macos=1
-		;;
-	*)
-		die "unsupported APPLE_PLATFORMS entry: $platform"
-		;;
-	esac
-done
-[ "$include_ios" -eq 1 ] || [ "$include_macos" -eq 1 ] || die "APPLE_PLATFORMS must include ios, macos, or both"
-
-if [ "$include_ios" -eq 1 ]; then
-	[ -n "$ios_simulator_targets" ] || die "IOS_SIMULATOR_TARGETS must not be empty when APPLE_PLATFORMS includes ios"
-fi
-if [ "$include_macos" -eq 1 ]; then
-	[ -n "$macos_targets" ] || die "MACOS_TARGETS must not be empty when APPLE_PLATFORMS includes macos"
-fi
+[ -n "$ios_device_targets" ] && include_ios_device=1
+[ -n "$ios_simulator_targets" ] && include_ios_simulator=1
+[ -n "$macos_targets" ] && include_macos=1
 
 need_cmd cargo "install Rust from https://rustup.rs, then restart Xcode so run scripts can find ~/.cargo/bin"
 need_cmd rustc "install Rust from https://rustup.rs, then restart Xcode so run scripts can find ~/.cargo/bin"
@@ -129,10 +121,12 @@ developer_dir=$(xcode-select -p)
 if ! xcodebuild -version >/dev/null 2>&1; then
 	die "selected developer directory is not full Xcode: $developer_dir; install full Xcode, open it once, then run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer"
 fi
-if [ "$include_ios" -eq 1 ]; then
-	required_sdks="iphoneos iphonesimulator"
-else
-	required_sdks=
+required_sdks=
+if [ "$include_ios_device" -eq 1 ]; then
+	required_sdks="${required_sdks:+$required_sdks }iphoneos"
+fi
+if [ "$include_ios_simulator" -eq 1 ]; then
+	required_sdks="${required_sdks:+$required_sdks }iphonesimulator"
 fi
 if [ "$include_macos" -eq 1 ]; then
 	required_sdks="${required_sdks:+$required_sdks }macosx"
@@ -145,8 +139,11 @@ for sdk in $required_sdks; do
 done
 
 required_targets=
-if [ "$include_ios" -eq 1 ]; then
-	required_targets="$ios_device_target $ios_simulator_targets"
+if [ "$include_ios_device" -eq 1 ]; then
+	required_targets="${required_targets:+$required_targets }$ios_device_targets"
+fi
+if [ "$include_ios_simulator" -eq 1 ]; then
+	required_targets="${required_targets:+$required_targets }$ios_simulator_targets"
 fi
 if [ "$include_macos" -eq 1 ]; then
 	required_targets="${required_targets:+$required_targets }$macos_targets"
@@ -163,7 +160,18 @@ if command -v rustup >/dev/null 2>&1; then
 	fi
 fi
 
-if [ -n "${CPSL_ROOT:-}" ]; then
+if [ "${HERM_CPSL_FORCE_SUBMODULE:-0}" = 1 ]; then
+	if [ -n "${CPSL_ROOT:-}" ]; then
+		printf 'Ignoring CPSL_ROOT for Xcode CPSL build; using Herm submodule: %s\n' "$default_cpsl_root"
+	fi
+	if [ ! -f "$default_cpsl_root/Cargo.toml" ]; then
+		need_cmd git "install Git"
+		printf 'Initializing CPSL submodule in %s\n' "$default_cpsl_root"
+		git -C "$herm_root" submodule update --init -- external/cpsl
+	fi
+	cpsl_root=$(CDPATH= cd "$default_cpsl_root" && pwd -P) || \
+		die "missing CPSL submodule at $default_cpsl_root; run: git submodule update --init external/cpsl"
+elif [ -n "${CPSL_ROOT:-}" ]; then
 	cpsl_root=$(CDPATH= cd "$CPSL_ROOT" && pwd -P) || die "CPSL_ROOT is not a directory: $CPSL_ROOT"
 else
 	if [ ! -f "$default_cpsl_root/Cargo.toml" ]; then
@@ -235,6 +243,11 @@ build_target() {
 	else
 		cargo_features=ffi-minimal
 	fi
+	set -- build --manifest-path "$cpsl_root/Cargo.toml" --target-dir "$target_dir" -p cpsl-ffi
+	if [ "$cargo_profile" = release ]; then
+		set -- "$@" --release
+	fi
+	set -- "$@" --no-default-features --features "$cargo_features" --target "$target"
 	env \
 		"SDKROOT=$sdk_path" \
 		"$deployment_env=$deployment_target" \
@@ -243,9 +256,9 @@ build_target() {
 		"AR_$target_env=$ar" \
 		"CARGO_TARGET_${target_env_upper}_LINKER=$clang" \
 		"RUSTFLAGS=$rustflags" \
-		cargo build --manifest-path "$cpsl_root/Cargo.toml" --target-dir "$target_dir" -p cpsl-ffi --release --no-default-features --features "$cargo_features" --target "$target"
+		cargo "$@"
 
-	target_lib="$target_dir/$target/release/$lib_name"
+	target_lib="$target_dir/$target/$cargo_profile/$lib_name"
 	[ -f "$target_lib" ] || die "expected CPSL library not found: $target_lib"
 	mkdir -p "$output_dir"
 	cp "$target_lib" "$output_dir/$lib_name"
@@ -290,18 +303,31 @@ install_apple_pdfium_artifacts() {
 	rm -rf "$pdfium_work_dir" "$pdfium_dir"
 	mkdir -p "$pdfium_work_dir" "$pdfium_dir"
 
-	if [ "$include_ios" -eq 1 ]; then
+	if [ "$include_ios_device" -eq 1 ]; then
 		install_pdfium_target ios-device-arm64 "$pdfium_work_dir/ios-device-arm64"
 		copy_pdfium_library \
 			"$pdfium_work_dir/ios-device-arm64/lib/$pdfium_lib_name" \
 			"$pdfium_dir/ios-arm64/lib/$pdfium_lib_name"
+	fi
 
-		install_pdfium_target ios-simulator-arm64 "$pdfium_work_dir/ios-simulator-arm64"
-		install_pdfium_target ios-simulator-x64 "$pdfium_work_dir/ios-simulator-x64"
-		combine_pdfium_libraries \
-			"$pdfium_dir/ios-simulator/lib/$pdfium_lib_name" \
-			"$pdfium_work_dir/ios-simulator-arm64/lib/$pdfium_lib_name" \
-			"$pdfium_work_dir/ios-simulator-x64/lib/$pdfium_lib_name"
+	if [ "$include_ios_simulator" -eq 1 ]; then
+		set --
+		for target in $ios_simulator_targets; do
+			case "$target" in
+			aarch64-apple-ios-sim)
+				install_pdfium_target ios-simulator-arm64 "$pdfium_work_dir/ios-simulator-arm64"
+				set -- "$@" "$pdfium_work_dir/ios-simulator-arm64/lib/$pdfium_lib_name"
+				;;
+			x86_64-apple-ios)
+				install_pdfium_target ios-simulator-x64 "$pdfium_work_dir/ios-simulator-x64"
+				set -- "$@" "$pdfium_work_dir/ios-simulator-x64/lib/$pdfium_lib_name"
+				;;
+			*)
+				die "unsupported iOS simulator PDFium target: $target"
+				;;
+			esac
+		done
+		combine_pdfium_libraries "$pdfium_dir/ios-simulator/lib/$pdfium_lib_name" "$@"
 	fi
 
 	if [ "$include_macos" -eq 1 ]; then
@@ -341,8 +367,11 @@ build_universal_library() {
 	combine_libraries "$output" "$@"
 }
 
-if [ "$include_ios" -eq 1 ]; then
-	build_target "$ios_device_target" iphoneos IPHONEOS_DEPLOYMENT_TARGET "$ios_deployment_target" "$ios_device_dir"
+if [ "$include_ios_device" -eq 1 ]; then
+	build_universal_library "$ios_device_dir/$lib_name" iphoneos IPHONEOS_DEPLOYMENT_TARGET "$ios_deployment_target" $ios_device_targets
+fi
+
+if [ "$include_ios_simulator" -eq 1 ]; then
 	build_universal_library "$ios_simulator_dir/$lib_name" iphonesimulator IPHONEOS_DEPLOYMENT_TARGET "$ios_deployment_target" $ios_simulator_targets
 fi
 
@@ -355,10 +384,11 @@ if [ "$profile" = apple-app ]; then
 fi
 
 set -- -create-xcframework
-if [ "$include_ios" -eq 1 ]; then
-	set -- "$@" \
-		-library "$ios_device_dir/$lib_name" -headers "$include_dir" \
-		-library "$ios_simulator_dir/$lib_name" -headers "$include_dir"
+if [ "$include_ios_device" -eq 1 ]; then
+	set -- "$@" -library "$ios_device_dir/$lib_name" -headers "$include_dir"
+fi
+if [ "$include_ios_simulator" -eq 1 ]; then
+	set -- "$@" -library "$ios_simulator_dir/$lib_name" -headers "$include_dir"
 fi
 if [ "$include_macos" -eq 1 ]; then
 	set -- "$@" -library "$macos_dir/$lib_name" -headers "$include_dir"
@@ -367,13 +397,24 @@ set -- "$@" -output "$xcframework_path"
 
 xcodebuild "$@"
 
-if [ -z "${OUT_DIR:-}" ] && [ -z "${CPSL_WORK_DIR:-}" ]; then
+source_stamp_path=$(cpsl_xcframework_source_stamp_path "$out_dir")
+if source_revision=$(cpsl_xcframework_source_revision "$cpsl_root"); then
+	cpsl_xcframework_write_source_stamp_value "$source_stamp_path" "$cpsl_root" "$source_revision" "$cargo_profile"
+elif [ "${HERM_CPSL_FORCE_SUBMODULE:-0}" = 1 ]; then
+	die "failed to read CPSL submodule revision for source stamp: $cpsl_root"
+else
+	cpsl_xcframework_write_source_stamp_value "$source_stamp_path" "$cpsl_root" unknown "$cargo_profile"
+fi
+
+if [ -z "${OUT_DIR:-}" ] && [ -z "${CPSL_WORK_DIR:-}" ] && [ -z "${CONFIGURATION:-}" ]; then
 	display_out=".herm-cpsl/artifacts/apple"
 else
 	display_out="$out_dir"
 fi
 
 printf '\nBuilt CPSL Apple XCFramework (%s)\n' "$profile"
+printf '  cargo profile: %s\n' "$cargo_profile"
+printf '  targets: %s\n' "$CPSL_REQUEST_DESCRIPTION"
 printf '  image: %s\n' "$display_out"
 printf '  xcframework: %s/%s\n' "$display_out" "$xcframework_name"
 if [ "$profile" = apple-app ]; then

--- a/scripts/copy-cpsl-pdfium-for-xcode.sh
+++ b/scripts/copy-cpsl-pdfium-for-xcode.sh
@@ -8,25 +8,50 @@ die() {
 
 script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd -P)
 herm_root=$(CDPATH= cd "$script_dir/.." && pwd -P)
-pdfium_root="$herm_root/.herm-cpsl/artifacts/apple/libs/pdfium"
+. "$script_dir/lib/cpsl-xcframework.sh"
+work_dir=${CPSL_WORK_DIR:-"$herm_root/.herm-cpsl"}
+cargo_profile=$(cpsl_apple_cargo_profile_from_environment) || die "failed to resolve CPSL Cargo profile"
+out_dir=${OUT_DIR:-$(cpsl_apple_default_artifact_dir "$work_dir")}
+pdfium_root="$out_dir/libs/pdfium"
+placeholder_dir="$herm_root/scripts/cpsl-xcframework-placeholder"
+link_path="$placeholder_dir/cpsl.xcframework"
+link_stamp="$out_dir/.xcode-linked-xcframework.stamp"
 
-case "${PLATFORM_NAME:-}" in
-iphoneos)
-	pdfium_slice=ios-arm64
-	;;
-iphonesimulator)
-	pdfium_slice=ios-simulator
-	;;
-macosx)
-	pdfium_slice=macos
-	;;
-xros | xrsimulator)
-	die "CPSL does not yet support visionOS. Supported platforms: iOS and macOS."
-	;;
-*)
-	die "unsupported Apple platform for CPSL PDFium: ${PLATFORM_NAME:-<unset>}"
-	;;
-esac
+cpsl_pdfium_restore_xcframework_placeholder() {
+	status=$?
+
+	if ! rm -f "$link_stamp" 2>/dev/null; then
+		printf '%s\n' "warning: failed to remove CPSL XCFramework link stamp: $link_stamp" >&2
+	fi
+
+	if [ -e "$link_path" ] || [ -L "$link_path" ]; then
+		if cpsl_xcframework_restore_tracked_placeholder "$herm_root" "$link_path"; then
+			printf 'Restored CPSL XCFramework placeholder: %s\n' "$link_path"
+		else
+			printf '%s\n' "warning: failed to restore CPSL XCFramework placeholder: $link_path" >&2
+		fi
+	fi
+
+	return "$status"
+}
+
+trap cpsl_pdfium_restore_xcframework_placeholder EXIT
+
+request_assignments=$(cpsl_apple_request_from_xcode_env) || die "failed to resolve CPSL PDFium slice from Xcode environment"
+eval "$request_assignments"
+ios_device_targets=$IOS_DEVICE_TARGETS
+ios_simulator_targets=$IOS_SIMULATOR_TARGETS
+macos_targets=$MACOS_TARGETS
+
+cpsl_pdfium_satisfies_targets "$pdfium_root" "$ios_device_targets" "$ios_simulator_targets" "$macos_targets" || \
+	die "$pdfium_root does not contain requested PDFium target(s): $CPSL_REQUEST_DESCRIPTION"
+
+pdfium_slice=
+for slice in $CPSL_PDFIUM_SLICES; do
+	pdfium_slice=$slice
+	break
+done
+[ -n "$pdfium_slice" ] || die "no CPSL PDFium slice requested for ${PLATFORM_NAME:-<unset>}"
 
 src="$pdfium_root/$pdfium_slice/lib/libpdfium.dylib"
 [ -f "$src" ] || die "missing PDFium library: $src"

--- a/scripts/dev-apple-ios.sh
+++ b/scripts/dev-apple-ios.sh
@@ -389,7 +389,7 @@ project="$root/app/apple/herm.xcodeproj"
 target=herm
 scheme=herm
 app_path="$derived_data/Build/Products/$configuration-iphoneos/$target.app"
-xcframework_path="$root/.herm-cpsl/artifacts/apple/cpsl.xcframework"
+xcframework_path="$root/.herm-cpsl/artifacts/apple/$configuration/cpsl.xcframework"
 host_arch=$(uname -m)
 signing_style_setting=
 team_setting=
@@ -481,6 +481,7 @@ fi
 if [ -n "$cpsl_macos_targets" ]; then
 	export MACOS_TARGETS="$cpsl_macos_targets"
 fi
+export CONFIGURATION="$configuration"
 if [ "$cpsl_mode" = skip ]; then
 	"$root/scripts/link-cpsl-xcframework-for-xcode.sh" --skip
 else

--- a/scripts/dev-apple-macos.sh
+++ b/scripts/dev-apple-macos.sh
@@ -179,7 +179,7 @@ target=herm
 scheme=herm
 app_path="$derived_data/Build/Products/$configuration/$target.app"
 binary_path="$app_path/Contents/MacOS/$target"
-xcframework_path="$root/.herm-cpsl/artifacts/apple/cpsl.xcframework"
+xcframework_path="$root/.herm-cpsl/artifacts/apple/$configuration/cpsl.xcframework"
 entitlements_path="$derived_data/Build/Intermediates.noindex/herm.build/$configuration/herm.build/$target.app.xcent"
 source_entitlements_path="$root/app/apple/herm/herm-macOS.entitlements"
 host_arch=$(uname -m)
@@ -212,6 +212,7 @@ fi
 if [ -n "$cpsl_macos_targets" ]; then
 	export MACOS_TARGETS="$cpsl_macos_targets"
 fi
+export CONFIGURATION="$configuration"
 if [ "$cpsl_mode" = skip ]; then
 	"$root/scripts/link-cpsl-xcframework-for-xcode.sh" --skip
 else

--- a/scripts/ensure-cpsl-apple-xcframework.sh
+++ b/scripts/ensure-cpsl-apple-xcframework.sh
@@ -11,16 +11,17 @@ usage() {
 Usage:
   scripts/ensure-cpsl-apple-xcframework.sh [options]
 
-Ensures the full CPSL Apple XCFramework exists before building Herm.
+Ensures the requested CPSL Apple XCFramework slices exist before building Herm.
 
 Options:
-  --skip   Require an existing full XCFramework; do not build.
+  --skip   Require an existing matching XCFramework; do not build.
   -h, --help
            Show this help.
 
 Environment:
   HERM_CPSL_REBUILD=1  Force a CPSL XCFramework rebuild.
-  CPSL_ROOT, CPSL_WORK_DIR, OUT_DIR, IOS_SIMULATOR_TARGETS, MACOS_TARGETS
+  CPSL_ROOT, CPSL_WORK_DIR, OUT_DIR, APPLE_PLATFORMS,
+  IOS_DEVICE_TARGETS, IOS_SIMULATOR_TARGETS, MACOS_TARGETS, CONFIGURATION
                          Passed through to build-cpsl-apple-xcframework.sh.
 EOF
 }
@@ -95,12 +96,18 @@ cpsl_ensure_rebuild_reason() {
 		printf '%s\n' "$xcframework_path is still the bootstrap placeholder"
 		return 0
 	}
-	cpsl_xcframework_is_full "$xcframework_info" || {
-		printf '%s\n' "$xcframework_path is incomplete"
+	if [ "$require_submodule_source_stamp" -eq 1 ]; then
+		cpsl_xcframework_source_stamp_matches "$source_stamp_path" "$default_cpsl_root" "$cargo_profile" || {
+			printf '%s\n' "$xcframework_path was not built from external/cpsl at the current revision and Cargo profile"
+			return 0
+		}
+	fi
+	cpsl_xcframework_satisfies_targets "$xcframework_info" "$ios_device_targets" "$ios_simulator_targets" "$macos_targets" || {
+		printf '%s\n' "$xcframework_path does not contain requested CPSL target(s): $CPSL_REQUEST_DESCRIPTION"
 		return 0
 	}
-	cpsl_ensure_pdfium_is_full || {
-		printf '%s\n' "$pdfium_path is incomplete"
+	cpsl_pdfium_satisfies_targets "$pdfium_path" "$ios_device_targets" "$ios_simulator_targets" "$macos_targets" || {
+		printf '%s\n' "$pdfium_path does not contain requested PDFium target(s): $CPSL_REQUEST_DESCRIPTION"
 		return 0
 	}
 	cpsl_xcframework_inputs_newer_than "$xcframework_info" "$herm_root" && {
@@ -114,13 +121,6 @@ cpsl_ensure_should_reuse() {
 	xcframework_info=$1
 
 	! cpsl_ensure_rebuild_reason "$xcframework_info" >/dev/null
-}
-
-cpsl_ensure_pdfium_is_full() {
-	for slice in ios-arm64 ios-simulator macos; do
-		[ -f "$pdfium_path/$slice/lib/libpdfium.dylib" ] || return 1
-	done
-	return 0
 }
 
 script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd -P)
@@ -150,18 +150,38 @@ if cpsl_ensure_is_visionos_build; then
 	die "CPSL does not yet support visionOS. Supported platforms: iOS and macOS."
 fi
 
+request_assignments=$(cpsl_apple_request_from_environment) || die "failed to resolve CPSL Apple build targets"
+eval "$request_assignments"
+ios_device_targets=$IOS_DEVICE_TARGETS
+ios_simulator_targets=$IOS_SIMULATOR_TARGETS
+macos_targets=$MACOS_TARGETS
+
+if cpsl_apple_has_xcode_selection; then
+	HERM_CPSL_FORCE_SUBMODULE=1
+	export HERM_CPSL_FORCE_SUBMODULE
+	unset CPSL_ROOT
+fi
+require_submodule_source_stamp=${HERM_CPSL_FORCE_SUBMODULE:-0}
+
 work_dir=${CPSL_WORK_DIR:-"$herm_root/.herm-cpsl"}
-out_dir=${OUT_DIR:-"$work_dir/artifacts/apple"}
+cargo_profile=$(cpsl_apple_cargo_profile_from_environment) || die "failed to resolve CPSL Cargo profile"
+out_dir=${OUT_DIR:-$(cpsl_apple_default_artifact_dir "$work_dir")}
+default_cpsl_root="$herm_root/external/cpsl"
 xcframework_path="$out_dir/cpsl.xcframework"
 pdfium_path="$out_dir/libs/pdfium"
+source_stamp_path=$(cpsl_xcframework_source_stamp_path "$out_dir")
 xcframework_info=$(cpsl_xcframework_info_plist "$xcframework_path")
 
 if [ "$skip_mode" -eq 1 ]; then
 	[ -d "$xcframework_path" ] || die "missing $xcframework_path; rerun without --skip"
-	cpsl_xcframework_is_full "$xcframework_info" || \
-		die "$xcframework_path is incomplete; rerun without --skip"
-	cpsl_ensure_pdfium_is_full || \
-		die "$pdfium_path is incomplete; rerun without --skip"
+	if [ "$require_submodule_source_stamp" -eq 1 ]; then
+		cpsl_xcframework_source_stamp_matches "$source_stamp_path" "$default_cpsl_root" "$cargo_profile" || \
+			die "$xcframework_path was not built from external/cpsl at the current revision and Cargo profile; rerun without --skip"
+	fi
+	cpsl_xcframework_satisfies_targets "$xcframework_info" "$ios_device_targets" "$ios_simulator_targets" "$macos_targets" || \
+		die "$xcframework_path does not contain requested CPSL target(s): $CPSL_REQUEST_DESCRIPTION; rerun without --skip"
+	cpsl_pdfium_satisfies_targets "$pdfium_path" "$ios_device_targets" "$ios_simulator_targets" "$macos_targets" || \
+		die "$pdfium_path does not contain requested PDFium target(s): $CPSL_REQUEST_DESCRIPTION; rerun without --skip"
 	printf 'Using existing CPSL XCFramework: %s\n' "$xcframework_path"
 	exit 0
 fi
@@ -184,5 +204,10 @@ if cpsl_ensure_should_reuse "$xcframework_info"; then
 fi
 rebuild_reason=$(cpsl_ensure_rebuild_reason "$xcframework_info" || printf '%s\n' "$rebuild_reason")
 
-printf 'Building CPSL Apple XCFramework for: ios macos (%s)\n' "$rebuild_reason"
-APPLE_PLATFORMS="ios macos" "$herm_root/scripts/build-cpsl-apple-xcframework.sh"
+printf 'Building CPSL Apple XCFramework for: %s (%s)\n' "$CPSL_REQUEST_DESCRIPTION" "$rebuild_reason"
+APPLE_PLATFORMS="$APPLE_PLATFORMS" \
+	IOS_DEVICE_TARGETS="$IOS_DEVICE_TARGETS" \
+	IOS_SIMULATOR_TARGETS="$IOS_SIMULATOR_TARGETS" \
+	MACOS_TARGETS="$MACOS_TARGETS" \
+	CONFIGURATION="${CONFIGURATION:-}" \
+	"$herm_root/scripts/build-cpsl-apple-xcframework.sh"

--- a/scripts/lib/cpsl-xcframework.sh
+++ b/scripts/lib/cpsl-xcframework.sh
@@ -6,11 +6,690 @@ cpsl_xcframework_info_plist() {
 	printf '%s/Info.plist' "$xcframework_path"
 }
 
-cpsl_xcframework_has_ios_device() {
+cpsl_xcframework_plist_tokens() {
 	info=$1
 
 	[ -f "$info" ] || return 1
-	awk '
+	awk '{ gsub(/></, ">\n<"); print }' "$info"
+}
+
+cpsl_apple_shell_quote() {
+	printf "'%s'" "$(printf '%s' "$1" | sed "s/'/'\\\\''/g")"
+}
+
+cpsl_apple_list_append_unique() {
+	list=$1
+	value=$2
+
+	[ -n "$value" ] || {
+		printf '%s' "$list"
+		return 0
+	}
+
+	for entry in $list; do
+		[ "$entry" = "$value" ] && {
+			printf '%s' "$list"
+			return 0
+		}
+	done
+
+	printf '%s%s%s' "$list" "${list:+ }" "$value"
+}
+
+cpsl_xcode_arch_list_contains() {
+	arch_list=$1
+	want_arch=$2
+
+	for listed_arch in $arch_list; do
+		[ "$listed_arch" = "$want_arch" ] && return 0
+	done
+
+	return 1
+}
+
+cpsl_apple_platform_from_xcode() {
+	platform_name=${1:-}
+	sdk_name=${2:-}
+
+	case "$platform_name" in
+	iphoneos | iphonesimulator | macosx)
+		printf '%s\n' "$platform_name"
+		return 0
+		;;
+	xros | xrsimulator)
+		printf '%s\n' "CPSL does not yet support visionOS. Supported platforms: iOS and macOS." >&2
+		return 1
+		;;
+	"")
+		;;
+	*)
+		printf '%s\n' "unsupported Apple platform for CPSL: $platform_name" >&2
+		return 1
+		;;
+	esac
+
+	case "$sdk_name" in
+	iphoneos*)
+		printf '%s\n' iphoneos
+		;;
+	iphonesimulator*)
+		printf '%s\n' iphonesimulator
+		;;
+	macosx*)
+		printf '%s\n' macosx
+		;;
+	xros* | xrsimulator*)
+		printf '%s\n' "CPSL does not yet support visionOS. Supported platforms: iOS and macOS." >&2
+		return 1
+		;;
+	"")
+		printf '%s\n' "PLATFORM_NAME or SDK_NAME is required to derive CPSL Apple targets from Xcode" >&2
+		return 1
+		;;
+	*)
+		printf '%s\n' "unsupported Apple SDK for CPSL: $sdk_name" >&2
+		return 1
+		;;
+	esac
+}
+
+cpsl_apple_archs_from_xcode() {
+	archs=${1:-}
+	current_arch=${2:-}
+
+	if [ -n "$archs" ]; then
+		printf '%s\n' "$archs"
+		return 0
+	fi
+
+	case "$current_arch" in
+	"" | undefined_arch)
+		printf '%s\n' "ARCHS is required to derive CPSL Apple targets from Xcode" >&2
+		return 1
+		;;
+	*)
+		printf '%s\n' "$current_arch"
+		;;
+	esac
+}
+
+cpsl_apple_xcode_current_arch() {
+	current_arch=${CURRENT_ARCH:-}
+
+	case "$current_arch" in
+	"" | undefined_arch)
+		printf '%s\n' "${NATIVE_ARCH_ACTUAL:-}"
+		;;
+	*)
+		printf '%s\n' "$current_arch"
+		;;
+	esac
+}
+
+cpsl_apple_rust_target_for_platform_arch() {
+	platform=$1
+	arch=$2
+
+	case "$platform:$arch" in
+	iphoneos:arm64)
+		printf '%s\n' aarch64-apple-ios
+		;;
+	iphonesimulator:arm64)
+		printf '%s\n' aarch64-apple-ios-sim
+		;;
+	iphonesimulator:x86_64)
+		printf '%s\n' x86_64-apple-ios
+		;;
+	macosx:arm64)
+		printf '%s\n' aarch64-apple-darwin
+		;;
+	macosx:x86_64)
+		printf '%s\n' x86_64-apple-darwin
+		;;
+	*)
+		printf '%s\n' "unsupported CPSL Apple platform/architecture: $platform $arch" >&2
+		return 1
+		;;
+	esac
+}
+
+cpsl_apple_category_for_rust_target() {
+	target=$1
+
+	case "$target" in
+	aarch64-apple-ios)
+		printf '%s\n' ios_device
+		;;
+	aarch64-apple-ios-sim | x86_64-apple-ios)
+		printf '%s\n' ios_simulator
+		;;
+	aarch64-apple-darwin | x86_64-apple-darwin)
+		printf '%s\n' macos
+		;;
+	*)
+		printf '%s\n' "unsupported CPSL Apple Rust target: $target" >&2
+		return 1
+		;;
+	esac
+}
+
+cpsl_apple_arch_for_rust_target() {
+	target=$1
+
+	case "$target" in
+	aarch64-apple-ios | aarch64-apple-ios-sim | aarch64-apple-darwin)
+		printf '%s\n' arm64
+		;;
+	x86_64-apple-ios | x86_64-apple-darwin)
+		printf '%s\n' x86_64
+		;;
+	*)
+		printf '%s\n' "unsupported CPSL Apple Rust target: $target" >&2
+		return 1
+		;;
+	esac
+}
+
+cpsl_apple_request_print() {
+	apple_platforms=$1
+	ios_device_targets=$2
+	ios_simulator_targets=$3
+	macos_targets=$4
+	description=$5
+
+	pdfium_slices=
+	if [ -n "$ios_device_targets" ]; then
+		pdfium_slices=$(cpsl_apple_list_append_unique "$pdfium_slices" ios-arm64)
+	fi
+	if [ -n "$ios_simulator_targets" ]; then
+		pdfium_slices=$(cpsl_apple_list_append_unique "$pdfium_slices" ios-simulator)
+	fi
+	if [ -n "$macos_targets" ]; then
+		pdfium_slices=$(cpsl_apple_list_append_unique "$pdfium_slices" macos)
+	fi
+
+	printf 'APPLE_PLATFORMS=%s\n' "$(cpsl_apple_shell_quote "$apple_platforms")"
+	printf 'IOS_DEVICE_TARGETS=%s\n' "$(cpsl_apple_shell_quote "$ios_device_targets")"
+	printf 'IOS_SIMULATOR_TARGETS=%s\n' "$(cpsl_apple_shell_quote "$ios_simulator_targets")"
+	printf 'MACOS_TARGETS=%s\n' "$(cpsl_apple_shell_quote "$macos_targets")"
+	printf 'CPSL_PDFIUM_SLICES=%s\n' "$(cpsl_apple_shell_quote "$pdfium_slices")"
+	printf 'CPSL_REQUEST_DESCRIPTION=%s\n' "$(cpsl_apple_shell_quote "$description")"
+}
+
+cpsl_apple_request_from_xcode_env() {
+	platform=$(cpsl_apple_platform_from_xcode "${PLATFORM_NAME:-}" "${SDK_NAME:-}") || return 1
+	current_arch=$(cpsl_apple_xcode_current_arch)
+	archs=$(cpsl_apple_archs_from_xcode "${ARCHS:-}" "$current_arch") || return 1
+	apple_platforms=
+	ios_device_targets=
+	ios_simulator_targets=
+	macos_targets=
+
+	for arch in $archs; do
+		target=$(cpsl_apple_rust_target_for_platform_arch "$platform" "$arch") || return 1
+		case "$platform" in
+		iphoneos)
+			apple_platforms=$(cpsl_apple_list_append_unique "$apple_platforms" ios)
+			ios_device_targets=$(cpsl_apple_list_append_unique "$ios_device_targets" "$target")
+			;;
+		iphonesimulator)
+			apple_platforms=$(cpsl_apple_list_append_unique "$apple_platforms" ios)
+			ios_simulator_targets=$(cpsl_apple_list_append_unique "$ios_simulator_targets" "$target")
+			;;
+		macosx)
+			apple_platforms=$(cpsl_apple_list_append_unique "$apple_platforms" macos)
+			macos_targets=$(cpsl_apple_list_append_unique "$macos_targets" "$target")
+			;;
+		esac
+	done
+
+	cpsl_apple_request_print "$apple_platforms" "$ios_device_targets" "$ios_simulator_targets" "$macos_targets" "$platform $archs"
+}
+
+cpsl_apple_request_from_build_vars() {
+	apple_platforms=$1
+	ios_device_targets=$2
+	ios_simulator_targets=$3
+	macos_targets=$4
+	include_ios=0
+	include_macos=0
+	normalized_platforms=
+
+	[ -n "$apple_platforms" ] || {
+		printf '%s\n' "APPLE_PLATFORMS must not be empty" >&2
+		return 1
+	}
+
+	for platform in $apple_platforms; do
+		case "$platform" in
+		ios)
+			include_ios=1
+			normalized_platforms=$(cpsl_apple_list_append_unique "$normalized_platforms" ios)
+			;;
+		macos)
+			include_macos=1
+			normalized_platforms=$(cpsl_apple_list_append_unique "$normalized_platforms" macos)
+			;;
+		*)
+			printf '%s\n' "unsupported APPLE_PLATFORMS entry: $platform" >&2
+			return 1
+			;;
+		esac
+	done
+
+	[ "$include_ios" -eq 1 ] || [ "$include_macos" -eq 1 ] || {
+		printf '%s\n' "APPLE_PLATFORMS must include ios, macos, or both" >&2
+		return 1
+	}
+
+	if [ "$include_ios" -eq 0 ]; then
+		ios_device_targets=
+		ios_simulator_targets=
+	elif [ -z "$ios_device_targets" ] && [ -z "$ios_simulator_targets" ]; then
+		printf '%s\n' "IOS_DEVICE_TARGETS or IOS_SIMULATOR_TARGETS must be non-empty when APPLE_PLATFORMS includes ios" >&2
+		return 1
+	fi
+
+	if [ "$include_macos" -eq 0 ]; then
+		macos_targets=
+	elif [ -z "$macos_targets" ]; then
+		printf '%s\n' "MACOS_TARGETS must not be empty when APPLE_PLATFORMS includes macos" >&2
+		return 1
+	fi
+
+	for target in $ios_device_targets; do
+		category=$(cpsl_apple_category_for_rust_target "$target") || return 1
+		[ "$category" = ios_device ] || {
+			printf '%s\n' "IOS_DEVICE_TARGETS contains non-device target: $target" >&2
+			return 1
+		}
+	done
+	for target in $ios_simulator_targets; do
+		category=$(cpsl_apple_category_for_rust_target "$target") || return 1
+		[ "$category" = ios_simulator ] || {
+			printf '%s\n' "IOS_SIMULATOR_TARGETS contains non-simulator target: $target" >&2
+			return 1
+		}
+	done
+	for target in $macos_targets; do
+		category=$(cpsl_apple_category_for_rust_target "$target") || return 1
+		[ "$category" = macos ] || {
+			printf '%s\n' "MACOS_TARGETS contains non-macOS target: $target" >&2
+			return 1
+		}
+	done
+
+	cpsl_apple_request_print "$normalized_platforms" "$ios_device_targets" "$ios_simulator_targets" "$macos_targets" \
+		"$normalized_platforms; ios-device=$ios_device_targets; ios-simulator=$ios_simulator_targets; macos=$macos_targets"
+}
+
+cpsl_apple_has_xcode_selection() {
+	[ -n "${PLATFORM_NAME:-}" ] || [ -n "${SDK_NAME:-}" ]
+}
+
+cpsl_apple_request_from_environment() {
+	if cpsl_apple_has_xcode_selection; then
+		cpsl_apple_request_from_xcode_env
+		return $?
+	fi
+
+	cpsl_apple_request_from_build_vars \
+		"${APPLE_PLATFORMS-"ios macos"}" \
+		"${IOS_DEVICE_TARGETS-"aarch64-apple-ios"}" \
+		"${IOS_SIMULATOR_TARGETS-"aarch64-apple-ios-sim x86_64-apple-ios"}" \
+		"${MACOS_TARGETS-"aarch64-apple-darwin x86_64-apple-darwin"}"
+}
+
+cpsl_apple_cargo_profile_from_configuration() {
+	configuration=${1:-}
+
+	case "$configuration" in
+	Debug)
+		printf '%s\n' debug
+		;;
+	"" | Release)
+		printf '%s\n' release
+		;;
+	*)
+		printf '%s\n' "unsupported Xcode configuration for CPSL build: $configuration" >&2
+		return 1
+		;;
+	esac
+}
+
+cpsl_apple_cargo_profile_from_environment() {
+	cpsl_apple_cargo_profile_from_configuration "${CONFIGURATION:-}"
+}
+
+cpsl_apple_default_artifact_dir() {
+	work_dir=$1
+
+	if [ -n "${CONFIGURATION:-}" ]; then
+		printf '%s/artifacts/apple/%s' "$work_dir" "$CONFIGURATION"
+	else
+		printf '%s/artifacts/apple' "$work_dir"
+	fi
+}
+
+cpsl_xcframework_has_library_arch() {
+	info=$1
+	want_platform=$2
+	want_variant=$3
+	want_arch=$4
+
+	cpsl_xcframework_plist_tokens "$info" | awk -v want_platform="$want_platform" -v want_variant="$want_variant" -v want_arch="$want_arch" '
+		/<dict>/ {
+			depth++
+			if (depth == 2) {
+				platform = ""
+				variant = ""
+				arch = 0
+				in_arches = 0
+			}
+			next
+		}
+		depth == 2 && /<key>SupportedPlatform<\/key>/ {
+			getline
+			if ($0 ~ /<string>ios<\/string>/) {
+				platform = "ios"
+			} else if ($0 ~ /<string>macos<\/string>/ || $0 ~ /<string>macosx<\/string>/) {
+				platform = "macos"
+			}
+			next
+		}
+		depth == 2 && /<key>SupportedPlatformVariant<\/key>/ {
+			getline
+			if ($0 ~ /<string>simulator<\/string>/) {
+				variant = "simulator"
+			}
+			next
+		}
+		depth == 2 && /<key>SupportedArchitectures<\/key>/ {
+			in_arches = 1
+			next
+		}
+		depth == 2 && in_arches && /<\/array>/ {
+			in_arches = 0
+			next
+		}
+		depth == 2 && in_arches {
+			if ($0 ~ "<string>" want_arch "</string>") {
+				arch = 1
+			}
+			next
+		}
+		/<\/dict>/ {
+			if (depth == 2 && platform == want_platform && variant == want_variant && arch) {
+				found = 1
+			}
+			depth--
+			next
+		}
+		END {
+			exit found ? 0 : 1
+		}
+	'
+}
+
+cpsl_xcframework_library_identifier() {
+	info=$1
+	want_platform=$2
+	want_variant=$3
+
+	cpsl_xcframework_plist_tokens "$info" | awk -v want_platform="$want_platform" -v want_variant="$want_variant" '
+		/<dict>/ {
+			depth++
+			if (depth == 2) {
+				platform = ""
+				variant = ""
+				identifier = ""
+			}
+			next
+		}
+		depth == 2 && /<key>LibraryIdentifier<\/key>/ {
+			getline
+			identifier = $0
+			gsub(/.*<string>/, "", identifier)
+			gsub(/<\/string>.*/, "", identifier)
+			next
+		}
+		depth == 2 && /<key>SupportedPlatform<\/key>/ {
+			getline
+			if ($0 ~ /<string>ios<\/string>/) {
+				platform = "ios"
+			} else if ($0 ~ /<string>macos<\/string>/ || $0 ~ /<string>macosx<\/string>/) {
+				platform = "macos"
+			}
+			next
+		}
+		depth == 2 && /<key>SupportedPlatformVariant<\/key>/ {
+			getline
+			if ($0 ~ /<string>simulator<\/string>/) {
+				variant = "simulator"
+			}
+			next
+		}
+		/<\/dict>/ {
+			if (depth == 2 && platform == want_platform && variant == want_variant && identifier != "") {
+				print identifier
+				found = 1
+				exit
+			}
+			depth--
+			next
+		}
+		END {
+			exit found ? 0 : 1
+		}
+	'
+}
+
+cpsl_xcframework_library_identifier_for_category() {
+	info=$1
+	category=$2
+
+	case "$category" in
+	ios_device)
+		cpsl_xcframework_library_identifier "$info" ios ""
+		;;
+	ios_simulator)
+		cpsl_xcframework_library_identifier "$info" ios simulator
+		;;
+	macos)
+		cpsl_xcframework_library_identifier "$info" macos ""
+		;;
+	*)
+		printf '%s\n' "unsupported CPSL XCFramework category: $category" >&2
+		return 1
+		;;
+	esac
+}
+
+cpsl_xcframework_has_rust_target() {
+	info=$1
+	target=$2
+	category=$(cpsl_apple_category_for_rust_target "$target") || return 1
+	arch=$(cpsl_apple_arch_for_rust_target "$target") || return 1
+
+	case "$category" in
+	ios_device)
+		cpsl_xcframework_has_library_arch "$info" ios "" "$arch"
+		;;
+	ios_simulator)
+		cpsl_xcframework_has_library_arch "$info" ios simulator "$arch"
+		;;
+	macos)
+		cpsl_xcframework_has_library_arch "$info" macos "" "$arch"
+		;;
+	*)
+		return 1
+		;;
+	esac
+}
+
+cpsl_xcframework_satisfies_targets() {
+	info=$1
+	ios_device_targets=$2
+	ios_simulator_targets=$3
+	macos_targets=$4
+
+	for target in $ios_device_targets $ios_simulator_targets $macos_targets; do
+		cpsl_xcframework_has_rust_target "$info" "$target" || return 1
+	done
+
+	return 0
+}
+
+cpsl_pdfium_slice_for_rust_target() {
+	target=$1
+
+	case "$target" in
+	aarch64-apple-ios)
+		printf '%s\n' ios-arm64
+		;;
+	aarch64-apple-ios-sim | x86_64-apple-ios)
+		printf '%s\n' ios-simulator
+		;;
+	aarch64-apple-darwin | x86_64-apple-darwin)
+		printf '%s\n' macos
+		;;
+	*)
+		printf '%s\n' "unsupported CPSL Apple Rust target: $target" >&2
+		return 1
+		;;
+	esac
+}
+
+cpsl_pdfium_lipo_archs() {
+	file=$1
+
+	if [ -n "${CPSL_LIPO:-}" ]; then
+		"$CPSL_LIPO" -archs "$file"
+		return $?
+	fi
+
+	if command -v lipo >/dev/null 2>&1; then
+		lipo -archs "$file"
+		return $?
+	fi
+
+	return 127
+}
+
+cpsl_pdfium_binary_has_arch() {
+	file=$1
+	arch=$2
+
+	[ -f "$file" ] || return 1
+
+	if archs=$(cpsl_pdfium_lipo_archs "$file" 2>/dev/null); then
+		status=0
+	else
+		status=$?
+	fi
+	if [ "$status" -ne 0 ]; then
+		[ "$status" -eq 127 ] && return 0
+		return 1
+	fi
+
+	for found_arch in $archs; do
+		[ "$found_arch" = "$arch" ] && return 0
+	done
+
+	return 1
+}
+
+cpsl_pdfium_has_rust_target() {
+	pdfium_root=$1
+	target=$2
+	slice=$(cpsl_pdfium_slice_for_rust_target "$target") || return 1
+	arch=$(cpsl_apple_arch_for_rust_target "$target") || return 1
+	lib="$pdfium_root/$slice/lib/libpdfium.dylib"
+
+	cpsl_pdfium_binary_has_arch "$lib" "$arch"
+}
+
+cpsl_pdfium_satisfies_targets() {
+	pdfium_root=$1
+	ios_device_targets=$2
+	ios_simulator_targets=$3
+	macos_targets=$4
+
+	for target in $ios_device_targets $ios_simulator_targets $macos_targets; do
+		cpsl_pdfium_has_rust_target "$pdfium_root" "$target" || return 1
+	done
+
+	return 0
+}
+
+cpsl_xcframework_source_stamp_path() {
+	out_dir=$1
+	printf '%s/.cpsl-source.stamp' "$out_dir"
+}
+
+cpsl_xcframework_source_revision() {
+	source_root=$1
+
+	git -C "$source_root" rev-parse --verify HEAD 2>/dev/null || return 1
+}
+
+cpsl_xcframework_source_stamp_expected() {
+	source_root=$1
+	source_revision=$2
+	cargo_profile=${3:-}
+
+	source_path=$(CDPATH= cd "$source_root" && pwd -P) || return 1
+	printf 'source_path=%s\n' "$source_path"
+	printf 'source_revision=%s\n' "$source_revision"
+	if [ -n "$cargo_profile" ]; then
+		printf 'cargo_profile=%s\n' "$cargo_profile"
+	fi
+}
+
+cpsl_xcframework_write_source_stamp_value() {
+	stamp_path=$1
+	source_root=$2
+	source_revision=$3
+	cargo_profile=${4:-}
+
+	mkdir -p "$(dirname "$stamp_path")"
+	cpsl_xcframework_source_stamp_expected "$source_root" "$source_revision" "$cargo_profile" >"$stamp_path"
+}
+
+cpsl_xcframework_write_source_stamp() {
+	stamp_path=$1
+	source_root=$2
+	cargo_profile=${3:-}
+	source_revision=$(cpsl_xcframework_source_revision "$source_root") || return 1
+
+	cpsl_xcframework_write_source_stamp_value "$stamp_path" "$source_root" "$source_revision" "$cargo_profile"
+}
+
+cpsl_xcframework_source_stamp_matches_value() {
+	stamp_path=$1
+	source_root=$2
+	source_revision=$3
+	cargo_profile=${4:-}
+
+	[ -f "$stamp_path" ] || return 1
+	expected=$(cpsl_xcframework_source_stamp_expected "$source_root" "$source_revision" "$cargo_profile") || return 1
+	actual=$(cat "$stamp_path") || return 1
+	[ "$actual" = "$expected" ]
+}
+
+cpsl_xcframework_source_stamp_matches() {
+	stamp_path=$1
+	source_root=$2
+	cargo_profile=${3:-}
+	source_revision=$(cpsl_xcframework_source_revision "$source_root") || return 1
+
+	cpsl_xcframework_source_stamp_matches_value "$stamp_path" "$source_root" "$source_revision" "$cargo_profile"
+}
+
+cpsl_xcframework_has_ios_device() {
+	info=$1
+
+	cpsl_xcframework_plist_tokens "$info" | awk '
 		/<dict>/ {
 			platform = ""
 			variant = ""
@@ -35,14 +714,13 @@ cpsl_xcframework_has_ios_device() {
 		END {
 			exit found ? 0 : 1
 		}
-	' "$info"
+	'
 }
 
 cpsl_xcframework_has_ios_simulator() {
 	info=$1
 
-	[ -f "$info" ] || return 1
-	awk '
+	cpsl_xcframework_plist_tokens "$info" | awk '
 		/<dict>/ {
 			platform = ""
 			variant = ""
@@ -67,14 +745,13 @@ cpsl_xcframework_has_ios_simulator() {
 		END {
 			exit found ? 0 : 1
 		}
-	' "$info"
+	'
 }
 
 cpsl_xcframework_has_macos() {
 	info=$1
 
-	[ -f "$info" ] || return 1
-	awk '
+	cpsl_xcframework_plist_tokens "$info" | awk '
 		/<key>SupportedPlatform<\/key>/ {
 			getline
 			if ($0 ~ /<string>macos<\/string>/ || $0 ~ /<string>macosx<\/string>/) {
@@ -84,7 +761,7 @@ cpsl_xcframework_has_macos() {
 		END {
 			exit found ? 0 : 1
 		}
-	' "$info"
+	'
 }
 
 cpsl_xcframework_is_full() {
@@ -274,6 +951,7 @@ cpsl_xcframework_inputs_newer_than() {
 
 	for path in \
 		"$herm_root/scripts/build-cpsl-apple-xcframework.sh" \
+		"$herm_root/scripts/lib/cpsl-xcframework.sh" \
 		"$herm_root/scripts/apply-cpsl-patches.sh"
 	do
 		[ -f "$path" ] || continue

--- a/scripts/link-cpsl-xcframework-for-xcode.sh
+++ b/scripts/link-cpsl-xcframework-for-xcode.sh
@@ -7,8 +7,132 @@ herm_root=$(CDPATH= cd "$script_dir/.." && pwd -P)
 
 placeholder_dir="$herm_root/scripts/cpsl-xcframework-placeholder"
 link_path="$placeholder_dir/cpsl.xcframework"
-built_path="$herm_root/.herm-cpsl/artifacts/apple/cpsl.xcframework"
-link_stamp="$herm_root/.herm-cpsl/artifacts/apple/.xcode-linked-xcframework.stamp"
+work_dir=${CPSL_WORK_DIR:-"$herm_root/.herm-cpsl"}
+cargo_profile=$(cpsl_apple_cargo_profile_from_environment) || {
+	printf '%s\n' "error: failed to resolve CPSL Cargo profile" >&2
+	exit 1
+}
+out_dir=${OUT_DIR:-$(cpsl_apple_default_artifact_dir "$work_dir")}
+built_path="$out_dir/cpsl.xcframework"
+link_stamp="$out_dir/.xcode-linked-xcframework.stamp"
+tmp_dir=
+
+request_assignments=$(cpsl_apple_request_from_environment) || {
+	printf '%s\n' "error: failed to resolve CPSL Apple build targets" >&2
+	exit 1
+}
+eval "$request_assignments"
+ios_device_targets=$IOS_DEVICE_TARGETS
+ios_simulator_targets=$IOS_SIMULATOR_TARGETS
+macos_targets=$MACOS_TARGETS
+
+HERM_CPSL_FORCE_SUBMODULE=1
+export HERM_CPSL_FORCE_SUBMODULE
+unset CPSL_ROOT
+
+cpsl_xcode_cleanup() {
+	[ -n "${tmp_dir:-}" ] || return 0
+	rm -rf "$tmp_dir"
+}
+
+trap cpsl_xcode_cleanup EXIT HUP INT TERM
+
+cpsl_xcode_write_build_stamp() {
+	stamp_path=${SCRIPT_OUTPUT_FILE_0:-}
+
+	[ -n "$stamp_path" ] || return 0
+	mkdir -p "$(dirname "$stamp_path")"
+	printf '%s\n' "linked $(date -u '+%Y-%m-%dT%H:%M:%SZ')" >"$stamp_path"
+}
+
+cpsl_xcode_processed_dylib_is_placeholder() {
+	dylib=$1
+
+	[ -f "$dylib" ] || return 1
+
+	size=$(wc -c <"$dylib" | tr -d '[:space:]')
+	[ "${size:-0}" -lt 1024 ]
+}
+
+cpsl_xcode_processed_outputs_need_refresh() {
+	products_dir=${TARGET_BUILD_DIR:-}
+
+	[ -n "$products_dir" ] || return 1
+
+	dylib="$products_dir/libcpsl.dylib"
+	modulemap="$products_dir/include/module.modulemap"
+
+	[ -f "$modulemap" ] || return 0
+	cpsl_xcode_processed_dylib_is_placeholder "$dylib"
+}
+
+cpsl_xcode_invalidate_processed_outputs() {
+	products_dir=${TARGET_BUILD_DIR:-}
+
+	[ -n "$products_dir" ] || return 0
+
+	if [ -e "$products_dir/libcpsl.dylib" ] || [ -d "$products_dir/include" ]; then
+		printf 'Refreshing CPSL ProcessXCFramework outputs: %s\n' "$products_dir"
+	fi
+	rm -f "$products_dir/libcpsl.dylib"
+	rm -rf "$products_dir/include"
+}
+
+cpsl_xcode_publish_processed_outputs() {
+	products_dir=${TARGET_BUILD_DIR:-}
+	seen_categories=
+	published=0
+
+	[ -n "$products_dir" ] || return 0
+
+	for target in $ios_device_targets $ios_simulator_targets $macos_targets; do
+		category=$(cpsl_apple_category_for_rust_target "$target") || exit 1
+		case " $seen_categories " in
+		*" $category "*)
+			continue
+			;;
+		esac
+		slice_id=$(cpsl_xcode_placeholder_slice_for_category "$category") || exit 1
+		slice_dir="$link_path/$slice_id"
+
+		[ -d "$slice_dir" ] || {
+			printf '%s\n' "error: missing linked CPSL slice for publish: $slice_dir" >&2
+			exit 1
+		}
+		[ -f "$slice_dir/libcpsl.dylib" ] || {
+			printf '%s\n' "error: missing linked CPSL library for publish: $slice_dir/libcpsl.dylib" >&2
+			exit 1
+		}
+		[ -f "$slice_dir/Headers/cpsl.h" ] || {
+			printf '%s\n' "error: missing linked CPSL header for publish: $slice_dir/Headers/cpsl.h" >&2
+			exit 1
+		}
+		[ -f "$slice_dir/Headers/module.modulemap" ] || {
+			printf '%s\n' "error: missing linked CPSL module map for publish: $slice_dir/Headers/module.modulemap" >&2
+			exit 1
+		}
+
+		mkdir -p "$products_dir/include"
+		cp "$slice_dir/Headers/cpsl.h" "$products_dir/include/cpsl.h"
+		cp "$slice_dir/Headers/module.modulemap" "$products_dir/include/module.modulemap"
+		cp "$slice_dir/libcpsl.dylib" "$products_dir/.libcpsl.dylib.tmp"
+		mv "$products_dir/.libcpsl.dylib.tmp" "$products_dir/libcpsl.dylib"
+		seen_categories="${seen_categories:+$seen_categories }$category"
+		published=1
+	done
+
+	[ "$published" -eq 1 ] || {
+		printf '%s\n' "error: no CPSL slice to publish for current Xcode request" >&2
+		exit 1
+	}
+}
+
+cpsl_xcode_make_temp_dir() {
+	if [ -z "${tmp_dir:-}" ]; then
+		tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/herm-cpsl-xcode-link.XXXXXX")
+	fi
+	mkdir -p "$tmp_dir"
+}
 
 cpsl_xcode_file_metadata() {
 	path=$1
@@ -40,6 +164,18 @@ cpsl_xcode_artifact_fingerprint() {
 	)
 }
 
+cpsl_xcode_link_stamp_content() {
+	artifact_fingerprint=$1
+
+	printf 'IOS_DEVICE_TARGETS=%s\n' "$ios_device_targets"
+	printf 'IOS_SIMULATOR_TARGETS=%s\n' "$ios_simulator_targets"
+	printf 'MACOS_TARGETS=%s\n' "$macos_targets"
+	printf 'CARGO_PROFILE=%s\n' "$cargo_profile"
+	printf 'ARTIFACT_FINGERPRINT_BEGIN\n'
+	printf '%s\n' "$artifact_fingerprint"
+	printf 'ARTIFACT_FINGERPRINT_END\n'
+}
+
 cpsl_xcode_link_is_current() {
 	expected_fingerprint=$1
 	linked_info=$(cpsl_xcframework_info_plist "$link_path")
@@ -47,19 +183,260 @@ cpsl_xcode_link_is_current() {
 	[ -f "$link_stamp" ] || return 1
 	[ -d "$link_path" ] || return 1
 	cpsl_xcframework_is_placeholder "$link_path" && return 1
-	cpsl_xcframework_is_full "$linked_info" || return 1
+	cpsl_xcframework_satisfies_targets "$linked_info" "$ios_device_targets" "$ios_simulator_targets" "$macos_targets" || return 1
 
 	actual_fingerprint=$(cat "$link_stamp") || return 1
+	expected_fingerprint=$(cpsl_xcode_link_stamp_content "$expected_fingerprint")
 	[ "$actual_fingerprint" = "$expected_fingerprint" ]
+}
+
+cpsl_xcode_placeholder_slice_for_category() {
+	category=$1
+
+	case "$category" in
+	ios_device)
+		printf '%s\n' ios-arm64
+		;;
+	ios_simulator)
+		printf '%s\n' ios-arm64_x86_64-simulator
+		;;
+	macos)
+		printf '%s\n' macos-arm64_x86_64
+		;;
+	*)
+		printf '%s\n' "error: unsupported CPSL XCFramework category: $category" >&2
+		return 1
+		;;
+	esac
+}
+
+cpsl_xcode_lipo_archs() {
+	lib=$1
+
+	[ -f "$lib" ] || {
+		printf '%s\n' "error: missing library for lipo inspection: $lib" >&2
+		return 1
+	}
+
+	xcrun lipo -archs "$lib"
+}
+
+cpsl_xcode_stub_sdk_for_category() {
+	category=$1
+
+	case "$category" in
+	ios_simulator)
+		printf '%s\n' iphonesimulator
+		;;
+	macos)
+		printf '%s\n' macosx
+		;;
+	*)
+		printf '%s\n' "error: validation stubs are not supported for CPSL category: $category" >&2
+		return 1
+		;;
+	esac
+}
+
+cpsl_xcode_stub_min_flag_for_category() {
+	category=$1
+
+	case "$category" in
+	ios_simulator)
+		printf '%s\n' "-mios-simulator-version-min=${IPHONEOS_DEPLOYMENT_TARGET:-17.0}"
+		;;
+	macos)
+		printf '%s\n' "-mmacosx-version-min=${MACOSX_DEPLOYMENT_TARGET:-14.0}"
+		;;
+	*)
+		printf '%s\n' "error: validation stubs are not supported for CPSL category: $category" >&2
+		return 1
+		;;
+	esac
+}
+
+cpsl_xcode_create_validation_stub() {
+	category=$1
+	arch=$2
+	output=$3
+	sdk=$(cpsl_xcode_stub_sdk_for_category "$category") || exit 1
+	min_flag=$(cpsl_xcode_stub_min_flag_for_category "$category") || exit 1
+
+	cpsl_xcode_make_temp_dir
+	stub_source="$tmp_dir/cpsl-validation-stub.c"
+	printf '%s\n' 'int herm_cpsl_validation_stub(void) { return 0; }' >"$stub_source"
+
+	printf 'Creating CPSL validation stub (%s %s): %s\n' "$category" "$arch" "$output"
+	if ! xcrun --sdk "$sdk" clang -dynamiclib -arch "$arch" "$min_flag" \
+		-Wl,-install_name,@rpath/libcpsl.dylib \
+		"$stub_source" -o "$output"; then
+		printf '%s\n' "error: failed to create CPSL validation stub for $category $arch" >&2
+		exit 1
+	fi
+}
+
+cpsl_xcode_requested_arches_for_category() {
+	category=$1
+	targets=
+
+	case "$category" in
+	ios_device)
+		targets=$ios_device_targets
+		;;
+	ios_simulator)
+		targets=$ios_simulator_targets
+		;;
+	macos)
+		targets=$macos_targets
+		;;
+	*)
+		printf '%s\n' "error: unsupported CPSL XCFramework category: $category" >&2
+		return 1
+		;;
+	esac
+
+	arches=
+	for target in $targets; do
+		arch=$(cpsl_apple_arch_for_rust_target "$target") || return 1
+		arches=$(cpsl_apple_list_append_unique "$arches" "$arch")
+	done
+	printf '%s\n' "$arches"
+}
+
+cpsl_xcode_placeholder_arches_for_category() {
+	category=$1
+
+	case "$category" in
+	ios_device)
+		printf '%s\n' arm64
+		;;
+	ios_simulator | macos)
+		printf '%s\n' "arm64 x86_64"
+		;;
+	*)
+		printf '%s\n' "error: unsupported CPSL XCFramework category: $category" >&2
+		return 1
+		;;
+	esac
+}
+
+cpsl_xcode_make_overlay_validation_safe() {
+	category=$1
+	lib=$2
+	requested_arches=$(cpsl_xcode_requested_arches_for_category "$category") || exit 1
+	placeholder_arches=$(cpsl_xcode_placeholder_arches_for_category "$category") || exit 1
+	lib_arches=$(cpsl_xcode_lipo_archs "$lib") || {
+		printf '%s\n' "error: failed to inspect CPSL overlay library architectures: $lib" >&2
+		exit 1
+	}
+
+	for arch in $requested_arches; do
+		cpsl_xcode_arch_list_contains "$lib_arches" "$arch" || {
+			printf '%s\n' "error: CPSL built library is missing requested architecture $arch: $lib" >&2
+			exit 1
+		}
+	done
+
+	missing_arches=
+	for arch in $placeholder_arches; do
+		if ! cpsl_xcode_arch_list_contains "$lib_arches" "$arch"; then
+			missing_arches="${missing_arches:+$missing_arches }$arch"
+		fi
+	done
+	[ -n "$missing_arches" ] || return 0
+
+	if [ "$category" = ios_device ]; then
+		printf '%s\n' "error: CPSL iOS device overlay is missing required architecture(s): $missing_arches" >&2
+		exit 1
+	fi
+
+	cpsl_xcode_make_temp_dir
+	set -- "$lib"
+	for arch in $missing_arches; do
+		stub_lib="$tmp_dir/libcpsl-$category-$arch-validation-stub.dylib"
+		cpsl_xcode_create_validation_stub "$category" "$arch" "$stub_lib"
+		set -- "$@" "$stub_lib"
+	done
+
+	universal_lib="$tmp_dir/libcpsl-$category-validation-safe.dylib"
+	if ! xcrun lipo -create "$@" -output "$universal_lib"; then
+		printf '%s\n' "error: failed to combine CPSL overlay library with validation stub(s): $lib" >&2
+		exit 1
+	fi
+	cp "$universal_lib" "$lib"
+}
+
+cpsl_xcode_overlay_built_slice() {
+	category=$1
+	built_info=$(cpsl_xcframework_info_plist "$built_path")
+	source_id=$(cpsl_xcframework_library_identifier_for_category "$built_info" "$category") || {
+		printf '%s\n' "error: built CPSL XCFramework does not contain $category" >&2
+		exit 1
+	}
+	dest_id=$(cpsl_xcode_placeholder_slice_for_category "$category") || exit 1
+	source_dir="$built_path/$source_id"
+	dest_dir="$link_path/$dest_id"
+	dest_lib_tmp="$dest_dir/.libcpsl.dylib.tmp.$$"
+
+	[ -d "$source_dir" ] || {
+		printf '%s\n' "error: missing built CPSL XCFramework slice: $source_dir" >&2
+		exit 1
+	}
+	[ -d "$dest_dir" ] || {
+		printf '%s\n' "error: missing linked CPSL placeholder slice: $dest_dir" >&2
+		exit 1
+	}
+
+	cpsl_xcode_make_temp_dir
+	prepared_dir="$tmp_dir/prepared-$dest_id"
+	rm -rf "$prepared_dir"
+	cp -R "$source_dir" "$prepared_dir"
+	cpsl_xcode_make_overlay_validation_safe "$category" "$prepared_dir/libcpsl.dylib"
+
+	mkdir -p "$dest_dir/Headers"
+	cp "$prepared_dir/Headers/cpsl.h" "$dest_dir/Headers/cpsl.h"
+	if [ -f "$prepared_dir/Headers/module.modulemap" ]; then
+		cp "$prepared_dir/Headers/module.modulemap" "$dest_dir/Headers/module.modulemap"
+	fi
+	cp "$prepared_dir/libcpsl.dylib" "$dest_lib_tmp"
+	mv "$dest_lib_tmp" "$dest_dir/libcpsl.dylib"
+}
+
+cpsl_xcode_overlay_requested_slices() {
+	seen_categories=
+	overlaid=0
+
+	for target in $ios_device_targets $ios_simulator_targets $macos_targets; do
+		category=$(cpsl_apple_category_for_rust_target "$target") || exit 1
+		case " $seen_categories " in
+		*" $category "*)
+			continue
+			;;
+		esac
+		cpsl_xcode_overlay_built_slice "$category"
+		seen_categories="${seen_categories:+$seen_categories }$category"
+		overlaid=1
+	done
+
+	[ "$overlaid" -eq 1 ] || {
+		printf '%s\n' "error: no CPSL XCFramework slices requested for overlay" >&2
+		exit 1
+	}
+	rm -f "$(cpsl_xcframework_placeholder_marker "$link_path")"
 }
 
 cpsl_xcframework_remove_stray_links "$placeholder_dir" "$link_path"
 
+# Xcode may run ProcessXCFramework before this script in the dependency target.
+# Clear placeholder extracts early so the app target reprocesses after linking.
+if cpsl_xcode_processed_outputs_need_refresh; then
+	cpsl_xcode_invalidate_processed_outputs
+fi
+
 # Xcode validates the linked XCFramework path before any build phase runs, so a
 # tracked bootstrap directory must exist on fresh clones. Locally, repair broken
 # symlinks or non-directory contents before building the real artifact. Existing
-# directories may be either the bootstrap placeholder or a prior full local copy;
-# stale directories are replaced after the cached artifact is validated.
+# directories may be either the bootstrap placeholder or a prior local copy.
 if [ -L "$link_path" ]; then
 	if [ ! -e "$link_path" ]; then
 		rm "$link_path"
@@ -68,7 +445,10 @@ if [ -L "$link_path" ]; then
 elif [ ! -e "$link_path" ]; then
 	"$herm_root/scripts/bootstrap-cpsl-xcframework-placeholder.sh"
 elif [ -d "$link_path" ]; then
-	:
+	linked_info=$(cpsl_xcframework_info_plist "$link_path")
+	if ! cpsl_xcframework_is_full "$linked_info"; then
+		"$herm_root/scripts/bootstrap-cpsl-xcframework-placeholder.sh"
+	fi
 elif [ -e "$link_path" ]; then
 	rm -rf "$link_path"
 	"$herm_root/scripts/bootstrap-cpsl-xcframework-placeholder.sh"
@@ -87,19 +467,14 @@ built_fingerprint=$(cpsl_xcode_artifact_fingerprint "$built_path") || {
 
 if cpsl_xcode_link_is_current "$built_fingerprint"; then
 	printf 'Using linked CPSL XCFramework: %s\n' "$link_path"
-	exit 0
-fi
-
-if [ -d "$link_path" ] && cpsl_xcframework_is_placeholder "$link_path"; then
+else
+	"$herm_root/scripts/bootstrap-cpsl-xcframework-placeholder.sh"
+	cpsl_xcode_overlay_requested_slices
 	cpsl_xcframework_set_skip_worktree "$herm_root"
+	mkdir -p "$(dirname "$link_stamp")"
+	cpsl_xcode_link_stamp_content "$built_fingerprint" >"$link_stamp"
+	printf 'Linked CPSL XCFramework: %s\n' "$link_path"
 fi
 
-if [ -L "$link_path" ]; then
-	rm "$link_path"
-elif [ -e "$link_path" ]; then
-	rm -rf "$link_path"
-fi
-cp -R "$built_path" "$link_path"
-mkdir -p "$(dirname "$link_stamp")"
-printf '%s\n' "$built_fingerprint" >"$link_stamp"
-printf 'Linked CPSL XCFramework: %s\n' "$link_path"
+cpsl_xcode_publish_processed_outputs
+cpsl_xcode_write_build_stamp

--- a/scripts/test-cpsl-xcframework.sh
+++ b/scripts/test-cpsl-xcframework.sh
@@ -1,0 +1,231 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd -P)
+. "$script_dir/lib/cpsl-xcframework.sh"
+
+fail() {
+	printf '%s\n' "error: $*" >&2
+	exit 1
+}
+
+assert_eq() {
+	name=$1
+	want=$2
+	got=$3
+
+	[ "$want" = "$got" ] || fail "$name: expected '$want', got '$got'"
+}
+
+resolve_xcode_request() (
+	PLATFORM_NAME=$1
+	SDK_NAME=$2
+	ARCHS=$3
+	export PLATFORM_NAME SDK_NAME ARCHS
+	unset APPLE_PLATFORMS IOS_DEVICE_TARGETS IOS_SIMULATOR_TARGETS MACOS_TARGETS CURRENT_ARCH NATIVE_ARCH_ACTUAL
+	cpsl_apple_request_from_environment
+)
+
+resolve_xcode_request_with_native_arch() (
+	PLATFORM_NAME=$1
+	SDK_NAME=$2
+	NATIVE_ARCH_ACTUAL=$3
+	export PLATFORM_NAME SDK_NAME NATIVE_ARCH_ACTUAL
+	unset ARCHS APPLE_PLATFORMS IOS_DEVICE_TARGETS IOS_SIMULATOR_TARGETS MACOS_TARGETS CURRENT_ARCH
+	cpsl_apple_request_from_environment
+)
+
+resolve_xcode_request_with_undefined_current_arch() (
+	PLATFORM_NAME=$1
+	SDK_NAME=$2
+	CURRENT_ARCH=undefined_arch
+	NATIVE_ARCH_ACTUAL=$3
+	export PLATFORM_NAME SDK_NAME CURRENT_ARCH NATIVE_ARCH_ACTUAL
+	unset ARCHS APPLE_PLATFORMS IOS_DEVICE_TARGETS IOS_SIMULATOR_TARGETS MACOS_TARGETS
+	cpsl_apple_request_from_environment
+)
+
+request=$(resolve_xcode_request iphonesimulator iphonesimulator17.0 arm64)
+eval "$request"
+assert_eq "sim arm64 apple platforms" ios "$APPLE_PLATFORMS"
+assert_eq "sim arm64 device targets" "" "$IOS_DEVICE_TARGETS"
+assert_eq "sim arm64 simulator targets" aarch64-apple-ios-sim "$IOS_SIMULATOR_TARGETS"
+assert_eq "sim arm64 PDFium" ios-simulator "$CPSL_PDFIUM_SLICES"
+
+request=$(resolve_xcode_request iphonesimulator iphonesimulator17.0 "arm64 x86_64")
+eval "$request"
+assert_eq "sim universal targets" "aarch64-apple-ios-sim x86_64-apple-ios" "$IOS_SIMULATOR_TARGETS"
+assert_eq "sim universal PDFium" ios-simulator "$CPSL_PDFIUM_SLICES"
+
+request=$(resolve_xcode_request iphoneos iphoneos17.0 arm64)
+eval "$request"
+assert_eq "device target" aarch64-apple-ios "$IOS_DEVICE_TARGETS"
+assert_eq "device PDFium" ios-arm64 "$CPSL_PDFIUM_SLICES"
+
+request=$(resolve_xcode_request macosx macosx14.0 x86_64)
+eval "$request"
+assert_eq "macOS target" x86_64-apple-darwin "$MACOS_TARGETS"
+assert_eq "macOS PDFium" macos "$CPSL_PDFIUM_SLICES"
+
+request=$(resolve_xcode_request_with_native_arch macosx macosx14.0 arm64)
+eval "$request"
+assert_eq "native arch fallback macOS target" aarch64-apple-darwin "$MACOS_TARGETS"
+
+request=$(resolve_xcode_request_with_undefined_current_arch macosx macosx14.0 arm64)
+eval "$request"
+assert_eq "undefined current arch fallback macOS target" aarch64-apple-darwin "$MACOS_TARGETS"
+
+if resolve_xcode_request iphoneos iphoneos17.0 x86_64 >/dev/null 2>&1; then
+	fail "iphoneos x86_64 should be rejected"
+fi
+
+request=$(cpsl_apple_request_from_build_vars ios "" aarch64-apple-ios-sim "")
+eval "$request"
+assert_eq "manual sim-only device targets" "" "$IOS_DEVICE_TARGETS"
+assert_eq "manual sim-only simulator targets" aarch64-apple-ios-sim "$IOS_SIMULATOR_TARGETS"
+
+request=$(cpsl_apple_request_from_build_vars macos aarch64-apple-ios aarch64-apple-ios-sim aarch64-apple-darwin)
+eval "$request"
+assert_eq "manual mac-only platforms" macos "$APPLE_PLATFORMS"
+assert_eq "manual mac-only ignores iOS device" "" "$IOS_DEVICE_TARGETS"
+assert_eq "manual mac-only ignores iOS simulator" "" "$IOS_SIMULATOR_TARGETS"
+assert_eq "manual mac-only target" aarch64-apple-darwin "$MACOS_TARGETS"
+
+assert_eq "debug configuration cargo profile" debug "$(cpsl_apple_cargo_profile_from_configuration Debug)"
+assert_eq "release configuration cargo profile" release "$(cpsl_apple_cargo_profile_from_configuration Release)"
+assert_eq "default cargo profile" release "$(cpsl_apple_cargo_profile_from_configuration "")"
+if cpsl_apple_cargo_profile_from_configuration Staging >/dev/null 2>&1; then
+	fail "unsupported configuration should be rejected"
+fi
+
+artifact_dir=$(CONFIGURATION=Debug cpsl_apple_default_artifact_dir /tmp/cpsl-work)
+assert_eq "debug artifact dir" /tmp/cpsl-work/artifacts/apple/Debug "$artifact_dir"
+artifact_dir=$(CONFIGURATION=Release cpsl_apple_default_artifact_dir /tmp/cpsl-work)
+assert_eq "release artifact dir" /tmp/cpsl-work/artifacts/apple/Release "$artifact_dir"
+artifact_dir=$(unset CONFIGURATION; cpsl_apple_default_artifact_dir /tmp/cpsl-work)
+assert_eq "manual artifact dir" /tmp/cpsl-work/artifacts/apple "$artifact_dir"
+
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/cpsl-xcframework-test.XXXXXX")
+trap 'rm -rf "$tmp_dir"' EXIT HUP INT TERM
+info="$tmp_dir/Info.plist"
+cat >"$info" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+<key>AvailableLibraries</key>
+<array>
+<dict>
+<key>LibraryIdentifier</key>
+<string>ios-arm64-simulator</string>
+<key>SupportedArchitectures</key>
+<array>
+<string>arm64</string>
+</array>
+<key>SupportedPlatform</key>
+<string>ios</string>
+<key>SupportedPlatformVariant</key>
+<string>simulator</string>
+</dict>
+<dict>
+<key>LibraryIdentifier</key>
+<string>macos-x86_64</string>
+<key>SupportedArchitectures</key>
+<array>
+<string>x86_64</string>
+</array>
+<key>SupportedPlatform</key>
+<string>macos</string>
+</dict>
+</array>
+</dict>
+</plist>
+EOF
+
+cpsl_xcframework_satisfies_targets "$info" "" "aarch64-apple-ios-sim" "" || \
+	fail "Info.plist should satisfy arm64 simulator"
+cpsl_xcframework_satisfies_targets "$info" "" "" "x86_64-apple-darwin" || \
+	fail "Info.plist should satisfy x86_64 macOS"
+if cpsl_xcframework_satisfies_targets "$info" "" "x86_64-apple-ios" ""; then
+	fail "Info.plist should not satisfy x86_64 simulator"
+fi
+if cpsl_xcframework_satisfies_targets "$info" "aarch64-apple-ios" "" ""; then
+	fail "Info.plist should not satisfy iOS device"
+fi
+
+compact_info="$tmp_dir/CompactInfo.plist"
+cat >"$compact_info" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict><key>AvailableLibraries</key><array>
+<dict><key>LibraryIdentifier</key><string>macos-arm64_x86_64</string><key>SupportedArchitectures</key><array><string>arm64</string><string>x86_64</string></array><key>SupportedPlatform</key><string>macos</string></dict>
+<dict><key>LibraryIdentifier</key><string>ios-arm64_x86_64-simulator</string><key>SupportedArchitectures</key><array><string>arm64</string><string>x86_64</string></array><key>SupportedPlatform</key><string>ios</string><key>SupportedPlatformVariant</key><string>simulator</string></dict>
+<dict><key>LibraryIdentifier</key><string>ios-arm64</string><key>SupportedArchitectures</key><array><string>arm64</string></array><key>SupportedPlatform</key><string>ios</string></dict>
+</array></dict></plist>
+EOF
+cpsl_xcframework_is_full "$compact_info" || \
+	fail "compact Info.plist should satisfy full XCFramework checks"
+cpsl_xcframework_satisfies_targets "$compact_info" "aarch64-apple-ios" "aarch64-apple-ios-sim x86_64-apple-ios" "aarch64-apple-darwin x86_64-apple-darwin" || \
+	fail "compact Info.plist should satisfy all Apple targets"
+
+source_a="$tmp_dir/source-a"
+source_b="$tmp_dir/source-b"
+mkdir -p "$source_a" "$source_b"
+stamp="$tmp_dir/source.stamp"
+cpsl_xcframework_write_source_stamp_value "$stamp" "$source_a" rev-a
+cpsl_xcframework_source_stamp_matches_value "$stamp" "$source_a" rev-a || \
+	fail "source stamp should match same source and revision"
+if cpsl_xcframework_source_stamp_matches_value "$stamp" "$source_b" rev-a; then
+	fail "source stamp should reject different source path"
+fi
+if cpsl_xcframework_source_stamp_matches_value "$stamp" "$source_a" rev-b; then
+	fail "source stamp should reject different source revision"
+fi
+cpsl_xcframework_write_source_stamp_value "$stamp" "$source_a" rev-a debug
+cpsl_xcframework_source_stamp_matches_value "$stamp" "$source_a" rev-a debug || \
+	fail "source stamp should match same Cargo profile"
+if cpsl_xcframework_source_stamp_matches_value "$stamp" "$source_a" rev-a release; then
+	fail "source stamp should reject different Cargo profile"
+fi
+
+lipo_stub="$tmp_dir/lipo"
+cat >"$lipo_stub" <<'EOF'
+#!/bin/sh
+if [ "$1" != "-archs" ]; then
+	exit 2
+fi
+cat "$2"
+EOF
+chmod +x "$lipo_stub"
+pdfium_root="$tmp_dir/pdfium"
+mkdir -p \
+	"$pdfium_root/ios-arm64/lib" \
+	"$pdfium_root/ios-simulator/lib" \
+	"$pdfium_root/macos/lib"
+printf '%s\n' arm64 >"$pdfium_root/ios-arm64/lib/libpdfium.dylib"
+printf '%s\n' arm64 >"$pdfium_root/ios-simulator/lib/libpdfium.dylib"
+printf '%s\n' x86_64 >"$pdfium_root/macos/lib/libpdfium.dylib"
+CPSL_LIPO=$lipo_stub
+export CPSL_LIPO
+cpsl_pdfium_satisfies_targets "$pdfium_root" "aarch64-apple-ios" "aarch64-apple-ios-sim" "x86_64-apple-darwin" || \
+	fail "PDFium should satisfy requested archs"
+if cpsl_pdfium_satisfies_targets "$pdfium_root" "" "x86_64-apple-ios" ""; then
+	fail "PDFium should reject missing simulator x86_64"
+fi
+if cpsl_pdfium_satisfies_targets "$pdfium_root" "" "" "aarch64-apple-darwin"; then
+	fail "PDFium should reject missing macOS arm64"
+fi
+unset CPSL_LIPO
+
+cpsl_xcode_arch_list_contains arm64 arm64 || fail "arch list should contain arm64"
+if cpsl_xcode_arch_list_contains arm64 x86_64; then
+	fail "arch list should not contain x86_64"
+fi
+missing_arches=
+lib_arches=arm64
+for arch in arm64 x86_64; do
+	if ! cpsl_xcode_arch_list_contains "$lib_arches" "$arch"; then
+		missing_arches="${missing_arches:+$missing_arches }$arch"
+	fi
+done
+assert_eq "missing placeholder arches" x86_64 "$missing_arches"
+
+printf '%s\n' "CPSL XCFramework helper tests passed"


### PR DESCRIPTION
## Summary
- replace the CPSL aggregate preflight with a native Xcode dependency target so the helper inherits the app build platform, architectures, and configuration before Swift compilation
- derive CPSL Rust targets and PDFium sidecars from the active Xcode destination, build only the requested slices, and keep Debug/Release artifacts separated by Cargo profile and source stamp
- keep the linked XCFramework placeholder validation-safe while overlaying requested slices for Xcode, then restore the bootstrap placeholder after the PDFium copy phase
- document the configuration-aware Xcode workflow and add shell coverage for target resolution, artifact matching, source stamps, and PDFium slice validation

## Testing
- sh scripts/test-cpsl-xcframework.sh
- sh -n scripts/lib/cpsl-xcframework.sh
- sh -n scripts/build-cpsl-apple-xcframework.sh
- sh -n scripts/ensure-cpsl-apple-xcframework.sh
- sh -n scripts/link-cpsl-xcframework-for-xcode.sh
- sh -n scripts/copy-cpsl-pdfium-for-xcode.sh
- sh -n scripts/dev-apple-macos.sh
- sh -n scripts/dev-apple-ios.sh
- git diff --check
- pre-commit hooks on commit