### PR TITLE
Fix CPSL unsafe pointer handling

### DIFF
--- a/cmd/herm/cpsl_library.go
+++ b/cmd/herm/cpsl_library.go
@@ -9,8 +9,6 @@ import (
 	"unsafe"
 )
 
-type cpslSession uintptr
-
 type cpslBackendMetadata struct {
 	Name         string   `json:"name"`
 	ABIVersion   uint32   `json:"abi_version"`
@@ -85,8 +83,8 @@ func stringFromC(value unsafe.Pointer) string {
 		return ""
 	}
 	var bytes []byte
-	for ptr := uintptr(value); ; ptr++ {
-		b := *(*byte)(unsafe.Pointer(ptr))
+	for offset := uintptr(0); ; offset++ {
+		b := *(*byte)(unsafe.Add(value, offset))
 		if b == 0 {
 			return string(bytes)
 		}

--- a/cmd/herm/cpsl_library_test.go
+++ b/cmd/herm/cpsl_library_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"testing"
+	"unsafe"
+)
+
+func TestStringFromCStopsAtNUL(t *testing.T) {
+	value := []byte("cpsl\x00ignored")
+	if got := stringFromC(unsafe.Pointer(&value[0])); got != "cpsl" {
+		t.Fatalf("stringFromC() = %q, want %q", got, "cpsl")
+	}
+}

--- a/cmd/herm/cpsl_loader_unix.go
+++ b/cmd/herm/cpsl_loader_unix.go
@@ -12,6 +12,8 @@ import (
 	"github.com/ebitengine/purego"
 )
 
+type cpslSession unsafe.Pointer
+
 type cpslNativeLibrary struct {
 	handle uintptr
 
@@ -95,24 +97,24 @@ func (l *cpslNativeLibrary) backendMetadataJSON() (string, error) {
 
 func (l *cpslNativeLibrary) sessionNew(configJSON string) (cpslSession, error) {
 	if err := validateFFIString(configJSON); err != nil {
-		return 0, err
+		return nil, err
 	}
 	session := l.sessionNewFn(configJSON)
 	if session == nil {
-		return 0, fmt.Errorf("CPSL session creation failed: %s", l.lastError())
+		return nil, fmt.Errorf("CPSL session creation failed: %s", l.lastError())
 	}
-	return cpslSession(uintptr(session)), nil
+	return cpslSession(session), nil
 }
 
 func (l *cpslNativeLibrary) sessionFree(session cpslSession) {
-	l.sessionFreeFn(unsafe.Pointer(uintptr(session)))
+	l.sessionFreeFn(unsafe.Pointer(session))
 }
 
 func (l *cpslNativeLibrary) eval(opts cpslSessionEvalOptions) (string, error) {
 	if err := validateFFIString(opts.requestJSON); err != nil {
 		return "", err
 	}
-	value := l.evalFn(unsafe.Pointer(uintptr(opts.session)), opts.requestJSON)
+	value := l.evalFn(unsafe.Pointer(opts.session), opts.requestJSON)
 	if value == nil {
 		return "", fmt.Errorf("CPSL eval failed: %s", l.lastError())
 	}

--- a/cmd/herm/cpsl_loader_unsupported.go
+++ b/cmd/herm/cpsl_loader_unsupported.go
@@ -6,6 +6,8 @@ package main
 
 import "fmt"
 
+type cpslSession uintptr
+
 type cpslNativeLibrary struct{}
 
 func openCPSLNativeLibrary(path string) (*cpslNativeLibrary, error) {

--- a/cmd/herm/cpsl_loader_windows.go
+++ b/cmd/herm/cpsl_loader_windows.go
@@ -11,6 +11,8 @@ import (
 	"unsafe"
 )
 
+type cpslSession uintptr
+
 type cpslNativeLibrary struct {
 	dll              *syscall.DLL
 	abiVersionProc   *syscall.Proc

--- a/cmd/herm/cpsl_worker_test.go
+++ b/cmd/herm/cpsl_worker_test.go
@@ -39,10 +39,9 @@ func TestServeCPSLWorkerEvalPreservesID(t *testing.T) {
 			}
 			return `{"ok":true,"stdout":"ok\n","stderr":"","exit_code":0,"error":null,"warnings":[],"cwd":"/workdir"}`, nil
 		}},
-		session: 1,
-		stdin:   strings.NewReader(request),
-		stdout:  &stdout,
-		stderr:  ioDiscard{},
+		stdin:  strings.NewReader(request),
+		stdout: &stdout,
+		stderr: ioDiscard{},
 	})
 	if err != nil {
 		t.Fatalf("serveCPSLWorker: %v", err)


### PR DESCRIPTION
## Summary

- use unsafe.Add for C-string traversal instead of uintptr pointer arithmetic
- preserve Unix CPSL session handles as unsafe.Pointer while retaining native uintptr handles on Windows
- add focused C-string conversion coverage

## Validation

- go vet ./...
- go test ./...
- go test -gcflags=all=-d=checkptr=2 ./cmd/herm
- Darwin vet and cross-platform loader compilation