### PR TITLE
Add voice dictation to the composer (iOS & macOS)

### DIFF
--- a/app/apple/herm.xcodeproj/project.pbxproj
+++ b/app/apple/herm.xcodeproj/project.pbxproj
@@ -477,6 +477,8 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Herm uses the microphone to let you dictate your message.";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Herm uses speech recognition to turn your dictation into text.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
@@ -527,6 +529,8 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Herm uses the microphone to let you dictate your message.";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Herm uses speech recognition to turn your dictation into text.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;

--- a/app/apple/herm/Models/CPSLChatModel.swift
+++ b/app/apple/herm/Models/CPSLChatModel.swift
@@ -25,6 +25,7 @@ final class CPSLChatModel: ObservableObject {
     @Published private(set) var filePreview: CPSLFilePreview?
 
     let service = CPSLDebugService()
+    let dictation = CPSLDictationService()
     private var store: CPSLConversationStore?
     private var storeLoadTask: Task<CPSLConversationStore, Error>?
     var currentNodeID: String?
@@ -128,6 +129,7 @@ final class CPSLChatModel: ObservableObject {
             return
         }
 
+        dictation.cancel()
         promptText = ""
         isFileBrowserOpen = false
         filePreview = nil

--- a/app/apple/herm/Services/CPSLAppleSpeechRecognizer.swift
+++ b/app/apple/herm/Services/CPSLAppleSpeechRecognizer.swift
@@ -1,0 +1,137 @@
+@preconcurrency import AVFoundation
+import Foundation
+import Speech
+
+/// On-device voice-to-text via Apple's Speech framework.
+@MainActor
+final class CPSLAppleSpeechRecognizer: CPSLSpeechRecognizer {
+    private var transcriber: SpeechTranscriber?
+    private var analyzer: SpeechAnalyzer?
+    private var negotiatedLocale: (spokenID: String, locale: Locale)?
+    private var modelReadySpokenID: String?
+
+    // Locale.current is negotiated against the bundle's localizations (en only),
+    // so it forces English regardless of the spoken language. Use the user's
+    // actual system language preference instead.
+    private var spokenID: String {
+        Locale.preferredLanguages.first ?? Locale.current.identifier
+    }
+
+    func authorize() async throws {
+        guard await requestAuthorization() else {
+            throw CPSLDictationError.notAuthorized
+        }
+    }
+
+    func modelNeedsDownload() async throws -> Bool {
+        let spokenID = spokenID
+        if modelReadySpokenID == spokenID {
+            return false
+        }
+        let locale = try await resolveLocale(for: spokenID)
+        try await AssetInventory.reserve(locale: locale)
+        let installed = await SpeechTranscriber.installedLocales
+        if installed.contains(where: { $0.identifier(.bcp47) == locale.identifier(.bcp47) }) {
+            modelReadySpokenID = spokenID
+            return false
+        }
+        return true
+    }
+
+    func installModel() async throws {
+        let spokenID = spokenID
+        let locale = try await resolveLocale(for: spokenID)
+        let request = try await AssetInventory.assetInstallationRequest(
+            supporting: [makeTranscriber(locale: locale)]
+        )
+        try await request?.downloadAndInstall()
+        modelReadySpokenID = spokenID
+    }
+
+    func prepare() async throws -> AVAudioFormat {
+        let locale = try await resolveLocale(for: spokenID)
+        let transcriber = makeTranscriber(locale: locale)
+        self.transcriber = transcriber
+
+        guard let format = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: [transcriber]) else {
+            throw CPSLDictationError.unavailable
+        }
+        self.analyzer = SpeechAnalyzer(modules: [transcriber])
+        return format
+    }
+
+    func transcribe(_ audio: AsyncStream<AVAudioPCMBuffer>) -> AsyncThrowingStream<String, Error> {
+        AsyncThrowingStream { continuation in
+            let work = Task { @MainActor in
+                guard let transcriber = self.transcriber, let analyzer = self.analyzer else {
+                    continuation.finish(throwing: CPSLDictationError.unavailable)
+                    return
+                }
+
+                // Read results before start so no early result is missed.
+                let results = Task { @MainActor in
+                    var finalized = ""
+                    for try await result in transcriber.results {
+                        let text = String(result.text.characters)
+                        if result.isFinal {
+                            finalized += text
+                            continuation.yield(finalized)
+                        } else {
+                            continuation.yield(finalized + text)
+                        }
+                    }
+                }
+
+                defer {
+                    results.cancel()
+                }
+
+                do {
+                    try await analyzer.start(inputSequence: audio.map { AnalyzerInput(buffer: $0) })
+                    try await results.value
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in work.cancel() }
+        }
+    }
+
+    func finish() async {
+        let analyzer = analyzer
+        self.analyzer = nil
+        transcriber = nil
+        try? await analyzer?.finalizeAndFinishThroughEndOfInput()
+    }
+
+    private func requestAuthorization() async -> Bool {
+        await withCheckedContinuation { continuation in
+            SFSpeechRecognizer.requestAuthorization { status in
+                continuation.resume(returning: status == .authorized)
+            }
+        }
+    }
+
+    private func makeTranscriber(locale: Locale) -> SpeechTranscriber {
+        SpeechTranscriber(
+            locale: locale,
+            transcriptionOptions: [],
+            reportingOptions: [.volatileResults, .fastResults],
+            attributeOptions: []
+        )
+    }
+
+    private func resolveLocale(for spokenID: String) async throws -> Locale {
+        if let negotiated = negotiatedLocale, negotiated.spokenID == spokenID {
+            return negotiated.locale
+        }
+        guard let locale = await SpeechTranscriber.supportedLocale(
+            equivalentTo: Locale(identifier: spokenID)
+        ) else {
+            throw CPSLDictationError.localeUnsupported
+        }
+        negotiatedLocale = (spokenID, locale)
+        return locale
+    }
+}

--- a/app/apple/herm/Services/CPSLDictationService.swift
+++ b/app/apple/herm/Services/CPSLDictationService.swift
@@ -1,0 +1,362 @@
+import Accelerate
+@preconcurrency import AVFoundation
+import Foundation
+import Observation
+
+enum CPSLDictationState {
+    case idle
+    /// Permissions and model checks; capture hasn't started.
+    case preparing
+    /// First use of a language; capture hasn't started.
+    case downloadingModel
+    case recording
+    /// Capture stopped, transcription finalizing.
+    case finishing
+}
+
+/// Drives dictation: mic capture, waveform levels and state. Delegates
+/// voice-to-text to an injected `CPSLSpeechRecognizer`.
+@MainActor
+@Observable
+final class CPSLDictationService {
+    private var isSimulator: Bool {
+#if targetEnvironment(simulator)
+        true
+#else
+        false
+#endif
+    }
+
+    private var microphoneDenied: Bool {
+#if os(macOS)
+        let micStatus = AVCaptureDevice.authorizationStatus(for: .audio)
+        return micStatus == .denied || micStatus == .restricted
+#else
+        return AVAudioApplication.shared.recordPermission == .denied
+#endif
+    }
+
+    private(set) var state: CPSLDictationState = .idle
+    private(set) var transcript = ""
+    private(set) var levels: [Float] = []
+    var errorMessage: String?
+
+    var isActive: Bool {
+        state != .idle
+    }
+
+    private static let audioQueue = DispatchQueue(label: "CPSLDictationService.audio")
+
+    @ObservationIgnored private let recognizer: any CPSLSpeechRecognizer
+    @ObservationIgnored private let maxLevels = 256
+    @ObservationIgnored private var audioEngine: AVAudioEngine?
+    @ObservationIgnored private var audioContinuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
+    @ObservationIgnored private var levelContinuation: AsyncStream<Float>.Continuation?
+    @ObservationIgnored private var transcriptTask: Task<Void, Never>?
+    @ObservationIgnored private var levelTask: Task<Void, Never>?
+    @ObservationIgnored private var startTask: Task<Void, Never>?
+
+    init(recognizer: (any CPSLSpeechRecognizer)? = nil) {
+        self.recognizer = recognizer ?? CPSLAppleSpeechRecognizer()
+    }
+
+    func start() {
+        guard state == .idle else {
+            return
+        }
+        guard !isSimulator else {
+            errorMessage = CPSLDictationError.simulatorUnsupported.errorDescription
+            return
+        }
+        guard !microphoneDenied else {
+            errorMessage = CPSLDictationError.notAuthorized.errorDescription
+            return
+        }
+        state = .preparing
+        errorMessage = nil
+        transcript = ""
+        levels = []
+        startTask = Task {
+            do {
+                try await beginRecording()
+            } catch {
+                if !(error is CancellationError) {
+                    self.errorMessage = (error as? CPSLDictationError)?.errorDescription
+                        ?? error.localizedDescription
+                }
+                self.abort()
+            }
+        }
+    }
+
+    /// Stops capture but lets transcription finalize so the complete text lands
+    /// in `transcript` before the session closes. Use when keeping the result.
+    func finish() {
+        switch state {
+        case .idle, .finishing:
+            return
+        case .preparing, .downloadingModel:
+            cancel()
+            return
+        case .recording:
+            break
+        }
+        state = .finishing
+        stopCapture()
+        let recognizer = recognizer
+        Task { [weak self] in
+            await self?.startTask?.value
+            self?.startTask = nil
+            await recognizer.finish()
+            await self?.transcriptTask?.value
+            self?.transcriptTask = nil
+            self?.state = .idle
+        }
+    }
+
+    func cancel() {
+        guard isActive else {
+            return
+        }
+        abort()
+    }
+
+    private func beginRecording() async throws {
+        guard await requestMicrophoneAccess() else {
+            throw CPSLDictationError.notAuthorized
+        }
+        try await recognizer.authorize()
+
+        if try await recognizer.modelNeedsDownload() {
+            state = .downloadingModel
+            try await recognizer.installModel()
+        }
+
+        guard isActive, !Task.isCancelled else {
+            return
+        }
+
+        let (audioStream, audioContinuation) = AsyncStream<AVAudioPCMBuffer>.makeStream()
+        self.audioContinuation = audioContinuation
+
+        let (levelStream, levelContinuation) = AsyncStream<Float>.makeStream(
+            bufferingPolicy: .bufferingNewest(maxLevels)
+        )
+        self.levelContinuation = levelContinuation
+        levelTask = Task { [weak self] in
+            for await value in levelStream {
+                guard let self else {
+                    return
+                }
+                levels.append(value)
+                if levels.count > maxLevels {
+                    levels.removeFirst(levels.count - maxLevels)
+                }
+            }
+        }
+
+        // Capture starts before the recognizer's per-session setup: the
+        // unbounded audio stream buffers whatever is said meanwhile, so the
+        // first word isn't lost to analyzer spin-up.
+        let engine = try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<AVAudioEngine, Error>) in
+            Self.audioQueue.async {
+                do {
+                    try Self.startAudioSession()
+                    let engine = try Self.startAudioEngine(
+                        audioContinuation: audioContinuation,
+                        levelContinuation: levelContinuation
+                    )
+                    continuation.resume(returning: engine)
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+
+        guard isActive, !Task.isCancelled, self.audioContinuation != nil else {
+            stopEngineOffMain(engine, deactivateSession: self.audioContinuation == nil)
+            return
+        }
+        self.audioEngine = engine
+        state = .recording
+
+        let analyzerFormat = try await recognizer.prepare()
+
+        guard isActive, !Task.isCancelled else {
+            return
+        }
+
+        let transcripts = recognizer.transcribe(
+            Self.convertedStream(from: audioStream, to: analyzerFormat)
+        )
+        transcriptTask = Task { [weak self] in
+            do {
+                for try await text in transcripts {
+                    self?.transcript = text
+                }
+            } catch {
+                if !(error is CancellationError) {
+                    self?.errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func requestMicrophoneAccess() async -> Bool {
+#if os(macOS)
+        return await AVCaptureDevice.requestAccess(for: .audio)
+#else
+        return await withCheckedContinuation { continuation in
+            AVAudioApplication.requestRecordPermission { granted in
+                continuation.resume(returning: granted)
+            }
+        }
+#endif
+    }
+
+    private nonisolated static func startAudioSession() throws {
+#if !os(macOS)
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.record, mode: .measurement, options: .duckOthers)
+        try session.setActive(true, options: .notifyOthersOnDeactivation)
+#endif
+    }
+
+    private nonisolated static func startAudioEngine(
+        audioContinuation: AsyncStream<AVAudioPCMBuffer>.Continuation,
+        levelContinuation: AsyncStream<Float>.Continuation
+    ) throws -> AVAudioEngine {
+        let audioEngine = AVAudioEngine()
+        let inputNode = audioEngine.inputNode
+        let inputFormat = inputNode.outputFormat(forBus: 0)
+
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { buffer, _ in
+            levelContinuation.yield(CPSLDictationService.level(of: buffer))
+            audioContinuation.yield(buffer)
+        }
+
+        audioEngine.prepare()
+        try audioEngine.start()
+        return audioEngine
+    }
+
+    /// Converts captured buffers to the analyzer's format at consumption, so
+    /// capture can start before the recognizer has negotiated its format.
+    private nonisolated static func convertedStream(
+        from audio: AsyncStream<AVAudioPCMBuffer>,
+        to format: AVAudioFormat
+    ) -> AsyncStream<AVAudioPCMBuffer> {
+        AsyncStream { continuation in
+            let task = Task.detached {
+                var converter: AVAudioConverter?
+                for await buffer in audio {
+                    if converter == nil, buffer.format != format {
+                        converter = AVAudioConverter(from: buffer.format, to: format)
+                        converter?.primeMethod = .none
+                    }
+                    if let converted = convert(buffer: buffer, using: converter, to: format) {
+                        continuation.yield(converted)
+                    }
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    private nonisolated static func level(of buffer: AVAudioPCMBuffer) -> Float {
+        guard let channelData = buffer.floatChannelData else {
+            return 0
+        }
+        let frames = Int(buffer.frameLength)
+        guard frames > 0 else {
+            return 0
+        }
+        var rootMeanSquare: Float = 0
+        vDSP_rmsqv(channelData[0], 1, &rootMeanSquare, vDSP_Length(frames))
+        guard rootMeanSquare > 0 else {
+            return 0
+        }
+        let decibels = 20 * log10(rootMeanSquare)
+        let normalized = (decibels + 50) / 50
+        return min(1, max(0, normalized))
+    }
+
+    private nonisolated static func convert(
+        buffer: AVAudioPCMBuffer,
+        using converter: AVAudioConverter?,
+        to format: AVAudioFormat
+    ) -> AVAudioPCMBuffer? {
+        guard let converter else {
+            return buffer
+        }
+
+        let ratio = format.sampleRate / buffer.format.sampleRate
+        let capacity = AVAudioFrameCount(Double(buffer.frameLength) * ratio) + 1024
+        guard let output = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: capacity) else {
+            return nil
+        }
+
+        var consumed = false
+        var conversionError: NSError?
+        converter.convert(to: output, error: &conversionError) { _, statusPointer in
+            if consumed {
+                statusPointer.pointee = .noDataNow
+                return nil
+            }
+            consumed = true
+            statusPointer.pointee = .haveData
+            return buffer
+        }
+
+        if conversionError != nil || output.frameLength == 0 {
+            return nil
+        }
+        return output
+    }
+
+    private func abort() {
+        startTask?.cancel()
+        startTask = nil
+        stopCapture()
+        transcriptTask?.cancel()
+        transcriptTask = nil
+        transcript = ""
+        state = .idle
+        let recognizer = recognizer
+        Task {
+            await recognizer.finish()
+        }
+    }
+
+    private func stopCapture() {
+        let engine = audioEngine
+        audioEngine = nil
+
+        audioContinuation?.finish()
+        audioContinuation = nil
+        levelContinuation?.finish()
+        levelContinuation = nil
+
+        levelTask?.cancel()
+        levelTask = nil
+
+        stopEngineOffMain(engine, deactivateSession: true)
+    }
+
+    private func stopEngineOffMain(_ engine: AVAudioEngine?, deactivateSession: Bool) {
+        Self.audioQueue.async {
+            if let engine {
+                if engine.isRunning {
+                    engine.stop()
+                }
+                engine.inputNode.removeTap(onBus: 0)
+            }
+#if !os(macOS)
+            if deactivateSession {
+                try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+            }
+#endif
+        }
+    }
+}

--- a/app/apple/herm/Services/CPSLSpeechRecognizer.swift
+++ b/app/apple/herm/Services/CPSLSpeechRecognizer.swift
@@ -1,0 +1,36 @@
+@preconcurrency import AVFoundation
+import Foundation
+
+enum CPSLDictationError: LocalizedError {
+    case notAuthorized
+    case unavailable
+    case localeUnsupported
+    case simulatorUnsupported
+
+    var errorDescription: String? {
+        switch self {
+        case .notAuthorized:
+            return "Microphone or speech access denied"
+        case .unavailable:
+            return "Dictation isn't available on this device"
+        case .localeUnsupported:
+            return "Dictation isn't available for this language"
+        case .simulatorUnsupported:
+            return "Dictation needs a real device — it isn't available in the Simulator"
+        }
+    }
+}
+
+/// Voice-to-text engine, kept separate from capture/waveform/state so the
+/// backend can be swapped (Apple today, an LLM later). Authorization and model
+/// install are split from `prepare()` so the caller can gate capture on them
+/// and surface a download state.
+@MainActor
+protocol CPSLSpeechRecognizer {
+    func authorize() async throws
+    func modelNeedsDownload() async throws -> Bool
+    func installModel() async throws
+    func prepare() async throws -> AVAudioFormat
+    func transcribe(_ audio: AsyncStream<AVAudioPCMBuffer>) -> AsyncThrowingStream<String, Error>
+    func finish() async
+}

--- a/app/apple/herm/Views/Composer/CPSLPromptComposerView.swift
+++ b/app/apple/herm/Views/Composer/CPSLPromptComposerView.swift
@@ -1,7 +1,12 @@
 import Dispatch
 import SwiftUI
+
 #if canImport(UIKit)
 import UIKit
+#endif
+
+#if canImport(AppKit)
+import AppKit
 #endif
 
 #if canImport(UIKit)
@@ -125,9 +130,17 @@ struct CPSLPromptComposerView: View {
     @ObservedObject var model: CPSLChatModel
     let dismissKeyboardRequest: Int
     let dismissKeyboard: () -> Void
+    @State private var focusAfterDictation = false
+#if os(macOS)
+    @State private var collapseSelectionOnFocus = false
+#endif
     @State private var promptContentHeight: CGFloat = 0
     @State private var focusPromptRequest = 0
     @FocusState private var isPromptFocused: Bool
+
+    private var dictation: CPSLDictationService {
+        model.dictation
+    }
 
     private var hasPromptInput: Bool {
         !model.promptText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
@@ -149,7 +162,7 @@ struct CPSLPromptComposerView: View {
         min(max(promptContentHeight, promptLineHeight), promptLineHeight * 6)
     }
 
-    var body: some View {
+    private var composerContent: some View {
         VStack(alignment: .leading, spacing: CPSLTheme.composerSpacing) {
             ZStack(alignment: .topLeading) {
                 if model.promptText.isEmpty {
@@ -220,22 +233,25 @@ struct CPSLPromptComposerView: View {
                 Spacer()
 
                 Button {
-                    dismissKeyboard()
-                    model.showComingSoon("coming soon")
+                    toggleDictation()
                 } label: {
-                    Image(systemName: "mic.fill")
+                    Image(systemName: dictation.isActive ? "mic.fill" : "mic")
                         .font(CPSLTheme.iconMediumFont)
                         .frame(width: CPSLTheme.controlSize, height: CPSLTheme.controlSize)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .foregroundStyle(CPSLTheme.text)
+                .foregroundStyle(dictation.isActive ? CPSLTheme.mauve : CPSLTheme.text)
                 .cpslGlassBackground(
                     in: RoundedRectangle(cornerRadius: CPSLTheme.controlRadius, style: .continuous),
-                    tint: CPSLGlassTuning.tint(CPSLTheme.card, opacity: 0.38),
+                    tint: CPSLGlassTuning.tint(
+                        dictation.isActive ? CPSLTheme.mauve : CPSLTheme.card,
+                        opacity: dictation.isActive ? 0.22 : 0.38
+                    ),
                     strokeOpacity: 0.045
                 )
                 .contentShape(RoundedRectangle(cornerRadius: CPSLTheme.controlRadius, style: .continuous))
+                .disabled(model.isRunning)
 
                 Button {
                     dismissKeyboard()
@@ -284,8 +300,23 @@ struct CPSLPromptComposerView: View {
             tint: CPSLGlassTuning.tint(CPSLTheme.background, opacity: 0.54),
             strokeOpacity: 0.055
         )
+    }
+
+    var body: some View {
+        Group {
+            if dictation.isActive {
+                CPSLDictationBarView(
+                    dictation: dictation,
+                    onCancel: cancelDictation,
+                    onConfirm: confirmDictation
+                )
+            } else {
+                composerContent
+            }
+        }
         .padding(.horizontal, CPSLTheme.chromeHorizontalInset)
         .padding(.bottom, CPSLTheme.medium)
+        .animation(.easeOut(duration: 0.2), value: dictation.isActive)
         .onChange(of: dismissKeyboardRequest) { _, _ in
             isPromptFocused = false
         }
@@ -294,6 +325,63 @@ struct CPSLPromptComposerView: View {
                 isPromptFocused = false
             }
         }
+        .onChange(of: dictation.isActive) { wasActive, isActive in
+            guard wasActive, !isActive else {
+                return
+            }
+            commitTranscript()
+            if focusAfterDictation {
+                focusAfterDictation = false
+#if os(macOS)
+                collapseSelectionOnFocus = true
+#endif
+                focusPrompt()
+            }
+        }
+#if os(macOS)
+        .onChange(of: isPromptFocused) { _, focused in
+            guard focused, collapseSelectionOnFocus else {
+                return
+            }
+            collapseSelectionOnFocus = false
+            DispatchQueue.main.async {
+                guard let editor = NSApp.keyWindow?.firstResponder as? NSTextView else {
+                    return
+                }
+                let end = (editor.string as NSString).length
+                editor.setSelectedRange(NSRange(location: end, length: 0))
+            }
+        }
+#endif
+        .cpslDictationErrorAlert(dictation)
+    }
+
+    private func toggleDictation() {
+        dismissKeyboard()
+        if dictation.isActive {
+            dictation.finish()
+        } else {
+            dictation.start()
+        }
+    }
+
+    private func cancelDictation() {
+        focusAfterDictation = false
+        dictation.cancel()
+    }
+
+    private func confirmDictation() {
+        focusAfterDictation = true
+        dictation.finish()
+    }
+
+    private func commitTranscript() {
+        let transcript = dictation.transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !transcript.isEmpty else {
+            return
+        }
+        let base = model.promptText.trimmingCharacters(in: .whitespacesAndNewlines)
+        model.promptText = base.isEmpty ? transcript : base + " " + transcript
     }
 
     private func focusPrompt() {

--- a/app/apple/herm/Views/Composer/Dictation/CPSLDictationBarView.swift
+++ b/app/apple/herm/Views/Composer/Dictation/CPSLDictationBarView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+/// Replaces the composer while dictation is active: cancel on the left, a live
+/// waveform in the middle, and confirm on the right.
+struct CPSLDictationBarView: View {
+    var dictation: CPSLDictationService
+    let onCancel: () -> Void
+    let onConfirm: () -> Void
+
+    var body: some View {
+        HStack(spacing: CPSLTheme.medium) {
+            cancelButton
+
+            CPSLDictationStatusView(dictation: dictation)
+                .frame(maxWidth: .infinity)
+                .frame(height: CPSLTheme.controlSize)
+
+            confirmButton
+        }
+        .animation(.easeOut(duration: 0.15), value: dictation.state)
+        .padding(CPSLTheme.composerPadding)
+        .cpslGlassBackground(
+            in: Capsule(),
+            tint: CPSLGlassTuning.tint(CPSLTheme.background, opacity: 0.54),
+            strokeOpacity: 0.055
+        )
+    }
+
+    private var cancelButton: some View {
+        Button(action: onCancel) {
+            Image(systemName: "xmark")
+                .font(CPSLTheme.iconMediumFont)
+                .frame(width: CPSLTheme.controlSize, height: CPSLTheme.controlSize)
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(CPSLTheme.text)
+        .cpslGlassBackground(
+            in: Circle(),
+            tint: CPSLGlassTuning.tint(CPSLTheme.card, opacity: 0.38),
+            strokeOpacity: 0.045
+        )
+        .accessibilityLabel("Cancel dictation")
+    }
+
+    private var confirmButton: some View {
+        Button(action: onConfirm) {
+            Image(systemName: "arrow.up")
+                .font(CPSLTheme.iconFont(size: CPSLTheme.FontSize.iconLarge, weight: .semibold))
+                .frame(width: CPSLTheme.controlSize, height: CPSLTheme.controlSize)
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(CPSLTheme.background)
+        .background(CPSLTheme.text)
+        .clipShape(Circle())
+        .disabled(dictation.state != .recording)
+        .opacity(dictation.state == .recording ? 1 : 0.45)
+        .accessibilityLabel("Finish dictation")
+    }
+}

--- a/app/apple/herm/Views/Composer/Dictation/CPSLDictationErrorAlert.swift
+++ b/app/apple/herm/Views/Composer/Dictation/CPSLDictationErrorAlert.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+extension View {
+    func cpslDictationErrorAlert(_ dictation: CPSLDictationService) -> some View {
+        alert(
+            "Dictation unavailable",
+            isPresented: Binding(
+                get: { dictation.errorMessage != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        dictation.errorMessage = nil
+                    }
+                }
+            )
+        ) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(dictation.errorMessage ?? "")
+        }
+    }
+}

--- a/app/apple/herm/Views/Composer/Dictation/CPSLDictationStatusView.swift
+++ b/app/apple/herm/Views/Composer/Dictation/CPSLDictationStatusView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+/// Center of the dictation bar: names the current phase until audio flows,
+/// then shows the live waveform.
+struct CPSLDictationStatusView: View {
+    var dictation: CPSLDictationService
+
+    var body: some View {
+        switch dictation.state {
+        case .idle:
+            Color.clear
+        case .preparing:
+            phaseLabel("Getting ready…")
+        case .downloadingModel:
+            phaseLabel("Downloading speech model…")
+        case .recording:
+            CPSLDictationWaveform(dictation: dictation)
+        case .finishing:
+            phaseLabel("Transcribing…")
+        }
+    }
+
+    private func phaseLabel(_ text: String) -> some View {
+        HStack(spacing: CPSLTheme.small) {
+            ProgressView()
+                .controlSize(.small)
+                .tint(CPSLTheme.mutedText)
+            Text(text)
+                .font(CPSLTheme.controlFont)
+                .foregroundStyle(CPSLTheme.mutedText)
+                .lineLimit(1)
+        }
+    }
+}
+
+/// Reads `levels` in its own body so each level tick only redraws the
+/// waveform, not the whole bar.
+private struct CPSLDictationWaveform: View {
+    var dictation: CPSLDictationService
+
+    var body: some View {
+        CPSLWaveformView(levels: dictation.levels, color: CPSLTheme.text)
+    }
+}

--- a/app/apple/herm/Views/Composer/Dictation/CPSLWaveformView.swift
+++ b/app/apple/herm/Views/Composer/Dictation/CPSLWaveformView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// Scrolling level meter: the most recent samples appear on the right and drift
+/// left, fading down to dots as they age. Drawn in a single `Canvas` — no
+/// per-bar subviews to lay out — so it stays cheap under high-frequency updates.
+/// Pure presentation: pass normalized levels (0...1, newest last) from any source.
+struct CPSLWaveformView: View {
+    var levels: [Float]
+    var barWidth: CGFloat = 3
+    var barSpacing: CGFloat = 3
+    var minHeight: CGFloat = 3
+    var color: Color = CPSLTheme.text
+
+    var body: some View {
+        Canvas(opaque: false, rendersAsynchronously: false) { context, size in
+            let step = barWidth + barSpacing
+            let count = max(1, Int((size.width + barSpacing) / step))
+            for index in 0..<count {
+                let level = CGFloat(level(at: index, count: count))
+                let barHeight = max(minHeight, level * size.height)
+                let rect = CGRect(
+                    x: CGFloat(index) * step,
+                    y: (size.height - barHeight) / 2,
+                    width: barWidth,
+                    height: barHeight
+                )
+                let path = Path(roundedRect: rect, cornerRadius: barWidth / 2)
+                context.fill(path, with: .color(color.opacity(level > 0.03 ? 0.9 : 0.28)))
+            }
+        }
+    }
+
+    private func level(at index: Int, count: Int) -> Float {
+        let missing = count - levels.count
+        let levelIndex = index - missing
+        guard levelIndex >= 0, levelIndex < levels.count else {
+            return 0
+        }
+        return levels[levelIndex]
+    }
+}

--- a/app/apple/herm/herm-macOS.entitlements
+++ b/app/apple/herm/herm-macOS.entitlements
@@ -6,6 +6,8 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>
 		<string>iCloud.$(PRODUCT_BUNDLE_IDENTIFIER)</string>


### PR DESCRIPTION
## Summary

Adds voice dictation to the prompt composer on iOS and macOS. Tapping the mic button swaps the composer for a dictation bar with a live waveform; speech is transcribed on-device as you talk, and confirming appends the transcript to the prompt (preserving any text already typed).


https://github.com/user-attachments/assets/7cd872d5-62a1-47c2-ae4f-f3e3bf321fc5


## How it works

**Speech recognition backend.** Transcription uses Apple's Speech framework. The engine is deliberately isolated behind a `CPSLSpeechRecognizer` protocol, so the backend can be swapped later — e.g. streaming audio to an external LLM transcription API — without touching capture, state, or UI. `CPSLAppleSpeechRecognizer` is the only conformer today.

**Dictation service.** `CPSLDictationService` (owned by `CPSLChatModel`) drives the session through an explicit state machine:

```
idle → preparing → (downloadingModel) → recording → finishing → idle
```

- Permissions (mic + speech recognition) and the language-model check happen **before** capture starts — permission prompts never appear over a live recording.
- First use of a language shows a "Downloading speech model…" state instead of silently recording into a model download.
- Capture starts **before** the recognizer's per-session setup: raw mic buffers queue in an unbounded `AsyncStream` while the analyzer spins up, so the first word is never lost. Format conversion happens at consumption, off the real-time tap.
- `finish()` stops capture but lets transcription finalize ("Transcribing…" state) so the full text lands before commit; `cancel()` tears everything down and discards it.

**Audio pipeline.** Session/engine work (blocking IPC) runs on a dedicated serial queue; the tap callback only computes an RMS level via vDSP and yields the buffer. The locale negotiation and model-installed check are cached per language, so repeat sessions start with no asset-inventory I/O.

**UI.** All dictation UI lives in `Views/Composer/Dictation/`:
- `CPSLDictationBarView` — cancel / status / confirm bar
- `CPSLDictationStatusView` — names each phase, shows the waveform while recording
- `CPSLWaveformView` — pure-presentation scrolling level meter drawn in a single `Canvas`; level updates only invalidate the waveform leaf, not the bar
- `cpslDictationErrorAlert` — error surface, bound directly to the service

**Language.** The recognition locale follows the user's system language (`Locale.preferredLanguages`), not the bundle localization (which is en-only).

## Config

- `NSMicrophoneUsageDescription` and `NSSpeechRecognitionUsageDescription` added to build settings
- `com.apple.security.device.audio-input` entitlement added for macOS

## Test plan

- [ ] Dictate on a physical iPhone (Simulator is unsupported and shows an explanatory error)
- [ ] Dictate on macOS
- [ ] First word of the dictation is transcribed
- [ ] Confirm appends to existing prompt text with a separating space
- [ ] Cancel discards the transcript
- [ ] Deny mic or speech permission → alert, no broken state
- [ ] Switch system language to one without a downloaded model → download state appears, dictation works after install
- [ ] Send a prompt while dictating → dictation cancels cleanly
