### PR TITLE
Polish file browser navigation

### DIFF
--- a/app/apple/herm/Design/CPSLTheme.swift
+++ b/app/apple/herm/Design/CPSLTheme.swift
@@ -18,6 +18,20 @@ enum CPSLTheme {
     static let command = Color(red: 0.076, green: 0.091, blue: 0.145)
     static let error = Color(red: 0.36, green: 0.16, blue: 0.20)
 
+    enum IconPalette {
+        static let primary = CPSLTheme.text
+        static let secondary = CPSLTheme.secondaryText
+        static let folder = Color(red: 0.31, green: 0.49, blue: 0.72)
+        static let home = Self.folder
+        static let file = Self.primary
+        static let pdf = Self.file
+        static let mail = Self.primary
+        static let calendar = Self.primary
+        static let temporary = Self.secondary
+        static let cloud = Self.secondary
+        static let drive = Self.secondary
+    }
+
     static let small: CGFloat = 8
     static let medium: CGFloat = 12
     static let large: CGFloat = 20

--- a/app/apple/herm/Models/CPSLChatModel.swift
+++ b/app/apple/herm/Models/CPSLChatModel.swift
@@ -117,6 +117,13 @@ final class CPSLChatModel: ObservableObject {
             return
         }
 
+        if selectedConversationID == id {
+            isDrawerOpen = false
+            isFileBrowserOpen = false
+            filePreview = nil
+            return
+        }
+
         Task {
             await loadConversation(id: id)
         }
@@ -176,6 +183,8 @@ final class CPSLChatModel: ObservableObject {
         isFileBrowserOpen.toggle()
         if isFileBrowserOpen {
             isDrawerOpen = false
+            filePreview = nil
+            loadBrowserPath(browserPath)
         } else {
             filePreview = nil
         }
@@ -188,6 +197,7 @@ final class CPSLChatModel: ObservableObject {
 
     func loadBrowserPath(_ path: String) {
         let normalized = scopedBrowserPath(path)
+        let isChangingPath = normalized != browserPath
         browserPath = normalized
         fileBrowserError = nil
         expandedFilePaths.removeAll()
@@ -196,6 +206,10 @@ final class CPSLChatModel: ObservableObject {
         guard normalized != CPSLVirtualPath.root else {
             browserEntries = []
             return
+        }
+
+        if isChangingPath {
+            browserEntries = []
         }
 
         Task {
@@ -559,16 +573,28 @@ final class CPSLChatModel: ObservableObject {
         }
 
         if let parent {
+            guard expandedFilePaths.contains(parent) else {
+                return
+            }
             childEntriesByPath[parent] = listing.entries
         } else {
+            guard browserPath == path else {
+                return
+            }
             browserEntries = listing.entries
         }
     }
 
     private func applyDirectoryLoadFailure(_ message: String, path: String, childOf parent: String?) {
         if let parent {
+            guard expandedFilePaths.contains(parent) else {
+                return
+            }
             childEntriesByPath[parent] = []
         } else {
+            guard browserPath == path else {
+                return
+            }
             browserEntries = []
         }
         fileBrowserError = "\(path): \(message)"

--- a/app/apple/herm/Models/CPSLTypes.swift
+++ b/app/apple/herm/Models/CPSLTypes.swift
@@ -156,6 +156,11 @@ struct CPSLDirectoryListing: Sendable {
     let error: String?
 }
 
+enum CPSLFileBrowserNavigationDirection: Equatable, Sendable {
+    case forward
+    case backward
+}
+
 enum CPSLFilePreviewKind: Equatable, Sendable {
     case text(String)
     case pdf(URL)

--- a/app/apple/herm/Views/Chat/CPSLConversationDrawerView.swift
+++ b/app/apple/herm/Views/Chat/CPSLConversationDrawerView.swift
@@ -100,8 +100,9 @@ private struct CPSLConversationListView: View {
                         Button(role: .destructive) {
                             model.deleteConversation(id: conversation.id)
                         } label: {
-                            Label("Remove", systemImage: "trash")
+                            Text("Remove")
                         }
+                        .tint(CPSLTheme.danger)
                         .disabled(model.isRunning)
                     }
                     .listRowInsets(EdgeInsets(top: 4, leading: 0, bottom: 4, trailing: 0))
@@ -134,9 +135,7 @@ private struct CPSLConversationRowView: View {
 
     var body: some View {
         Button {
-            if !isSelected {
-                action()
-            }
+            action()
         } label: {
             VStack(alignment: .leading, spacing: 4) {
                 Text(title)

--- a/app/apple/herm/Views/Composer/CPSLPromptComposerView.swift
+++ b/app/apple/herm/Views/Composer/CPSLPromptComposerView.swift
@@ -26,7 +26,12 @@ private struct CPSLPromptTextView: UIViewRepresentable {
         textView.textColor = UIColor(CPSLTheme.text)
         textView.tintColor = UIColor(CPSLTheme.text)
         textView.font = CPSLTheme.bodyUIFont
-        textView.textContainerInset = .zero
+        textView.textContainerInset = UIEdgeInsets(
+            top: CPSLTheme.promptVerticalInset,
+            left: CPSLTheme.medium,
+            bottom: CPSLTheme.promptVerticalInset,
+            right: CPSLTheme.medium
+        )
         textView.textContainer.lineFragmentPadding = 0
         textView.returnKeyType = .default
         textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
@@ -158,8 +163,16 @@ struct CPSLPromptComposerView: View {
 #endif
     }
 
+    private var promptVerticalPadding: CGFloat {
+        CPSLTheme.promptVerticalInset * 2
+    }
+
+    private var promptMaxTextHeight: CGFloat {
+        promptLineHeight * 6 + promptVerticalPadding
+    }
+
     private var promptTextHeight: CGFloat {
-        min(max(promptContentHeight, promptLineHeight), promptLineHeight * 6)
+        min(max(promptContentHeight, promptLineHeight + promptVerticalPadding), promptMaxTextHeight)
     }
 
     private var composerContent: some View {
@@ -178,15 +191,13 @@ struct CPSLPromptComposerView: View {
                     text: $model.promptText,
                     isCommandInput: isCommandInput,
                     isDisabled: model.isRunning,
-                    maxHeight: promptLineHeight * 6,
+                    maxHeight: promptMaxTextHeight,
                     focusPromptRequest: focusPromptRequest,
                     dismissKeyboardRequest: dismissKeyboardRequest
                 ) { height in
                     promptContentHeight = height
                 }
                 .frame(height: promptTextHeight)
-                .padding(.horizontal, CPSLTheme.medium)
-                .padding(.vertical, CPSLTheme.promptVerticalInset)
 #else
                 TextField("", text: $model.promptText, axis: .vertical)
                     .textFieldStyle(.plain)
@@ -287,6 +298,14 @@ struct CPSLPromptComposerView: View {
             }
         }
         .padding(CPSLTheme.composerPadding)
+        .contentShape(RoundedRectangle(cornerRadius: CPSLTheme.composerRadius, style: .continuous))
+        .contextMenu {
+            Button {
+                pastePromptText()
+            } label: {
+                Label("Paste", systemImage: "doc.on.clipboard")
+            }
+        }
         .background {
             RoundedRectangle(cornerRadius: CPSLTheme.composerRadius, style: .continuous)
                 .fill(Color.clear)
@@ -391,5 +410,28 @@ struct CPSLPromptComposerView: View {
 
         focusPromptRequest += 1
         isPromptFocused = true
+    }
+
+    private func pastePromptText() {
+        guard !model.isRunning else {
+            return
+        }
+        guard let text = Self.pasteboardString(), !text.isEmpty else {
+            focusPrompt()
+            return
+        }
+
+        model.promptText += text
+        focusPrompt()
+    }
+
+    private static func pasteboardString() -> String? {
+#if os(macOS)
+        NSPasteboard.general.string(forType: .string)
+#elseif canImport(UIKit)
+        UIPasteboard.general.string
+#else
+        nil
+#endif
     }
 }

--- a/app/apple/herm/Views/Composer/CPSLToolStripView.swift
+++ b/app/apple/herm/Views/Composer/CPSLToolStripView.swift
@@ -19,7 +19,9 @@ struct CPSLToolStripView: View {
                 } label: {
                     HStack(spacing: CPSLTheme.small) {
                         Image(systemName: "folder.fill")
+                            .symbolRenderingMode(.hierarchical)
                             .font(CPSLTheme.iconFont(size: CPSLTheme.FontSize.iconMedium, weight: .semibold))
+                            .foregroundStyle(CPSLTheme.IconPalette.folder)
                         Text("Files")
                             .font(CPSLTheme.controlFont)
                     }
@@ -36,8 +38,8 @@ struct CPSLToolStripView: View {
                 .foregroundStyle(CPSLTheme.text)
                 .contentShape(RoundedRectangle(cornerRadius: CPSLTheme.controlRadius, style: .continuous))
 
-                CPSLDisabledToolIcon(systemName: "envelope.fill")
-                CPSLDisabledToolIcon(systemName: "calendar")
+                CPSLDisabledToolIcon(systemName: "envelope.fill", color: CPSLTheme.IconPalette.mail)
+                CPSLDisabledToolIcon(systemName: "calendar", color: CPSLTheme.IconPalette.calendar)
             }
             .padding(.horizontal, CPSLTheme.chromeHorizontalInset)
         }
@@ -48,11 +50,13 @@ struct CPSLToolStripView: View {
 
 private struct CPSLDisabledToolIcon: View {
     let systemName: String
+    let color: Color
 
     var body: some View {
         Image(systemName: systemName)
+            .symbolRenderingMode(.hierarchical)
             .font(CPSLTheme.iconFont(size: CPSLTheme.FontSize.iconMedium, weight: .semibold))
-            .foregroundStyle(CPSLTheme.mutedText)
+            .foregroundStyle(color)
             .frame(width: CPSLTheme.controlSize, height: CPSLTheme.controlSize)
             .cpslGlassBackground(
                 in: RoundedRectangle(cornerRadius: CPSLTheme.controlRadius, style: .continuous),

--- a/app/apple/herm/Views/Files/CPSLFileBrowserView.swift
+++ b/app/apple/herm/Views/Files/CPSLFileBrowserView.swift
@@ -1,6 +1,121 @@
 import Foundation
 import SwiftUI
 
+private enum CPSLFileBrowserPagePlacement: Equatable {
+    case entering
+    case center
+    case exiting
+}
+
+private enum CPSLFileBrowserMotion {
+    static let duration = 0.2
+    static let animation = Animation.easeOut(duration: duration)
+
+    static func offset(
+        for placement: CPSLFileBrowserPagePlacement,
+        direction: CPSLFileBrowserNavigationDirection,
+        width: CGFloat
+    ) -> CGFloat {
+        switch placement {
+        case .center:
+            return 0
+        case .entering:
+            return direction == .forward ? width : -width
+        case .exiting:
+            return direction == .forward ? -width : width
+        }
+    }
+}
+
+private struct CPSLFileBrowserFolderSnapshot: Equatable {
+    let path: String
+    let isRoot: Bool
+    let entries: [CPSLFileEntry]
+    let childEntriesByPath: [String: [CPSLFileEntry]]
+    let expandedFilePaths: Set<String>
+    let loadingFilePaths: Set<String>
+    let error: String?
+
+    init(model: CPSLChatModel) {
+        path = model.browserPath
+        isRoot = model.browserPath == CPSLVirtualPath.root
+        entries = model.browserEntries
+        childEntriesByPath = model.childEntriesByPath
+        expandedFilePaths = model.expandedFilePaths
+        loadingFilePaths = model.loadingFilePaths
+        error = model.fileBrowserError
+    }
+
+    func children(for path: String) -> [CPSLFileEntry] {
+        childEntriesByPath[path] ?? []
+    }
+
+    func isExpanded(_ entry: CPSLFileEntry) -> Bool {
+        expandedFilePaths.contains(entry.path)
+    }
+
+    func isLoading(_ path: String) -> Bool {
+        loadingFilePaths.contains(path)
+    }
+}
+
+private enum CPSLFileBrowserRoute: Identifiable, Equatable {
+    case folder(CPSLFileBrowserFolderSnapshot)
+    case preview(CPSLFilePreview)
+
+    var id: String {
+        switch self {
+        case .folder(let snapshot):
+            return "folder:\(snapshot.path)"
+        case .preview(let preview):
+            return "preview:\(preview.id)"
+        }
+    }
+
+    static func direction(
+        from source: CPSLFileBrowserRoute,
+        to target: CPSLFileBrowserRoute
+    ) -> CPSLFileBrowserNavigationDirection {
+        switch (source, target) {
+        case (.folder(let source), .folder(let target)):
+            return folderDirection(from: source.path, to: target.path)
+        case (.folder, .preview):
+            return .forward
+        case (.preview, .folder):
+            return .backward
+        case (.preview, .preview):
+            return .forward
+        }
+    }
+
+    private static func folderDirection(
+        from sourcePath: String,
+        to targetPath: String
+    ) -> CPSLFileBrowserNavigationDirection {
+        if targetPath == CPSLVirtualPath.root {
+            return .backward
+        }
+        if sourcePath.hasPrefix("\(targetPath)/") {
+            return .backward
+        }
+        return .forward
+    }
+}
+
+private struct CPSLFileBrowserDisplayPage: Identifiable, Equatable {
+    var route: CPSLFileBrowserRoute
+    var placement: CPSLFileBrowserPagePlacement
+    let direction: CPSLFileBrowserNavigationDirection
+
+    var id: String {
+        route.id
+    }
+
+    var zIndex: Double {
+        placement == .exiting ? 0 : 1
+    }
+}
+
 struct CPSLFileBrowserView: View {
     @ObservedObject var model: CPSLChatModel
 
@@ -8,16 +123,197 @@ struct CPSLFileBrowserView: View {
         CPSLFileOverlayPanel {
             CPSLFileBrowserHeader(model: model)
         } content: {
+            CPSLFileBrowserRouteStack(model: model)
+        }
+    }
+}
+
+private struct CPSLFileBrowserRouteStack: View {
+    @ObservedObject var model: CPSLChatModel
+    @State private var pages: [CPSLFileBrowserDisplayPage] = []
+    @State private var transitionGeneration = 0
+
+    private var currentRoute: CPSLFileBrowserRoute {
+        if let preview = model.filePreview {
+            return .preview(preview)
+        }
+        return .folder(CPSLFileBrowserFolderSnapshot(model: model))
+    }
+
+    private var visiblePages: [CPSLFileBrowserDisplayPage] {
+        if pages.isEmpty {
+            return [
+                CPSLFileBrowserDisplayPage(
+                    route: currentRoute,
+                    placement: .center,
+                    direction: .forward
+                )
+            ]
+        }
+        return pages
+    }
+
+    var body: some View {
+        GeometryReader { proxy in
             ZStack {
-                if let preview = model.filePreview {
-                    CPSLFilePreviewContentView(preview: preview)
-                        .transition(.move(edge: .trailing).combined(with: .opacity))
-                } else {
-                    CPSLFileBrowserPane(model: model)
-                        .transition(.move(edge: .leading).combined(with: .opacity))
+                ForEach(visiblePages) { page in
+                    CPSLFileBrowserRouteContent(
+                        route: page.route,
+                        actions: CPSLFileBrowserActions(model: model)
+                    )
+                    .frame(
+                        width: proxy.size.width,
+                        height: proxy.size.height,
+                        alignment: .topLeading
+                    )
+                    .background(CPSLTheme.command)
+                    .offset(
+                        x: CPSLFileBrowserMotion.offset(
+                            for: page.placement,
+                            direction: page.direction,
+                            width: proxy.size.width
+                        )
+                    )
+                    .zIndex(page.zIndex)
+                    .allowsHitTesting(page.id == visiblePages.last?.id && page.placement == .center)
                 }
             }
-            .animation(.easeOut(duration: 0.2), value: model.filePreview?.id)
+            .clipped()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+        .onAppear {
+            resetPages(to: currentRoute)
+        }
+        .onChange(of: currentRoute) { _, route in
+            reconcile(with: route)
+        }
+    }
+
+    private func resetPages(to route: CPSLFileBrowserRoute) {
+        transitionGeneration += 1
+        pages = [
+            CPSLFileBrowserDisplayPage(
+                route: route,
+                placement: .center,
+                direction: .forward
+            )
+        ]
+    }
+
+    private func reconcile(with route: CPSLFileBrowserRoute) {
+        guard let currentPage = pages.last else {
+            resetPages(to: route)
+            return
+        }
+
+        if currentPage.route.id == route.id {
+            pages[pages.count - 1].route = route
+            return
+        }
+
+        transition(to: route, from: currentPage.route)
+    }
+
+    private func transition(
+        to route: CPSLFileBrowserRoute,
+        from source: CPSLFileBrowserRoute
+    ) {
+        let direction = CPSLFileBrowserRoute.direction(from: source, to: route)
+        transitionGeneration += 1
+        let generation = transitionGeneration
+
+        var transaction = Transaction(animation: nil)
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            pages = [
+                CPSLFileBrowserDisplayPage(
+                    route: source,
+                    placement: .center,
+                    direction: direction
+                ),
+                CPSLFileBrowserDisplayPage(
+                    route: route,
+                    placement: .entering,
+                    direction: direction
+                )
+            ]
+        }
+
+        DispatchQueue.main.async {
+            guard transitionGeneration == generation else {
+                return
+            }
+            let incomingRoute = pages.last?.route ?? route
+            withAnimation(CPSLFileBrowserMotion.animation) {
+                pages = [
+                    CPSLFileBrowserDisplayPage(
+                        route: source,
+                        placement: .exiting,
+                        direction: direction
+                    ),
+                    CPSLFileBrowserDisplayPage(
+                        route: incomingRoute,
+                        placement: .center,
+                        direction: direction
+                    )
+                ]
+            }
+            pruneTransition(generation: generation, routeID: incomingRoute.id)
+        }
+    }
+
+    private func pruneTransition(generation: Int, routeID: String) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + CPSLFileBrowserMotion.duration) {
+            guard transitionGeneration == generation, let currentPage = pages.last else {
+                return
+            }
+            guard currentPage.route.id == routeID else {
+                return
+            }
+            pages = [
+                CPSLFileBrowserDisplayPage(
+                    route: currentPage.route,
+                    placement: .center,
+                    direction: currentPage.direction
+                )
+            ]
+        }
+    }
+}
+
+private struct CPSLFileBrowserRouteContent: View {
+    let route: CPSLFileBrowserRoute
+    let actions: CPSLFileBrowserActions
+
+    var body: some View {
+        switch route {
+        case .folder(let snapshot):
+            CPSLFileBrowserPane(snapshot: snapshot, actions: actions)
+        case .preview(let preview):
+            CPSLFilePreviewContentView(preview: preview)
+        }
+    }
+}
+
+@MainActor
+private struct CPSLFileBrowserActions {
+    let loadPath: (String) -> Void
+    let openEntry: (CPSLFileEntry) -> Void
+    let toggleExpansion: (CPSLFileEntry) -> Void
+    let showComingSoon: (String) -> Void
+
+    init(model: CPSLChatModel) {
+        loadPath = { path in
+            model.loadBrowserPath(path)
+        }
+        openEntry = { entry in
+            model.openFileEntry(entry)
+        }
+        toggleExpansion = { entry in
+            model.toggleExpansion(for: entry)
+        }
+        showComingSoon = { message in
+            model.showComingSoon(message)
         }
     }
 }
@@ -27,16 +323,13 @@ private struct CPSLFileBrowserHeader: View {
 
     var body: some View {
         HStack(spacing: CPSLTheme.medium) {
-            if model.filePreview != nil || model.canNavigateToParentDirectory {
-                CPSLFileOverlayIconButton(
-                    systemName: "chevron.left",
-                    accessibilityLabel: "Back"
-                ) {
-                    if model.filePreview != nil {
-                        model.closeFilePreview()
-                    } else {
-                        model.navigateToParentDirectory()
-                    }
+            CPSLFileBrowserBackButton(
+                isAvailable: model.filePreview != nil || model.canNavigateToParentDirectory
+            ) {
+                if model.filePreview != nil {
+                    model.closeFilePreview()
+                } else {
+                    model.navigateToParentDirectory()
                 }
             }
 
@@ -58,15 +351,32 @@ private struct CPSLFileBrowserHeader: View {
     }
 }
 
+private struct CPSLFileBrowserBackButton: View {
+    let isAvailable: Bool
+    let action: () -> Void
+
+    var body: some View {
+        ZStack {
+            if isAvailable {
+                CPSLFileOverlayIconButton(
+                    systemName: "chevron.left",
+                    accessibilityLabel: "Back"
+                ) { action() }
+            } else {
+                Color.clear
+                    .frame(width: CPSLTheme.controlSize, height: CPSLTheme.controlSize)
+                    .accessibilityHidden(true)
+            }
+        }
+    }
+}
+
 private struct CPSLFilePreviewHeaderTitle: View {
     let preview: CPSLFilePreview
 
     var body: some View {
         HStack(spacing: CPSLTheme.medium) {
-            Image(systemName: iconName)
-                .font(CPSLTheme.iconMediumFont)
-                .foregroundStyle(CPSLTheme.mauve)
-                .frame(width: 20)
+            CPSLFileIcon(systemName: iconName, color: iconColor)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(preview.name)
@@ -91,6 +401,15 @@ private struct CPSLFilePreviewHeaderTitle: View {
             return "doc.text.fill"
         }
     }
+
+    private var iconColor: Color {
+        switch preview.kind {
+        case .pdf:
+            return CPSLTheme.IconPalette.pdf
+        case .text:
+            return CPSLTheme.IconPalette.file
+        }
+    }
 }
 
 private struct CPSLFileBrowserHeaderTitle: View {
@@ -99,9 +418,7 @@ private struct CPSLFileBrowserHeaderTitle: View {
 
     var body: some View {
         HStack(spacing: CPSLTheme.medium) {
-            Image(systemName: iconName)
-                .font(CPSLTheme.iconMediumFont)
-                .foregroundStyle(CPSLTheme.mauve)
+            CPSLFileIcon(systemName: iconName, color: iconColor)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(displayTitle)
@@ -141,26 +458,41 @@ private struct CPSLFileBrowserHeaderTitle: View {
         }
         return "folder.fill"
     }
+
+    private var iconColor: Color {
+        if path == CPSLVirtualPath.home {
+            return CPSLTheme.IconPalette.home
+        }
+        if path == CPSLVirtualPath.temporary {
+            return CPSLTheme.IconPalette.temporary
+        }
+        return CPSLTheme.IconPalette.folder
+    }
 }
 
 private struct CPSLFileBrowserPane: View {
-    @ObservedObject var model: CPSLChatModel
+    let snapshot: CPSLFileBrowserFolderSnapshot
+    let actions: CPSLFileBrowserActions
 
     var body: some View {
         ScrollView {
             LazyVStack(spacing: 0) {
-                if let error = model.fileBrowserError {
+                if let error = snapshot.error {
                     CPSLFileBrowserErrorView(message: error)
                 }
 
-                if model.isAtFileBrowserRoot {
-                    CPSLFileLocationsView(model: model)
-                } else if model.isLoading(model.browserPath) && model.browserEntries.isEmpty {
+                if snapshot.isRoot {
+                    CPSLFileLocationsView(actions: actions)
+                } else if snapshot.isLoading(snapshot.path) && snapshot.entries.isEmpty {
                     CPSLFileBrowserLoadingView()
-                } else if model.browserEntries.isEmpty && model.fileBrowserError == nil {
+                } else if snapshot.entries.isEmpty && snapshot.error == nil {
                     CPSLFileBrowserEmptyView()
                 } else {
-                    CPSLFileRowsView(model: model, entries: model.browserEntries)
+                    CPSLFileRowsView(
+                        snapshot: snapshot,
+                        entries: snapshot.entries,
+                        actions: actions
+                    )
                 }
             }
             .padding(.vertical, CPSLTheme.small)
@@ -173,40 +505,44 @@ private struct CPSLFileBrowserPane: View {
 }
 
 private struct CPSLFileLocationsView: View {
-    @ObservedObject var model: CPSLChatModel
+    let actions: CPSLFileBrowserActions
 
     var body: some View {
         VStack(spacing: 0) {
             CPSLFileLocationRow(
                 title: "Home",
                 detail: CPSLVirtualPath.home,
-                systemName: "house.fill"
+                systemName: "house.fill",
+                color: CPSLTheme.IconPalette.home
             ) {
-                model.loadBrowserPath(CPSLVirtualPath.home)
+                actions.loadPath(CPSLVirtualPath.home)
             }
 
             CPSLFileLocationRow(
                 title: "Temporary",
                 detail: CPSLVirtualPath.temporary,
-                systemName: "clock.fill"
+                systemName: "clock.fill",
+                color: CPSLTheme.IconPalette.temporary
             ) {
-                model.loadBrowserPath(CPSLVirtualPath.temporary)
+                actions.loadPath(CPSLVirtualPath.temporary)
             }
 
             CPSLCloudConnectionRow(
                 title: "iCloud",
                 systemName: "icloud.fill",
+                color: CPSLTheme.IconPalette.cloud,
                 accessory: .singleIcon
             ) {
-                model.showComingSoon("coming soon")
+                actions.showComingSoon("coming soon")
             }
 
             CPSLCloudConnectionRow(
                 title: "Cloud Drives",
                 systemName: "externaldrive.fill",
+                color: CPSLTheme.IconPalette.drive,
                 accessory: .providerIcons
             ) {
-                model.showComingSoon("coming soon")
+                actions.showComingSoon("coming soon")
             }
         }
     }
@@ -216,12 +552,13 @@ private struct CPSLFileLocationRow: View {
     let title: LocalizedStringKey
     let detail: String
     let systemName: String
+    let color: Color
     let action: () -> Void
 
     var body: some View {
         Button(action: action) {
             HStack(spacing: CPSLTheme.medium) {
-                CPSLFileIcon(systemName: systemName, color: CPSLTheme.mauve)
+                CPSLFileIcon(systemName: systemName, color: color)
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(title)
@@ -256,12 +593,13 @@ private enum CPSLCloudAccessory {
 private struct CPSLCloudConnectionRow: View {
     let title: LocalizedStringKey
     let systemName: String
+    let color: Color
     let accessory: CPSLCloudAccessory
     let action: () -> Void
 
     var body: some View {
         HStack(spacing: CPSLTheme.medium) {
-            CPSLFileIcon(systemName: systemName, color: CPSLTheme.secondaryText)
+            CPSLFileIcon(systemName: systemName, color: color)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)
@@ -358,31 +696,65 @@ private struct CPSLCloudProviderMark: View {
     }
 }
 
+private enum CPSLFileRowMetrics {
+    static let height: CGFloat = 38
+    static let leading: CGFloat = CPSLTheme.medium
+    static let trailing: CGFloat = CPSLTheme.small
+    static let indent: CGFloat = 24
+    static let disclosureWidth: CGFloat = 24
+    static let iconWidth: CGFloat = 20
+
+    static func leadingPadding(depth: Int, isDirectory: Bool) -> CGFloat {
+        let base = leading + CGFloat(depth) * indent
+        if isDirectory {
+            return base
+        }
+        return base + (disclosureWidth - iconWidth) / 2
+    }
+}
+
 private struct CPSLFileRowsView: View {
-    @ObservedObject var model: CPSLChatModel
+    let snapshot: CPSLFileBrowserFolderSnapshot
     let entries: [CPSLFileEntry]
+    let actions: CPSLFileBrowserActions
+    let depth: Int
+
+    init(
+        snapshot: CPSLFileBrowserFolderSnapshot,
+        entries: [CPSLFileEntry],
+        actions: CPSLFileBrowserActions,
+        depth: Int = 0
+    ) {
+        self.snapshot = snapshot
+        self.entries = entries
+        self.actions = actions
+        self.depth = depth
+    }
 
     var body: some View {
         ForEach(entries) { entry in
             VStack(alignment: .leading, spacing: 0) {
                 CPSLFileRowView(
                     entry: entry,
-                    isExpanded: model.isExpanded(entry),
+                    depth: depth,
+                    isExpanded: snapshot.isExpanded(entry),
                     onOpen: {
-                        model.openFileEntry(entry)
+                        actions.openEntry(entry)
                     },
                     onToggleExpansion: {
-                        model.toggleExpansion(for: entry)
+                        actions.toggleExpansion(entry)
                     }
                 )
 
-                if entry.isDirectory && model.isExpanded(entry) {
-                    if model.isLoading(entry.path) {
-                        CPSLInlineFileLoadingView()
+                if entry.isDirectory && snapshot.isExpanded(entry) {
+                    if snapshot.isLoading(entry.path) {
+                        CPSLInlineFileLoadingView(depth: depth + 1)
                     } else {
                         CPSLFileRowsView(
-                            model: model,
-                            entries: model.children(for: entry.path)
+                            snapshot: snapshot,
+                            entries: snapshot.children(for: entry.path),
+                            actions: actions,
+                            depth: depth + 1
                         )
                     }
                 }
@@ -393,17 +765,19 @@ private struct CPSLFileRowsView: View {
 
 private struct CPSLFileRowView: View {
     let entry: CPSLFileEntry
+    let depth: Int
     let isExpanded: Bool
     let onOpen: () -> Void
     let onToggleExpansion: () -> Void
 
     var body: some View {
         HStack(spacing: CPSLTheme.small) {
-            CPSLFileDisclosureControl(
-                isDirectory: entry.isDirectory,
-                isExpanded: isExpanded,
-                onToggle: onToggleExpansion
-            )
+            if entry.isDirectory {
+                CPSLFileDisclosureControl(
+                    isExpanded: isExpanded,
+                    onToggle: onToggleExpansion
+                )
+            }
 
             Button(action: onOpen) {
                 HStack(spacing: CPSLTheme.medium) {
@@ -422,9 +796,14 @@ private struct CPSLFileRowView: View {
             .buttonStyle(.plain)
             .contentShape(Rectangle())
         }
-        .padding(.horizontal, CPSLTheme.small)
-        .padding(.vertical, CPSLTheme.small)
+        .padding(.leading, leadingPadding)
+        .padding(.trailing, CPSLFileRowMetrics.trailing)
+        .frame(height: CPSLFileRowMetrics.height)
         .contentShape(Rectangle())
+    }
+
+    private var leadingPadding: CGFloat {
+        CPSLFileRowMetrics.leadingPadding(depth: depth, isDirectory: entry.isDirectory)
     }
 
     private var iconName: String {
@@ -442,28 +821,32 @@ private struct CPSLFileRowView: View {
     }
 
     private var iconColor: Color {
-        entry.isDirectory ? CPSLTheme.mauve : CPSLTheme.secondaryText
+        if entry.isDirectory {
+            return CPSLTheme.IconPalette.folder
+        }
+        if entry.pathExtension == "pdf" {
+            return CPSLTheme.IconPalette.pdf
+        }
+        return CPSLTheme.IconPalette.file
     }
 }
 
 private struct CPSLFileDisclosureControl: View {
-    let isDirectory: Bool
     let isExpanded: Bool
     let onToggle: () -> Void
 
     var body: some View {
-        if isDirectory {
-            Button(action: onToggle) {
-                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-                    .font(CPSLTheme.iconFont(size: CPSLTheme.FontSize.caption, weight: .bold))
-                    .frame(width: 24, height: 28)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .foregroundStyle(CPSLTheme.secondaryText)
-        } else {
-            Color.clear.frame(width: 24, height: 28)
+        Button(action: onToggle) {
+            Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                .font(CPSLTheme.iconFont(size: CPSLTheme.FontSize.caption, weight: .bold))
+                .frame(
+                    width: CPSLFileRowMetrics.disclosureWidth,
+                    height: CPSLFileRowMetrics.height
+                )
+                .contentShape(Rectangle())
         }
+        .buttonStyle(.plain)
+        .foregroundStyle(CPSLTheme.secondaryText)
     }
 }
 
@@ -473,9 +856,10 @@ private struct CPSLFileIcon: View {
 
     var body: some View {
         Image(systemName: systemName)
+            .symbolRenderingMode(.hierarchical)
             .font(CPSLTheme.iconMediumFont)
             .foregroundStyle(color)
-            .frame(width: 20)
+            .frame(width: CPSLFileRowMetrics.iconWidth, height: CPSLFileRowMetrics.height)
     }
 }
 
@@ -510,6 +894,8 @@ private struct CPSLFileBrowserEmptyView: View {
 }
 
 private struct CPSLInlineFileLoadingView: View {
+    let depth: Int
+
     var body: some View {
         HStack {
             ProgressView()
@@ -519,8 +905,8 @@ private struct CPSLInlineFileLoadingView: View {
                 .foregroundStyle(CPSLTheme.mutedText)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.leading, 28)
-        .padding(.vertical, CPSLTheme.small)
+        .padding(.leading, CPSLFileRowMetrics.leading + CGFloat(depth) * CPSLFileRowMetrics.indent)
+        .frame(height: CPSLFileRowMetrics.height)
     }
 }
 

--- a/app/apple/herm/Views/Files/CPSLFileOverlayPanel.swift
+++ b/app/apple/herm/Views/Files/CPSLFileOverlayPanel.swift
@@ -74,6 +74,9 @@ struct CPSLFileOverlayPanel<Header: View, Content: View>: View {
     var body: some View {
         VStack(spacing: 0) {
             header
+            Rectangle()
+                .fill(CPSLTheme.text.opacity(0.07))
+                .frame(height: 1)
             content
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }


### PR DESCRIPTION
## Summary
- Rework file browser navigation to animate route snapshots with shared 0.2s motion
- Keep folder/file preview push and pop directions consistent
- Refresh file browser UI metrics and icon palette
- Guard stale async directory loads from updating the active route

## Validation
- `git diff --check`
- `swiftc -parse` on affected Swift files

Note: `scripts/vet-apple-agent-integration.sh` still fails because the existing dirty Xcode project file is missing the expected `Skills,` pattern; that file was not included in this commit.