### PR TITLE
Add configurable document vision to the CLI and Apple app

### DIFF
--- a/CPSL_BUILD.md
+++ b/CPSL_BUILD.md
@@ -239,8 +239,9 @@ The helper target is built as a dependency of `herm`, so it receives the same
 `PLATFORM_NAME`/`SDK_NAME`, `ARCHS`, and `CONFIGURATION` values as the app
 build and finishes before `ProcessXCFramework` runs. Its declared output is a
 DerivedData stamp file so Xcode does not create a dependency cycle with the
-linked XCFramework path. It is marked always-out-of-date so Xcode invokes the
-script each build, but the ensure script itself is cheap when nothing changed:
+linked XCFramework path. The phase has no declared inputs, so dependency
+analysis invokes it on each build without forcing the phase out of date. The
+ensure script itself is cheap when nothing changed:
 it reuses
 `.herm-cpsl/artifacts/apple/Debug/cpsl.xcframework` or
 `.herm-cpsl/artifacts/apple/Release/cpsl.xcframework` when it contains the

--- a/app/apple/herm.xcodeproj/project.pbxproj
+++ b/app/apple/herm.xcodeproj/project.pbxproj
@@ -273,7 +273,6 @@
 		};
 		85A100072FEA000000000007 /* Build CPSL XCFramework */ = {
 			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/app/apple/herm.xcodeproj/project.pbxproj
+++ b/app/apple/herm.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 				"Skills/apple-context/SKILL.md",
 				"Skills/beautiful-pdfs/print.css",
 				"Skills/beautiful-pdfs/SKILL.md",
+				"Skills/image-vision/SKILL.md",
 				Skills/webbrowser/SKILL.md,
 			);
 			target = 85D75D322FE62B6F0095BAB2 /* herm */;

--- a/app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
+++ b/app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
@@ -852,7 +852,7 @@ extension CPSLChatModel {
     }
 }
 
-private enum CPSLAgentRequestPreparationBuilder {
+private nonisolated enum CPSLAgentRequestPreparationBuilder {
     static func preparedRequestMessages(
         _ preparation: CPSLRequestPreparation,
         estimatedBytesPerToken: Int,

--- a/app/apple/herm/Resources/env.example
+++ b/app/apple/herm/Resources/env.example
@@ -1,6 +1,11 @@
 OPENAI_BASE_URL=https://api.x.ai/v1
 OPENAI_API_KEY=replace-with-token
 OPENAI_MODEL=replace-with-model
+# Optional doc.read vision provider. Each value falls back to the matching
+# OPENAI_* value above, so a single multimodal provider needs no extra config.
+# HERM_VISION_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai
+# HERM_VISION_API_KEY=replace-with-vision-token
+# HERM_VISION_MODEL=replace-with-vision-model
 HERM_MAX_TOOL_ROUNDS=200
 HERM_MAX_OUTPUT_TOKENS=16384
 # HERM_CONTEXT_WINDOW_TOKENS=128000

--- a/app/apple/herm/Services/Agent/CPSLAgentConfig.swift
+++ b/app/apple/herm/Services/Agent/CPSLAgentConfig.swift
@@ -10,6 +10,9 @@ nonisolated struct CPSLAgentConfig: Equatable, Sendable {
     let baseURL: URL
     let token: String
     let model: String
+    let visionBaseURL: URL
+    let visionToken: String
+    let visionModel: String
     let maxToolRounds: Int
     let maxOutputTokens: Int
     let contextWindowTokens: Int?
@@ -41,18 +44,7 @@ nonisolated struct CPSLAgentConfig: Equatable, Sendable {
         else {
             throw CPSLAgentConfigError.missingValue("OPENAI_BASE_URL")
         }
-        let trimmedBaseURL = baseURLValue.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let baseURL = URL(string: trimmedBaseURL),
-                let scheme = baseURL.scheme?.lowercased(),
-                ["http", "https"].contains(scheme),
-                baseURL.host?.isEmpty == false,
-                baseURL.user == nil,
-                baseURL.password == nil,
-                baseURL.query == nil,
-                baseURL.fragment == nil
-        else {
-            throw CPSLAgentConfigError.invalidValue("OPENAI_BASE_URL")
-        }
+        let baseURL = try validatedBaseURL(baseURLValue, key: "OPENAI_BASE_URL")
 
         guard let token = firstValue(
             in: source,
@@ -72,10 +64,31 @@ nonisolated struct CPSLAgentConfig: Equatable, Sendable {
             throw CPSLAgentConfigError.missingValue("OPENAI_MODEL")
         }
 
+        let visionBaseURL: URL
+        if let value = firstValue(
+            in: source,
+            keys: ["HERM_VISION_BASE_URL", "VISION_BASE_URL", "OPENAI_VISION_BASE_URL"]
+        ) {
+            visionBaseURL = try validatedBaseURL(value, key: "HERM_VISION_BASE_URL")
+        } else {
+            visionBaseURL = baseURL
+        }
+        let visionToken = firstValue(
+            in: source,
+            keys: ["HERM_VISION_API_KEY", "VISION_API_KEY", "OPENAI_VISION_API_KEY"]
+        )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? token.trimmingCharacters(in: .whitespacesAndNewlines)
+        let visionModel = firstValue(
+            in: source,
+            keys: ["HERM_VISION_MODEL", "VISION_MODEL", "OPENAI_VISION_MODEL"]
+        )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? model.trimmingCharacters(in: .whitespacesAndNewlines)
+
         return CPSLAgentConfig(
             baseURL: baseURL,
             token: token.trimmingCharacters(in: .whitespacesAndNewlines),
             model: model.trimmingCharacters(in: .whitespacesAndNewlines),
+            visionBaseURL: visionBaseURL,
+            visionToken: visionToken,
+            visionModel: visionModel,
             maxToolRounds: positiveIntValue(
                 in: source,
                 keys: ["HERM_MAX_TOOL_ROUNDS", "MAX_TOOL_ROUNDS"],
@@ -122,6 +135,22 @@ nonisolated struct CPSLAgentConfig: Equatable, Sendable {
             }
         }
         return nil
+    }
+
+    private static func validatedBaseURL(_ value: String, key: String) throws -> URL {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let url = URL(string: trimmed),
+              let scheme = url.scheme?.lowercased(),
+              ["http", "https"].contains(scheme),
+              url.host?.isEmpty == false,
+              url.user == nil,
+              url.password == nil,
+              url.query == nil,
+              url.fragment == nil
+        else {
+            throw CPSLAgentConfigError.invalidValue(key)
+        }
+        return url
     }
 
     private static func positiveIntValue(
@@ -171,7 +200,16 @@ nonisolated struct CPSLAgentConfig: Equatable, Sendable {
             environment["XAI_API_KEY"] != nil ||
             environment["OPENAI_MODEL"] != nil ||
             environment["MODEL"] != nil ||
-            environment["XAI_MODEL"] != nil
+            environment["XAI_MODEL"] != nil ||
+            environment["HERM_VISION_BASE_URL"] != nil ||
+            environment["VISION_BASE_URL"] != nil ||
+            environment["OPENAI_VISION_BASE_URL"] != nil ||
+            environment["HERM_VISION_API_KEY"] != nil ||
+            environment["VISION_API_KEY"] != nil ||
+            environment["OPENAI_VISION_API_KEY"] != nil ||
+            environment["HERM_VISION_MODEL"] != nil ||
+            environment["VISION_MODEL"] != nil ||
+            environment["OPENAI_VISION_MODEL"] != nil
     }
 }
 

--- a/app/apple/herm/Services/Agent/CPSLOpenAIClient.swift
+++ b/app/apple/herm/Services/Agent/CPSLOpenAIClient.swift
@@ -85,3 +85,112 @@ nonisolated struct CPSLOpenAIStreamRequest: Sendable {
     let tools: [CPSLOpenAITool]
     let maxTokens: Int?
 }
+
+nonisolated struct CPSLVisionInput: Sendable {
+    let data: Data
+    let mediaType: String
+}
+
+actor CPSLVisionClient {
+    private let config: CPSLAgentConfig
+    private let session: URLSession
+
+    init(config: CPSLAgentConfig, session: URLSession = .shared) {
+        self.config = config
+        self.session = session
+    }
+
+    func read(inputs: [CPSLVisionInput], query: String) async throws -> String {
+        guard !inputs.isEmpty,
+              inputs.allSatisfy({ ["image/jpeg", "image/png"].contains($0.mediaType) })
+        else {
+            throw CPSLOpenAIError.provider(
+                "This vision endpoint accepts JPEG and PNG inputs. Use structural mode for other file types."
+            )
+        }
+        var content = [CPSLVisionContentPart(type: "text", text: query, imageURL: nil)]
+        content.append(contentsOf: inputs.map { input in
+            CPSLVisionContentPart(
+                type: "image_url",
+                text: nil,
+                imageURL: CPSLVisionImageURL(
+                    url: "data:\(input.mediaType);base64,\(input.data.base64EncodedString())"
+                )
+            )
+        })
+        let body = CPSLVisionChatRequest(
+            model: config.visionModel,
+            messages: [CPSLVisionMessage(role: "user", content: content)],
+            maxCompletionTokens: config.maxOutputTokens
+        )
+        var request = URLRequest(url: config.visionBaseURL
+            .appendingPathComponent("chat")
+            .appendingPathComponent("completions"))
+        request.httpMethod = "POST"
+        request.httpBody = try JSONEncoder().encode(body)
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("Bearer \(config.visionToken)", forHTTPHeaderField: "Authorization")
+
+        let (data, response) = try await session.data(for: request)
+        if let httpResponse = response as? HTTPURLResponse,
+           !(200..<300).contains(httpResponse.statusCode) {
+            throw CPSLOpenAIError.httpStatus(
+                httpResponse.statusCode,
+                String(decoding: data.prefix(4_096), as: UTF8.self)
+            )
+        }
+        let completion = try JSONDecoder().decode(CPSLVisionChatResponse.self, from: data)
+        guard let text = completion.choices.first?.message.content?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !text.isEmpty
+        else {
+            throw CPSLOpenAIError.provider("Vision model returned no text.")
+        }
+        return text
+    }
+}
+
+nonisolated struct CPSLVisionChatRequest: Encodable, Sendable {
+    let model: String
+    let messages: [CPSLVisionMessage]
+    let maxCompletionTokens: Int
+
+    enum CodingKeys: String, CodingKey {
+        case model
+        case messages
+        case maxCompletionTokens = "max_completion_tokens"
+    }
+}
+
+nonisolated struct CPSLVisionMessage: Encodable, Sendable {
+    let role: String
+    let content: [CPSLVisionContentPart]
+}
+
+nonisolated struct CPSLVisionContentPart: Encodable, Sendable {
+    let type: String
+    let text: String?
+    let imageURL: CPSLVisionImageURL?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case text
+        case imageURL = "image_url"
+    }
+}
+
+nonisolated struct CPSLVisionImageURL: Encodable, Sendable {
+    let url: String
+}
+
+private nonisolated struct CPSLVisionChatResponse: Decodable, Sendable {
+    let choices: [CPSLVisionChoice]
+}
+
+private nonisolated struct CPSLVisionChoice: Decodable, Sendable {
+    let message: CPSLVisionResponseMessage
+}
+
+private nonisolated struct CPSLVisionResponseMessage: Decodable, Sendable {
+    let content: String?
+}

--- a/app/apple/herm/Services/CPSLDebugService.swift
+++ b/app/apple/herm/Services/CPSLDebugService.swift
@@ -48,6 +48,21 @@ private nonisolated final class CPSLLocationCallbackBox: @unchecked Sendable {
     }
 }
 
+private nonisolated final class CPSLVisionCallbackBox: @unchecked Sendable {
+    let client: CPSLVisionClient?
+    let configurationError: String?
+
+    init() {
+        do {
+            client = CPSLVisionClient(config: try CPSLAgentConfig.load())
+            configurationError = nil
+        } catch {
+            client = nil
+            configurationError = error.localizedDescription
+        }
+    }
+}
+
 private typealias CPSLFileActivityHandleFunction = @convention(c) (
     UnsafeMutableRawPointer?,
     UnsafePointer<CChar>?,
@@ -80,6 +95,25 @@ private typealias CPSLLocationUserDataFreeFunction = @convention(c) (
     UnsafeMutableRawPointer?
 ) -> Void
 
+private typealias CPSLVisionHandleFunction = @convention(c) (
+    UnsafeMutableRawPointer?,
+    UnsafeRawPointer?,
+    UInt,
+    UnsafePointer<CChar>?,
+    UnsafeMutableRawPointer?
+) -> Void
+
+private typealias CPSLVisionUserDataFreeFunction = @convention(c) (
+    UnsafeMutableRawPointer?
+) -> Void
+
+private typealias CPSLVisionRespondFunction = @convention(c) (
+    UnsafeMutableRawPointer?,
+    UnsafeRawPointer?,
+    UInt,
+    UInt8
+) -> Void
+
 private nonisolated struct CPSLFileActivityCallbacks {
     var user_data: UnsafeMutableRawPointer?
     var handle_activity: CPSLFileActivityHandleFunction?
@@ -97,6 +131,19 @@ private nonisolated struct CPSLLocationCallbacks {
     var handle_json: CPSLLocationHandleJSONFunction?
     var string_free: CPSLLocationStringFreeFunction?
     var user_data_free: CPSLLocationUserDataFreeFunction?
+}
+
+private nonisolated struct CPSLVisionInputFFI {
+    var data: UnsafeRawPointer?
+    var data_len: UInt
+    var filename: UnsafePointer<CChar>?
+    var media_type: UnsafePointer<CChar>?
+}
+
+private nonisolated struct CPSLVisionCallbacks {
+    var user_data: UnsafeMutableRawPointer?
+    var handle: CPSLVisionHandleFunction?
+    var user_data_free: CPSLVisionUserDataFreeFunction?
 }
 
 private typealias CPSLSessionNewWithCallbacksFunction = @convention(c) (
@@ -120,6 +167,15 @@ private typealias CPSLSessionNewWithHostCallbacksV2Function = @convention(c) (
     UnsafeRawPointer?
 ) -> OpaquePointer?
 
+private typealias CPSLSessionNewWithHostCallbacksV3Function = @convention(c) (
+    UnsafePointer<CChar>?,
+    UnsafePointer<cpsl_webbrowser_callbacks_t>?,
+    UnsafeRawPointer?,
+    UnsafeRawPointer?,
+    UnsafeRawPointer?,
+    UnsafeRawPointer?
+) -> OpaquePointer?
+
 private nonisolated final class CPSLWebBrowserCallbackResponse: @unchecked Sendable {
     private let lock = NSLock()
     private var value: String
@@ -135,6 +191,24 @@ private nonisolated final class CPSLWebBrowserCallbackResponse: @unchecked Senda
     }
 
     func get() -> String {
+        lock.lock()
+        let value = value
+        lock.unlock()
+        return value
+    }
+}
+
+private nonisolated final class CPSLVisionCallbackResponse: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Result<String, Error>?
+
+    func set(_ value: Result<String, Error>) {
+        lock.lock()
+        self.value = value
+        lock.unlock()
+    }
+
+    func get() -> Result<String, Error>? {
         lock.lock()
         let value = value
         lock.unlock()
@@ -271,6 +345,107 @@ private nonisolated let cpslCalendarActivityUserDataFree: CPSLCalendarActivityUs
     Unmanaged<CPSLCalendarActivityCallbackBox>.fromOpaque(userData).release()
 }
 
+private nonisolated let cpslVisionHandle: CPSLVisionHandleFunction = {
+    userData, rawInputs, inputCount, queryPointer, responseContext in
+    guard let respond = cpslVisionRespondFunction(), let responseContext else {
+        return
+    }
+
+    func complete(_ value: String, isError: Bool) {
+        let data = Data(value.utf8)
+        data.withUnsafeBytes { bytes in
+            respond(responseContext, bytes.baseAddress, UInt(bytes.count), isError ? 1 : 0)
+        }
+    }
+
+    guard let userData, let queryPointer else {
+        complete("vision callback received NULL input", isError: true)
+        return
+    }
+    guard !Thread.isMainThread else {
+        complete("vision callback cannot run on the main thread", isError: true)
+        return
+    }
+    guard inputCount == 0 || rawInputs != nil else {
+        complete("vision callback received a NULL input array", isError: true)
+        return
+    }
+    guard inputCount <= UInt(Int.max) else {
+        complete("vision callback received too many inputs", isError: true)
+        return
+    }
+
+    let callbackBox = Unmanaged<CPSLVisionCallbackBox>
+        .fromOpaque(userData)
+        .takeUnretainedValue()
+    guard let client = callbackBox.client else {
+        complete(
+            callbackBox.configurationError ?? "Vision model configuration is unavailable.",
+            isError: true
+        )
+        return
+    }
+
+    let inputsPointer = rawInputs?.assumingMemoryBound(to: CPSLVisionInputFFI.self)
+    var inputs: [CPSLVisionInput] = []
+    inputs.reserveCapacity(Int(inputCount))
+    for index in 0..<Int(inputCount) {
+        guard let ffiInput = inputsPointer?[index],
+              ffiInput.data_len == 0 || ffiInput.data != nil,
+              ffiInput.data_len <= UInt(Int.max),
+              let mediaTypePointer = ffiInput.media_type
+        else {
+            complete("vision callback received an invalid input", isError: true)
+            return
+        }
+        let data = ffiInput.data_len == 0
+            ? Data()
+            : Data(bytes: ffiInput.data!, count: Int(ffiInput.data_len))
+        inputs.append(CPSLVisionInput(
+            data: data,
+            mediaType: String(cString: mediaTypePointer)
+        ))
+    }
+
+    let query = String(cString: queryPointer)
+    let response = CPSLVisionCallbackResponse()
+    let semaphore = DispatchSemaphore(value: 0)
+    let task = Task {
+        do {
+            response.set(.success(try await client.read(
+                inputs: inputs,
+                query: query
+            )))
+        } catch {
+            response.set(.failure(error))
+        }
+        semaphore.signal()
+    }
+
+    if semaphore.wait(timeout: .now() + .seconds(55)) == .timedOut {
+        task.cancel()
+        complete("vision callback timed out", isError: true)
+        return
+    }
+    guard let result = response.get() else {
+        complete("vision callback did not complete", isError: true)
+        return
+    }
+    switch result {
+    case .success(let text):
+        complete(text, isError: false)
+    case .failure(let error):
+        complete(error.localizedDescription, isError: true)
+    }
+}
+
+private nonisolated let cpslVisionUserDataFree: CPSLVisionUserDataFreeFunction = { userData in
+    guard let userData else {
+        return
+    }
+    Unmanaged<CPSLVisionCallbackBox>.fromOpaque(userData).release()
+}
+
 private nonisolated func cpslSessionNewWithCallbacksFunction() -> CPSLSessionNewWithCallbacksFunction? {
 #if canImport(Darwin)
     let lookupHandle = UnsafeMutableRawPointer(bitPattern: -2)
@@ -314,6 +489,36 @@ private nonisolated func cpslSessionNewWithHostCallbacksV2Function() -> CPSLSess
         return nil
     }
     return unsafeBitCast(symbol, to: CPSLSessionNewWithHostCallbacksV2Function.self)
+}
+
+private nonisolated func cpslSessionNewWithHostCallbacksV3Function() -> CPSLSessionNewWithHostCallbacksV3Function? {
+#if canImport(Darwin)
+    let lookupHandle = UnsafeMutableRawPointer(bitPattern: -2)
+#else
+    let lookupHandle: UnsafeMutableRawPointer? = nil
+#endif
+    let symbol = "cpsl_session_new_with_host_callbacks_v3".withCString { name in
+        dlsym(lookupHandle, name)
+    }
+    guard let symbol else {
+        return nil
+    }
+    return unsafeBitCast(symbol, to: CPSLSessionNewWithHostCallbacksV3Function.self)
+}
+
+private nonisolated func cpslVisionRespondFunction() -> CPSLVisionRespondFunction? {
+#if canImport(Darwin)
+    let lookupHandle = UnsafeMutableRawPointer(bitPattern: -2)
+#else
+    let lookupHandle: UnsafeMutableRawPointer? = nil
+#endif
+    let symbol = "cpsl_vision_respond".withCString { name in
+        dlsym(lookupHandle, name)
+    }
+    guard let symbol else {
+        return nil
+    }
+    return unsafeBitCast(symbol, to: CPSLVisionRespondFunction.self)
 }
 
 private nonisolated func cpslWebBrowserOwnedErrorCString(_ message: String) -> UnsafeMutablePointer<CChar>? {
@@ -1029,12 +1234,14 @@ actor CPSLDebugService {
         let fileActivityCallbackBox = CPSLFileActivityCallbackBox(notifier: fileActivityNotifier)
         let calendarActivityCallbackBox = CPSLCalendarActivityCallbackBox(notifier: calendarActivityNotifier)
         let locationCallbackBox = CPSLLocationCallbackBox(service: location)
+        let visionCallbackBox = CPSLVisionCallbackBox()
         let result = await Self.performBlockingSessionInit(
             configJSON: configJSON,
             callbackBox: callbackBox,
             fileActivityCallbackBox: fileActivityCallbackBox,
             calendarActivityCallbackBox: calendarActivityCallbackBox,
-            locationCallbackBox: locationCallbackBox
+            locationCallbackBox: locationCallbackBox,
+            visionCallbackBox: visionCallbackBox
         )
         guard let newSession = result.pointer else {
             return result.errorMessage ?? "cpsl_session_new returned NULL"
@@ -1175,7 +1382,8 @@ actor CPSLDebugService {
         callbackBox: CPSLWebBrowserCallbackBox,
         fileActivityCallbackBox: CPSLFileActivityCallbackBox,
         calendarActivityCallbackBox: CPSLCalendarActivityCallbackBox,
-        locationCallbackBox: CPSLLocationCallbackBox
+        locationCallbackBox: CPSLLocationCallbackBox,
+        visionCallbackBox: CPSLVisionCallbackBox
     ) async -> CPSLSessionInitResult {
         await withCheckedContinuation { continuation in
             DispatchQueue.global(qos: .default).async {
@@ -1184,7 +1392,8 @@ actor CPSLDebugService {
                     callbackBox: callbackBox,
                     fileActivityCallbackBox: fileActivityCallbackBox,
                     calendarActivityCallbackBox: calendarActivityCallbackBox,
-                    locationCallbackBox: locationCallbackBox
+                    locationCallbackBox: locationCallbackBox,
+                    visionCallbackBox: visionCallbackBox
                 ))
             }
         }
@@ -1195,7 +1404,8 @@ actor CPSLDebugService {
         callbackBox: CPSLWebBrowserCallbackBox,
         fileActivityCallbackBox: CPSLFileActivityCallbackBox,
         calendarActivityCallbackBox: CPSLCalendarActivityCallbackBox,
-        locationCallbackBox: CPSLLocationCallbackBox
+        locationCallbackBox: CPSLLocationCallbackBox,
+        visionCallbackBox: CPSLVisionCallbackBox
     ) -> CPSLSessionInitResult {
         configureCPSLLibraryDirectory()
         let userData = Unmanaged.passRetained(callbackBox).toOpaque()
@@ -1224,9 +1434,37 @@ actor CPSLDebugService {
             string_free: cpslLocationStringFree,
             user_data_free: cpslLocationUserDataFree
         )
+        let visionUserData = Unmanaged.passRetained(visionCallbackBox).toOpaque()
+        var visionCallbacks = CPSLVisionCallbacks(
+            user_data: visionUserData,
+            handle: cpslVisionHandle,
+            user_data_free: cpslVisionUserDataFree
+        )
         let pointer: OpaquePointer?
         let fallback: String
-        if let sessionNewWithHostCallbacksV2 = cpslSessionNewWithHostCallbacksV2Function() {
+        if let sessionNewWithHostCallbacksV3 = cpslSessionNewWithHostCallbacksV3Function(),
+           cpslVisionRespondFunction() != nil {
+            pointer = configJSON.withCString { configPointer in
+                withUnsafePointer(to: &fileActivityCallbacks) { fileActivityCallbacksPointer in
+                    withUnsafePointer(to: &calendarActivityCallbacks) { calendarActivityCallbacksPointer in
+                        withUnsafePointer(to: &locationCallbacks) { locationCallbacksPointer in
+                            withUnsafePointer(to: &visionCallbacks) { visionCallbacksPointer in
+                                sessionNewWithHostCallbacksV3(
+                                    configPointer,
+                                    &callbacks,
+                                    UnsafeRawPointer(fileActivityCallbacksPointer),
+                                    UnsafeRawPointer(calendarActivityCallbacksPointer),
+                                    UnsafeRawPointer(locationCallbacksPointer),
+                                    UnsafeRawPointer(visionCallbacksPointer)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+            fallback = "cpsl_session_new_with_host_callbacks_v3 returned NULL"
+        } else if let sessionNewWithHostCallbacksV2 = cpslSessionNewWithHostCallbacksV2Function() {
+            cpslVisionUserDataFree(visionUserData)
             pointer = configJSON.withCString { configPointer in
                 withUnsafePointer(to: &fileActivityCallbacks) { fileActivityCallbacksPointer in
                     withUnsafePointer(to: &calendarActivityCallbacks) { calendarActivityCallbacksPointer in
@@ -1244,6 +1482,7 @@ actor CPSLDebugService {
             }
             fallback = "cpsl_session_new_with_host_callbacks_v2 returned NULL"
         } else if let sessionNewWithHostCallbacks = cpslSessionNewWithHostCallbacksFunction() {
+            cpslVisionUserDataFree(visionUserData)
             cpslCalendarActivityUserDataFree(calendarActivityUserData)
             pointer = configJSON.withCString { configPointer in
                 withUnsafePointer(to: &fileActivityCallbacks) { fileActivityCallbacksPointer in
@@ -1259,6 +1498,7 @@ actor CPSLDebugService {
             }
             fallback = "cpsl_session_new_with_host_callbacks returned NULL"
         } else if let sessionNewWithCallbacks = cpslSessionNewWithCallbacksFunction() {
+            cpslVisionUserDataFree(visionUserData)
             cpslCalendarActivityUserDataFree(calendarActivityUserData)
             cpslLocationUserDataFree(locationUserData)
             pointer = configJSON.withCString { configPointer in
@@ -1272,6 +1512,7 @@ actor CPSLDebugService {
             }
             fallback = "cpsl_session_new_with_callbacks returned NULL"
         } else {
+            cpslVisionUserDataFree(visionUserData)
             cpslFileActivityUserDataFree(fileActivityUserData)
             cpslCalendarActivityUserDataFree(calendarActivityUserData)
             cpslLocationUserDataFree(locationUserData)

--- a/app/apple/herm/Services/CPSLWebBrowserService.swift
+++ b/app/apple/herm/Services/CPSLWebBrowserService.swift
@@ -2071,7 +2071,7 @@ private final class CPSLWebBrowserKeyboardMonitor {
                 object: nil,
                 queue: .main
             ) { [weak self] notification in
-                Task { @MainActor in
+                MainActor.assumeIsolated {
                     self?.record(notification)
                 }
             }

--- a/app/apple/herm/Skills/image-vision/SKILL.md
+++ b/app/apple/herm/Skills/image-vision/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: image-vision
+description: Inspect attached or local images and visually analyze PDFs with CPSL vision. Use for photos, screenshots, scans, charts, diagrams, OCR, handwriting, UI inspection, or any task that depends on pixels, layout, or other non-structural page content.
+---
+
+# Image Vision
+
+Use CPSL's `doc` module with the exact attachment or local path. Do not guess or rewrite the path.
+
+## Read One File
+
+Start with the simplest form:
+
+```lua
+local result = doc.read("/attachments/conversation-id/photo.jpeg")
+print(result)
+```
+
+Images and PDFs default to vision when the vision callback is available. The built-in prompt extracts the document as structured Markdown and describes images, charts, diagrams, and other visual elements. This default is appropriate for most requests. Other supported document types default to structural extraction.
+
+Treat the returned text as the visual model's analysis, then answer the user's question rather than merely repeating the extraction.
+
+Supported visual inputs include PDF, PNG, JPEG, WebP, and GIF files.
+
+## Read Multiple Files
+
+Issue all asynchronous reads before awaiting any result so vision requests can run in parallel:
+
+```lua
+local front = doc.readAsync("/attachments/conversation-id/front.jpeg")
+local back = doc.readAsync("/attachments/conversation-id/back.jpeg")
+
+local frontText = front:await()
+local backText = back:await()
+print(frontText)
+print(backText)
+```
+
+## Customize The Prompt
+
+Set `query` only when the user needs a narrower analysis, special output format, or more detail than the default extraction:
+
+```lua
+local result = doc.read("/attachments/conversation-id/chart.jpeg", {
+  query = "Extract the chart's title, axis labels, legend, and data values as a Markdown table."
+})
+print(result)
+```
+
+Preserve the user's request in the query. Set `mode = "vision"` when an explicit visual-mode override is useful:
+
+```lua
+local result = doc.read("/attachments/conversation-id/report.pdf", {
+  mode = "vision",
+  query = "Describe the page layout and all diagrams."
+})
+print(result)
+```
+
+Use `mode = "structural"` for a PDF when machine-readable text matters and visual interpretation is unnecessary. When both appearance and exact embedded text matter, run vision and structural reads separately and distinguish their results. Do not substitute structural extraction for requested visual analysis.
+
+## Failure Handling
+
+- Treat `vision callback ... not available`, provider configuration, authentication, and unsupported-model errors as authoritative. Report the limitation and stop after that failure.
+- Do not retry through image resizing, EXIF inspection, color or pixel sampling, ASCII rendering, browser upload, network services, or invented OCR APIs.
+- Do not silently fall back to structural mode when the task requires seeing pixels, layout, handwriting, charts, or diagrams.
+- Never claim to have seen or analyzed a file unless the vision read succeeded.

--- a/app/apple/herm/Views/Composer/CPSLPromptComposerView.swift
+++ b/app/apple/herm/Views/Composer/CPSLPromptComposerView.swift
@@ -47,7 +47,7 @@ private struct CPSLPromptTextView: UIViewRepresentable {
         }
 
         let didChangeTraits = applyInputTraits(to: textView)
-        if !UIEdgeInsetsEqualToEdgeInsets(textView.textContainerInset, textContainerInset) {
+        if textView.textContainerInset != textContainerInset {
             textView.textContainerInset = textContainerInset
         }
         textView.isEditable = !isDisabled

--- a/cmd/herm/config.go
+++ b/cmd/herm/config.go
@@ -744,31 +744,6 @@ func (c Config) resolveExplorationModelResult(models []ModelDef) configuredModel
 	}
 }
 
-// resolveVisionModel returns the model used by CPSL vision document reads.
-// Vision is optional in config and follows the active model when unset.
-func (c Config) resolveVisionModel(models []ModelDef) string {
-	return c.resolveVisionModelResult(models).ResolvedModelID
-}
-
-func (c Config) resolveVisionModelResult(models []ModelDef) configuredModelResolution {
-	if c.VisionModel == "" {
-		return configuredModelResolution{ResolvedModelID: c.resolveActiveModel(models)}
-	}
-	available := c.availableModels(models)
-	lookup := c.lookupConfiguredModelID(lookupConfiguredModelIDOptions{modelID: c.VisionModel, smartDefault: defaultCanonicalVisionModel, available: available, models: models})
-	if lookup.Status == configuredModelUsable {
-		return lookup
-	}
-	fallback := c.resolveActiveModel(models)
-	return configuredModelResolution{
-		ConfiguredModelID: c.VisionModel,
-		ResolvedModelID:   fallback,
-		Fallback:          true,
-		Status:            lookup.Status,
-		Diagnostic:        configuredModelDiagnostic(configuredModelDiagnosticOptions{field: "vision_model", configured: c.VisionModel, fallback: fallback, status: lookup.Status}),
-	}
-}
-
 type lookupConfiguredModelIDOptions struct {
 	modelID      string
 	smartDefault string

--- a/cmd/herm/config.go
+++ b/cmd/herm/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	Routing               *RoutingPolicy              `json:"routing,omitempty"`
 	ActiveModel           string                      `json:"active_model,omitempty"`
 	ExplorationModel      string                      `json:"exploration_model,omitempty"` // model for sub-agents; falls back to ActiveModel
+	VisionModel           string                      `json:"vision_model,omitempty"`      // model for doc vision; falls back to ActiveModel
 	ModelSortCol          string                      `json:"model_sort_col,omitempty"`    // "name","provider","price","context"
 	ModelSortDirs         map[string]bool             `json:"model_sort_dirs,omitempty"`   // column name → ascending (per-column)
 	SubAgentMaxTurns      int                         `json:"sub_agent_max_turns,omitempty"`
@@ -740,6 +741,31 @@ func (c Config) resolveExplorationModelResult(models []ModelDef) configuredModel
 		Fallback:          true,
 		Status:            lookup.Status,
 		Diagnostic:        configuredModelDiagnostic(configuredModelDiagnosticOptions{field: "exploration_model", configured: c.ExplorationModel, fallback: fallback, status: lookup.Status}),
+	}
+}
+
+// resolveVisionModel returns the model used by CPSL vision document reads.
+// Vision is optional in config and follows the active model when unset.
+func (c Config) resolveVisionModel(models []ModelDef) string {
+	return c.resolveVisionModelResult(models).ResolvedModelID
+}
+
+func (c Config) resolveVisionModelResult(models []ModelDef) configuredModelResolution {
+	if c.VisionModel == "" {
+		return configuredModelResolution{ResolvedModelID: c.resolveActiveModel(models)}
+	}
+	available := c.availableModels(models)
+	lookup := c.lookupConfiguredModelID(lookupConfiguredModelIDOptions{modelID: c.VisionModel, smartDefault: defaultCanonicalVisionModel, available: available, models: models})
+	if lookup.Status == configuredModelUsable {
+		return lookup
+	}
+	fallback := c.resolveActiveModel(models)
+	return configuredModelResolution{
+		ConfiguredModelID: c.VisionModel,
+		ResolvedModelID:   fallback,
+		Fallback:          true,
+		Status:            lookup.Status,
+		Diagnostic:        configuredModelDiagnostic(configuredModelDiagnosticOptions{field: "vision_model", configured: c.VisionModel, fallback: fallback, status: lookup.Status}),
 	}
 }
 

--- a/cmd/herm/config_storage.go
+++ b/cmd/herm/config_storage.go
@@ -16,6 +16,7 @@ import (
 type ProjectConfig struct {
 	ActiveModel       string `json:"active_model,omitempty"`
 	ExplorationModel  string `json:"exploration_model,omitempty"`
+	VisionModel       string `json:"vision_model,omitempty"`
 	Personality       string `json:"personality,omitempty"`
 	SubAgentMaxTurns  int    `json:"sub_agent_max_turns,omitempty"`
 	ExploreMaxTurns   int    `json:"explore_max_turns,omitempty"`
@@ -41,6 +42,9 @@ func mergeConfigs(opts mergeConfigsOptions) Config {
 	}
 	if project.ExplorationModel != "" {
 		merged.ExplorationModel = project.ExplorationModel
+	}
+	if project.VisionModel != "" {
+		merged.VisionModel = project.VisionModel
 	}
 	if project.Personality != "" {
 		merged.Personality = project.Personality
@@ -231,6 +235,7 @@ func normalizeLoadedConfig(cfg Config) Config {
 	cfg = backfillLegacyConfigFieldsFromDeployments(cfg)
 	cfg.ActiveModel = migrateLoadedModelIDWithOfferings(migrateLoadedModelIDOptions{cfg: cfg, modelID: cfg.ActiveModel, smartDefault: defaultCanonicalActiveModel, offerings: defaultModelIDMigrationOfferings()})
 	cfg.ExplorationModel = migrateLoadedModelIDWithOfferings(migrateLoadedModelIDOptions{cfg: cfg, modelID: cfg.ExplorationModel, smartDefault: defaultCanonicalExplorationModel, offerings: defaultModelIDMigrationOfferings()})
+	cfg.VisionModel = migrateLoadedModelIDWithOfferings(migrateLoadedModelIDOptions{cfg: cfg, modelID: cfg.VisionModel, smartDefault: defaultCanonicalVisionModel, offerings: defaultModelIDMigrationOfferings()})
 	return cfg
 }
 
@@ -293,6 +298,7 @@ func normalizeConfigForModels(opts configModelsOptions) Config {
 	offerings = append(offerings, modelIDMigrationOfferingsFromModels(models)...)
 	cfg.ActiveModel = migrateLoadedModelIDWithOfferings(migrateLoadedModelIDOptions{cfg: cfg, modelID: cfg.ActiveModel, smartDefault: defaultCanonicalActiveModel, offerings: offerings})
 	cfg.ExplorationModel = migrateLoadedModelIDWithOfferings(migrateLoadedModelIDOptions{cfg: cfg, modelID: cfg.ExplorationModel, smartDefault: defaultCanonicalExplorationModel, offerings: offerings})
+	cfg.VisionModel = migrateLoadedModelIDWithOfferings(migrateLoadedModelIDOptions{cfg: cfg, modelID: cfg.VisionModel, smartDefault: defaultCanonicalVisionModel, offerings: offerings})
 	return cfg
 }
 
@@ -458,6 +464,7 @@ func normalizeProjectConfigWithOfferings(opts normalizeProjectConfigWithOffering
 	pc, offerings := opts.pc, opts.offerings
 	pc.ActiveModel = migrateProjectModelIDWithOfferings(migrateProjectModelIDOptions{modelID: pc.ActiveModel, smartDefault: defaultCanonicalActiveModel, offerings: offerings})
 	pc.ExplorationModel = migrateProjectModelIDWithOfferings(migrateProjectModelIDOptions{modelID: pc.ExplorationModel, smartDefault: defaultCanonicalExplorationModel, offerings: offerings})
+	pc.VisionModel = migrateProjectModelIDWithOfferings(migrateProjectModelIDOptions{modelID: pc.VisionModel, smartDefault: defaultCanonicalVisionModel, offerings: offerings})
 	return pc
 }
 

--- a/cmd/herm/config_test.go
+++ b/cmd/herm/config_test.go
@@ -276,6 +276,7 @@ func TestSaveConfigPreservesUnknownCanonicalModels(t *testing.T) {
 	cfg := Config{
 		ActiveModel:      "openai/newly-refreshed-model",
 		ExplorationModel: "z-ai/new-openrouter-only:free",
+		VisionModel:      "google/new-vision-model",
 		Deployments: map[string]DeploymentConfig{
 			"openrouter": {APIKey: "sk-or"},
 		},
@@ -287,8 +288,8 @@ func TestSaveConfigPreservesUnknownCanonicalModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loadConfigFrom: %v", err)
 	}
-	if loaded.ActiveModel != cfg.ActiveModel || loaded.ExplorationModel != cfg.ExplorationModel {
-		t.Fatalf("canonical model IDs should survive save/load, got active=%q exploration=%q", loaded.ActiveModel, loaded.ExplorationModel)
+	if loaded.ActiveModel != cfg.ActiveModel || loaded.ExplorationModel != cfg.ExplorationModel || loaded.VisionModel != cfg.VisionModel {
+		t.Fatalf("canonical model IDs should survive save/load, got active=%q exploration=%q vision=%q", loaded.ActiveModel, loaded.ExplorationModel, loaded.VisionModel)
 	}
 }
 
@@ -435,7 +436,7 @@ func TestCfgTabNamesStructure(t *testing.T) {
 func TestProjectTabFieldLabels(t *testing.T) {
 	a := &App{}
 	fields := a.projectTabFields()
-	wantLabels := []string{"Model", "Exploration", "Personality", "Sub-Agent Max Turns", "Thinking"}
+	wantLabels := []string{"Model", "Exploration", "Vision", "Personality", "Sub-Agent Max Turns", "Thinking"}
 	if len(fields) != len(wantLabels) {
 		t.Fatalf("projectTabFields returned %d fields, want %d", len(fields), len(wantLabels))
 	}
@@ -454,6 +455,7 @@ func TestProjectTabFieldGetSet(t *testing.T) {
 		cfgProjectDraft: ProjectConfig{
 			ActiveModel:      "test-model",
 			ExplorationModel: "explore-model",
+			VisionModel:      "vision-model",
 			Personality:      "brief",
 			SubAgentMaxTurns: 7,
 		},
@@ -467,10 +469,13 @@ func TestProjectTabFieldGetSet(t *testing.T) {
 	if v := fields[1].get(Config{}); v != "explore-model" {
 		t.Errorf("ExplorationModel get = %q, want %q", v, "explore-model")
 	}
-	if v := fields[2].get(Config{}); v != "brief" {
+	if v := fields[2].get(Config{}); v != "vision-model" {
+		t.Errorf("VisionModel get = %q, want %q", v, "vision-model")
+	}
+	if v := fields[3].get(Config{}); v != "brief" {
 		t.Errorf("Personality get = %q, want %q", v, "brief")
 	}
-	if v := fields[3].get(Config{}); v != "7" {
+	if v := fields[4].get(Config{}); v != "7" {
 		t.Errorf("SubAgentMaxTurns get = %q, want %q", v, "7")
 	}
 
@@ -483,11 +488,15 @@ func TestProjectTabFieldGetSet(t *testing.T) {
 	if a.cfgProjectDraft.ExplorationModel != "new-explore" {
 		t.Errorf("after set, ExplorationModel = %q, want %q", a.cfgProjectDraft.ExplorationModel, "new-explore")
 	}
-	fields[2].set(nil, "verbose")
+	fields[2].set(nil, "new-vision")
+	if a.cfgProjectDraft.VisionModel != "new-vision" {
+		t.Errorf("after set, VisionModel = %q, want %q", a.cfgProjectDraft.VisionModel, "new-vision")
+	}
+	fields[3].set(nil, "verbose")
 	if a.cfgProjectDraft.Personality != "verbose" {
 		t.Errorf("after set, Personality = %q, want %q", a.cfgProjectDraft.Personality, "verbose")
 	}
-	fields[3].set(nil, "20")
+	fields[4].set(nil, "20")
 	if a.cfgProjectDraft.SubAgentMaxTurns != 20 {
 		t.Errorf("after set, SubAgentMaxTurns = %d, want 20", a.cfgProjectDraft.SubAgentMaxTurns)
 	}
@@ -760,7 +769,7 @@ func TestRoutingTabHasSelectableActions(t *testing.T) {
 func TestProjectTabSubAgentClearsOnEmpty(t *testing.T) {
 	a := &App{cfgProjectDraft: ProjectConfig{SubAgentMaxTurns: 10}}
 	fields := a.projectTabFields()
-	fields[3].set(nil, "") // Sub-Agent Max Turns is at index 3 now
+	fields[4].set(nil, "")
 	if a.cfgProjectDraft.SubAgentMaxTurns != 0 {
 		t.Errorf("SubAgentMaxTurns = %d, want 0 after clearing", a.cfgProjectDraft.SubAgentMaxTurns)
 	}
@@ -1034,10 +1043,12 @@ func TestEnterConfigModeClearsStaleProjectModelsWhenNoProviders(t *testing.T) {
 		globalConfig: Config{
 			ActiveModel:      "orphan/global-active",
 			ExplorationModel: "orphan/global-explore",
+			VisionModel:      "orphan/global-vision",
 		},
 		projectConfig: ProjectConfig{
 			ActiveModel:      "anthropic/claude-opus-4-6",
 			ExplorationModel: "anthropic/claude-haiku-4-5",
+			VisionModel:      "google/gemini-vision",
 			Personality:      "kept",
 		},
 		models:   defaultTestModels(),
@@ -1048,11 +1059,11 @@ func TestEnterConfigModeClearsStaleProjectModelsWhenNoProviders(t *testing.T) {
 	app.enterConfigMode()
 	app.stopConfigTicker()
 
-	if app.cfgDraft.ActiveModel != "" || app.cfgDraft.ExplorationModel != "" {
-		t.Fatalf("global draft models = %q/%q, want cleared", app.cfgDraft.ActiveModel, app.cfgDraft.ExplorationModel)
+	if app.cfgDraft.ActiveModel != "" || app.cfgDraft.ExplorationModel != "" || app.cfgDraft.VisionModel != "" {
+		t.Fatalf("global draft models = %q/%q/%q, want cleared", app.cfgDraft.ActiveModel, app.cfgDraft.ExplorationModel, app.cfgDraft.VisionModel)
 	}
-	if app.cfgProjectDraft.ActiveModel != "" || app.cfgProjectDraft.ExplorationModel != "" {
-		t.Fatalf("project draft models = %q/%q, want cleared", app.cfgProjectDraft.ActiveModel, app.cfgProjectDraft.ExplorationModel)
+	if app.cfgProjectDraft.ActiveModel != "" || app.cfgProjectDraft.ExplorationModel != "" || app.cfgProjectDraft.VisionModel != "" {
+		t.Fatalf("project draft models = %q/%q/%q, want cleared", app.cfgProjectDraft.ActiveModel, app.cfgProjectDraft.ExplorationModel, app.cfgProjectDraft.VisionModel)
 	}
 	if app.cfgProjectDraft.Personality != "kept" {
 		t.Fatalf("Personality = %q, want unrelated project fields preserved", app.cfgProjectDraft.Personality)
@@ -1061,8 +1072,8 @@ func TestEnterConfigModeClearsStaleProjectModelsWhenNoProviders(t *testing.T) {
 	app.cfgDraft.Deployments = map[string]DeploymentConfig{"openrouter": {APIKey: "sk-test"}}
 	app.exitConfigMode(true)
 
-	if app.projectConfig.ActiveModel != "" || app.projectConfig.ExplorationModel != "" {
-		t.Fatalf("saved project models = %q/%q, want cleared after adding provider", app.projectConfig.ActiveModel, app.projectConfig.ExplorationModel)
+	if app.projectConfig.ActiveModel != "" || app.projectConfig.ExplorationModel != "" || app.projectConfig.VisionModel != "" {
+		t.Fatalf("saved project models = %q/%q/%q, want cleared after adding provider", app.projectConfig.ActiveModel, app.projectConfig.ExplorationModel, app.projectConfig.VisionModel)
 	}
 	if app.projectConfig.Personality != "kept" {
 		t.Fatalf("saved Personality = %q, want preserved", app.projectConfig.Personality)
@@ -1260,6 +1271,25 @@ func TestResolveExplorationModel_NoKeyForProvider(t *testing.T) {
 	// gpt-4o provider has no key, so it's not in available models — falls back
 	if got != "claude-sonnet" {
 		t.Errorf("resolveExplorationModel = %q, want %q (no key for exploration model provider)", got, "claude-sonnet")
+	}
+}
+
+func TestResolveVisionModel(t *testing.T) {
+	models := explorationTestModels()
+	fallback := Config{AnthropicAPIKey: "key", ActiveModel: "claude-sonnet"}
+	if got := fallback.resolveVisionModel(models); got != "claude-sonnet" {
+		t.Errorf("resolveVisionModel unset = %q, want active model", got)
+	}
+
+	dedicated := fallback
+	dedicated.VisionModel = "claude-haiku"
+	if got := dedicated.resolveVisionModel(models); got != "claude-haiku" {
+		t.Errorf("resolveVisionModel configured = %q, want claude-haiku", got)
+	}
+
+	dedicated.VisionModel = "nonexistent-model"
+	if got := dedicated.resolveVisionModel(models); got != "claude-sonnet" {
+		t.Errorf("resolveVisionModel invalid = %q, want active fallback", got)
 	}
 }
 
@@ -2134,6 +2164,9 @@ func TestConfigChangeLabelForProjectTabUsesProjectLabels(t *testing.T) {
 	}
 	if got := configChangeLabelForField(configChangeLabelForFieldOptions{field: fields[1], projectTab: true}); got != uiConfigLabelProjectExplorationModel {
 		t.Fatalf("exploration model label = %q, want %q", got, uiConfigLabelProjectExplorationModel)
+	}
+	if got := configChangeLabelForField(configChangeLabelForFieldOptions{field: fields[2], projectTab: true}); got != uiConfigLabelProjectVisionModel {
+		t.Fatalf("vision model label = %q, want %q", got, uiConfigLabelProjectVisionModel)
 	}
 	if got := configChangeLabelForField(configChangeLabelForFieldOptions{field: fields[0], projectTab: false}); got != uiConfigLabelActiveModel {
 		t.Fatalf("global tab should keep field label = %q", got)

--- a/cmd/herm/configeditor.go
+++ b/cmd/herm/configeditor.go
@@ -118,6 +118,7 @@ func (a *App) enterConfigMode() {
 	if len(a.cfgDraft.configuredProviders()) == 0 {
 		a.cfgDraft.ActiveModel = ""
 		a.cfgDraft.ExplorationModel = ""
+		a.cfgDraft.VisionModel = ""
 	}
 	if a.cfgDraft.Deployments != nil {
 		cloned := make(map[string]DeploymentConfig, len(a.cfgDraft.Deployments))
@@ -136,6 +137,7 @@ func (a *App) enterConfigMode() {
 	if len(a.cfgDraft.configuredProviders()) == 0 {
 		a.cfgProjectDraft.ActiveModel = ""
 		a.cfgProjectDraft.ExplorationModel = ""
+		a.cfgProjectDraft.VisionModel = ""
 	}
 	a.startConfigTicker()
 	a.renderInput()
@@ -155,12 +157,14 @@ func (a *App) exitConfigMode(save bool) {
 		if len(a.globalConfig.configuredProviders()) == 0 {
 			a.globalConfig.ActiveModel = ""
 			a.globalConfig.ExplorationModel = ""
+			a.globalConfig.VisionModel = ""
 		}
 		a.cfgDraft = a.globalConfig
 		a.projectConfig = normalizeProjectConfigForModels(normalizeProjectConfigForModelsOptions{pc: a.cfgProjectDraft, models: a.models})
 		if len(a.cfgDraft.configuredProviders()) == 0 {
 			a.projectConfig.ActiveModel = ""
 			a.projectConfig.ExplorationModel = ""
+			a.projectConfig.VisionModel = ""
 		}
 		a.cfgProjectDraft = a.projectConfig
 		a.rebuildEffectiveConfig()
@@ -231,6 +235,7 @@ func (a *App) exitConfigMode(save bool) {
 				})
 				a.resultCh <- langdagReadyMsg{client: client, provider: provider, runtimeApple: hasRuntimeAppleModels(models), err: err}
 			}()
+			a.configureCPSLVision()
 		}
 	}
 	a.cfgActive = false
@@ -444,6 +449,13 @@ func (a *App) resolvedExplorationDisplay(c Config) string {
 	return ""
 }
 
+func (a *App) resolvedVisionDisplay(c Config) string {
+	if c.VisionModel != "" {
+		return c.VisionModel
+	}
+	return ""
+}
+
 func (a *App) settingsTabFields() []cfgField {
 	return []cfgField{
 		{label: uiConfigLabelActiveModel, get: func(c Config) string { return c.ActiveModel }, set: func(c *Config, v string) {
@@ -462,6 +474,15 @@ func (a *App) settingsTabFields() []cfgField {
 			a.openConfigModelPicker(openConfigModelPickerOptions{getCurrentID: func() string { return a.cfgDraft.ExplorationModel }, onSelect: func(id string) {
 				a.cfgDraft.ExplorationModel = id
 				recordConfigChange(recordConfigChangeOptions{changed: a.cfgChangedLabels, label: uiConfigLabelExplorationModel, oldVal: oldVal, newVal: id})
+			}})
+		}},
+		{label: uiConfigLabelVisionModel, get: func(c Config) string { return c.VisionModel }, display: func(c Config) string { return a.resolvedVisionDisplay(c) }, set: func(c *Config, v string) {
+			c.VisionModel = normalizeConfigModelIDForModels(normalizeConfigModelIDForModelsOptions{cfg: *c, modelID: v, smartDefault: defaultCanonicalVisionModel, models: a.models})
+		}, picker: func(a *App) {
+			oldVal := a.cfgDraft.VisionModel
+			a.openConfigModelPicker(openConfigModelPickerOptions{getCurrentID: func() string { return a.cfgDraft.VisionModel }, onSelect: func(id string) {
+				a.cfgDraft.VisionModel = id
+				recordConfigChange(recordConfigChangeOptions{changed: a.cfgChangedLabels, label: uiConfigLabelVisionModel, oldVal: oldVal, newVal: id})
 			}})
 		}},
 		{label: "Paste Collapse", get: func(c Config) string { return strconv.Itoa(c.PasteCollapseMinChars) }, set: func(c *Config, v string) {
@@ -559,6 +580,27 @@ func (a *App) projectTabFields() []cfgField {
 				a.openConfigModelPicker(openConfigModelPickerOptions{getCurrentID: func() string { return a.cfgProjectDraft.ExplorationModel }, onSelect: func(id string) {
 					a.cfgProjectDraft.ExplorationModel = id
 					recordConfigChange(recordConfigChangeOptions{changed: a.cfgChangedLabels, label: uiConfigLabelProjectExplorationModel, oldVal: oldVal, newVal: id})
+				}})
+			},
+		},
+		{
+			label: uiConfigLabelVisionModel,
+			get:   func(_ Config) string { return a.cfgProjectDraft.VisionModel },
+			display: func(_ Config) string {
+				if a.cfgProjectDraft.VisionModel != "" && len(a.cfgDraft.configuredProviders()) == 0 {
+					return ""
+				}
+				return a.cfgProjectDraft.VisionModel
+			},
+			set: func(_ *Config, v string) {
+				a.cfgProjectDraft.VisionModel = normalizeProjectModelIDForModels(normalizeProjectModelIDForModelsOptions{modelID: v, smartDefault: defaultCanonicalVisionModel, models: a.models})
+			},
+			globalHint: func(c Config) string { return a.resolvedVisionDisplay(c) },
+			picker: func(a *App) {
+				oldVal := a.cfgProjectDraft.VisionModel
+				a.openConfigModelPicker(openConfigModelPickerOptions{getCurrentID: func() string { return a.cfgProjectDraft.VisionModel }, onSelect: func(id string) {
+					a.cfgProjectDraft.VisionModel = id
+					recordConfigChange(recordConfigChangeOptions{changed: a.cfgChangedLabels, label: uiConfigLabelProjectVisionModel, oldVal: oldVal, newVal: id})
 				}})
 			},
 		},

--- a/cmd/herm/configeditor_messages.go
+++ b/cmd/herm/configeditor_messages.go
@@ -59,7 +59,7 @@ func configChangeNoticeFor(opts configChangeNoticeForOptions) configChangeNotice
 }
 
 func isModelConfigLabel(label string) bool {
-	return isActiveModelConfigLabel(label) || isExplorationModelConfigLabel(label)
+	return isActiveModelConfigLabel(label) || isExplorationModelConfigLabel(label) || isVisionModelConfigLabel(label)
 }
 
 func modelConfigChangeNotice(opts configChangeNoticeForOptions) configChangeNotice {
@@ -93,6 +93,8 @@ func configNoticeProfileFor(label string) configNoticeProfile {
 		return configNoticeProfile{accentStyle: styleChatCyan, removedSuffix: uiConfigNoticeUnset}
 	case isExplorationModelConfigLabel(label):
 		return configNoticeProfile{accentStyle: styleChatMagenta, removedSuffix: uiConfigNoticeUnset}
+	case isVisionModelConfigLabel(label):
+		return configNoticeProfile{accentStyle: styleChatBlue, removedSuffix: uiConfigNoticeUnset}
 	case isAPIKeyConfigLabel(label):
 		return configNoticeProfile{accentStyle: styleChatGreen, removedSuffix: uiConfigNoticeRemoved}
 	default:

--- a/cmd/herm/cpsl_client.go
+++ b/cmd/herm/cpsl_client.go
@@ -18,6 +18,7 @@ const cpslWorkerStartupTimeout = 10 * time.Second
 
 type cpslWorkerBackend interface {
 	cpslEvaluator
+	ConfigureVision(context.Context, cpslVisionRuntimeConfig) error
 	Close() error
 }
 
@@ -179,6 +180,24 @@ func (c *CPSLWorkerClient) EvalCPSL(ctx context.Context, opts cpslEvalOptions) (
 		Input:     opts.input,
 		TimeoutMS: opts.timeoutSeconds * 1000,
 	})
+}
+
+func (c *CPSLWorkerClient) ConfigureVision(ctx context.Context, config cpslVisionRuntimeConfig) error {
+	response, err := c.eval(ctx, cpslWorkerRequest{
+		Op:        cpslWorkerOpVision,
+		TimeoutMS: int(cpslWorkerStartupTimeout / time.Millisecond),
+		Vision:    &config,
+	})
+	if err != nil {
+		return err
+	}
+	if !response.OK {
+		if response.Error != nil {
+			return newCPSLWorkerError(cpslWorkerErrorOptions{code: response.Error.Code, message: response.Error.Message})
+		}
+		return fmt.Errorf("CPSL vision configuration failed")
+	}
+	return nil
 }
 
 func (c *CPSLWorkerClient) eval(ctx context.Context, request cpslWorkerRequest) (cpslEvalResponse, error) {

--- a/cmd/herm/cpsl_client_test.go
+++ b/cmd/herm/cpsl_client_test.go
@@ -201,6 +201,30 @@ func TestCPSLWorkerClientEvalSuccess(t *testing.T) {
 	}
 }
 
+func TestCPSLWorkerClientConfigureVision(t *testing.T) {
+	var configured *cpslVisionRuntimeConfig
+	_, proc := newFakeCPSLProcess(t, func(request cpslWorkerRequest, encoder *json.Encoder) {
+		if request.Op == cpslWorkerOpVision {
+			configured = request.Vision
+		}
+		_ = encoder.Encode(cpslOKResponse(request.ID))
+	})
+	withFakeCPSLProcess(t, proc)
+
+	client, err := NewCPSLWorkerClient(newCPSLWorkerClientOptions{LibraryPath: "/tmp/libcpsl.so", Workspace: "/tmp/work"})
+	if err != nil {
+		t.Fatalf("NewCPSLWorkerClient: %v", err)
+	}
+	defer client.Close()
+
+	if err := client.ConfigureVision(context.Background(), cpslVisionRuntimeConfig{Model: "xai/grok-4.5"}); err != nil {
+		t.Fatalf("ConfigureVision: %v", err)
+	}
+	if configured == nil || configured.Model != "xai/grok-4.5" {
+		t.Fatalf("configured = %#v", configured)
+	}
+}
+
 func TestCPSLWorkerClientTimeoutKillsWorker(t *testing.T) {
 	var count int
 	var fake *fakeCPSLProcess

--- a/cmd/herm/cpsl_loader_unix.go
+++ b/cmd/herm/cpsl_loader_unix.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 	"unsafe"
 
@@ -17,13 +18,29 @@ type cpslSession unsafe.Pointer
 type cpslNativeLibrary struct {
 	handle uintptr
 
-	abiVersionFn   func() uint32
-	metadataJSONFn func() unsafe.Pointer
-	sessionNewFn   func(string) unsafe.Pointer
-	sessionFreeFn  func(unsafe.Pointer)
-	evalFn         func(unsafe.Pointer, string) unsafe.Pointer
-	stringFreeFn   func(unsafe.Pointer)
-	lastErrorFn    func() unsafe.Pointer
+	abiVersionFn                    func() uint32
+	metadataJSONFn                  func() unsafe.Pointer
+	sessionNewFn                    func(string) unsafe.Pointer
+	sessionNewWithHostCallbacksV3Fn func(string, unsafe.Pointer, unsafe.Pointer, unsafe.Pointer, unsafe.Pointer, unsafe.Pointer) unsafe.Pointer
+	visionRespondFn                 func(unsafe.Pointer, unsafe.Pointer, uintptr, uint8)
+	sessionFreeFn                   func(unsafe.Pointer)
+	evalFn                          func(unsafe.Pointer, string) unsafe.Pointer
+	stringFreeFn                    func(unsafe.Pointer)
+	lastErrorFn                     func() unsafe.Pointer
+	visionCallback                  func(uintptr, uintptr, uintptr, uintptr, uintptr)
+}
+
+type cpslVisionInputFFI struct {
+	data      unsafe.Pointer
+	dataLen   uintptr
+	filename  unsafe.Pointer
+	mediaType unsafe.Pointer
+}
+
+type cpslVisionCallbacksFFI struct {
+	userData     unsafe.Pointer
+	handle       uintptr
+	userDataFree uintptr
 }
 
 func openCPSLNativeLibrary(path string) (*cpslNativeLibrary, error) {
@@ -48,6 +65,8 @@ func openCPSLNativeLibrary(path string) (*cpslNativeLibrary, error) {
 	if err := lib.registerFunc(cpslRegisterFuncOptions{target: &lib.sessionNewFn, name: "cpsl_session_new"}); err != nil {
 		return nil, err
 	}
+	_ = lib.registerOptionalFunc(cpslRegisterFuncOptions{target: &lib.sessionNewWithHostCallbacksV3Fn, name: "cpsl_session_new_with_host_callbacks_v3"})
+	_ = lib.registerOptionalFunc(cpslRegisterFuncOptions{target: &lib.visionRespondFn, name: "cpsl_vision_respond"})
 	if err := lib.registerFunc(cpslRegisterFuncOptions{target: &lib.sessionFreeFn, name: "cpsl_session_free"}); err != nil {
 		return nil, err
 	}
@@ -82,6 +101,15 @@ func (l *cpslNativeLibrary) registerFunc(opts cpslRegisterFuncOptions) error {
 	return nil
 }
 
+func (l *cpslNativeLibrary) registerOptionalFunc(opts cpslRegisterFuncOptions) error {
+	symbol, err := purego.Dlsym(l.handle, opts.name)
+	if err != nil || symbol == 0 {
+		return err
+	}
+	purego.RegisterFunc(opts.target, symbol)
+	return nil
+}
+
 func (l *cpslNativeLibrary) abiVersion() (uint32, error) {
 	return l.abiVersionFn(), nil
 }
@@ -104,6 +132,70 @@ func (l *cpslNativeLibrary) sessionNew(configJSON string) (cpslSession, error) {
 		return nil, fmt.Errorf("CPSL session creation failed: %s", l.lastError())
 	}
 	return cpslSession(session), nil
+}
+
+func (l *cpslNativeLibrary) sessionNewWithVision(configJSON string, handler cpslVisionHandler) (cpslSession, error) {
+	if handler == nil || l.sessionNewWithHostCallbacksV3Fn == nil || l.visionRespondFn == nil {
+		return l.sessionNew(configJSON)
+	}
+	if err := validateFFIString(configJSON); err != nil {
+		return nil, err
+	}
+
+	callback := func(_ uintptr, inputsPointer uintptr, inputCount uintptr, queryPointer uintptr, responseContext uintptr) {
+		var result string
+		var callbackErr error
+		func() {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					callbackErr = fmt.Errorf("vision callback panicked: %v", recovered)
+				}
+			}()
+			ffiInputs := unsafe.Slice((*cpslVisionInputFFI)(unsafe.Pointer(inputsPointer)), inputCount)
+			inputs := make([]cpslVisionInput, 0, len(ffiInputs))
+			for _, input := range ffiInputs {
+				data := append([]byte(nil), unsafe.Slice((*byte)(input.data), input.dataLen)...)
+				inputs = append(inputs, cpslVisionInput{
+					Data:      data,
+					Filename:  stringFromC(input.filename),
+					MediaType: stringFromC(input.mediaType),
+				})
+			}
+			result, callbackErr = handler(inputs, stringFromC(unsafe.Pointer(queryPointer)))
+		}()
+		if callbackErr != nil {
+			result = callbackErr.Error()
+		}
+		bytes := []byte(result)
+		var data unsafe.Pointer
+		if len(bytes) > 0 {
+			data = unsafe.Pointer(&bytes[0])
+		}
+		l.visionRespondFn(unsafe.Pointer(responseContext), data, uintptr(len(bytes)), boolByte(callbackErr != nil))
+		runtime.KeepAlive(bytes)
+	}
+	l.visionCallback = callback
+	callbacks := cpslVisionCallbacksFFI{handle: purego.NewCallback(callback)}
+	session := l.sessionNewWithHostCallbacksV3Fn(
+		configJSON,
+		nil,
+		nil,
+		nil,
+		nil,
+		unsafe.Pointer(&callbacks),
+	)
+	runtime.KeepAlive(callbacks)
+	if session == nil {
+		return nil, fmt.Errorf("CPSL session creation failed: %s", l.lastError())
+	}
+	return cpslSession(session), nil
+}
+
+func boolByte(value bool) uint8 {
+	if value {
+		return 1
+	}
+	return 0
 }
 
 func (l *cpslNativeLibrary) sessionFree(session cpslSession) {

--- a/cmd/herm/cpsl_loader_unix.go
+++ b/cmd/herm/cpsl_loader_unix.go
@@ -134,7 +134,8 @@ func (l *cpslNativeLibrary) sessionNew(configJSON string) (cpslSession, error) {
 	return cpslSession(session), nil
 }
 
-func (l *cpslNativeLibrary) sessionNewWithVision(configJSON string, handler cpslVisionHandler) (cpslSession, error) {
+func (l *cpslNativeLibrary) sessionNewWithVision(opts cpslSessionVisionOptions) (cpslSession, error) {
+	configJSON, handler := opts.configJSON, opts.handler
 	if handler == nil || l.sessionNewWithHostCallbacksV3Fn == nil || l.visionRespondFn == nil {
 		return l.sessionNew(configJSON)
 	}
@@ -161,7 +162,10 @@ func (l *cpslNativeLibrary) sessionNewWithVision(configJSON string, handler cpsl
 					MediaType: stringFromC(input.mediaType),
 				})
 			}
-			result, callbackErr = handler(inputs, stringFromC(unsafe.Pointer(queryPointer)))
+			result, callbackErr = handler(cpslVisionReadOptions{
+				inputs: inputs,
+				query:  stringFromC(unsafe.Pointer(queryPointer)),
+			})
 		}()
 		if callbackErr != nil {
 			result = callbackErr.Error()

--- a/cmd/herm/cpsl_loader_unsupported.go
+++ b/cmd/herm/cpsl_loader_unsupported.go
@@ -26,8 +26,8 @@ func (l *cpslNativeLibrary) sessionNew(configJSON string) (cpslSession, error) {
 	return 0, fmt.Errorf("CPSL dynamic libraries are unsupported on this platform")
 }
 
-func (l *cpslNativeLibrary) sessionNewWithVision(configJSON string, handler cpslVisionHandler) (cpslSession, error) {
-	return l.sessionNew(configJSON)
+func (l *cpslNativeLibrary) sessionNewWithVision(opts cpslSessionVisionOptions) (cpslSession, error) {
+	return l.sessionNew(opts.configJSON)
 }
 
 func (l *cpslNativeLibrary) sessionFree(session cpslSession) {}

--- a/cmd/herm/cpsl_loader_unsupported.go
+++ b/cmd/herm/cpsl_loader_unsupported.go
@@ -26,6 +26,10 @@ func (l *cpslNativeLibrary) sessionNew(configJSON string) (cpslSession, error) {
 	return 0, fmt.Errorf("CPSL dynamic libraries are unsupported on this platform")
 }
 
+func (l *cpslNativeLibrary) sessionNewWithVision(configJSON string, handler cpslVisionHandler) (cpslSession, error) {
+	return l.sessionNew(configJSON)
+}
+
 func (l *cpslNativeLibrary) sessionFree(session cpslSession) {}
 
 func (l *cpslNativeLibrary) eval(opts cpslSessionEvalOptions) (string, error) {

--- a/cmd/herm/cpsl_loader_windows.go
+++ b/cmd/herm/cpsl_loader_windows.go
@@ -108,7 +108,8 @@ func (l *cpslNativeLibrary) sessionNew(configJSON string) (cpslSession, error) {
 	return cpslSession(value), nil
 }
 
-func (l *cpslNativeLibrary) sessionNewWithVision(configJSON string, handler cpslVisionHandler) (cpslSession, error) {
+func (l *cpslNativeLibrary) sessionNewWithVision(opts cpslSessionVisionOptions) (cpslSession, error) {
+	configJSON, handler := opts.configJSON, opts.handler
 	if handler == nil || l.sessionNewWithHostCallbacksV3Proc == nil || l.visionRespondProc == nil {
 		return l.sessionNew(configJSON)
 	}
@@ -135,7 +136,10 @@ func (l *cpslNativeLibrary) sessionNewWithVision(configJSON string, handler cpsl
 					MediaType: stringFromC(input.mediaType),
 				})
 			}
-			result, callbackErr = handler(inputs, stringFromC(unsafe.Pointer(queryPointer)))
+			result, callbackErr = handler(cpslVisionReadOptions{
+				inputs: inputs,
+				query:  stringFromC(unsafe.Pointer(queryPointer)),
+			})
 		}()
 		if callbackErr != nil {
 			result = callbackErr.Error()

--- a/cmd/herm/cpsl_loader_windows.go
+++ b/cmd/herm/cpsl_loader_windows.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"fmt"
+	"runtime"
 	"strings"
 	"syscall"
 	"unsafe"
@@ -14,14 +15,30 @@ import (
 type cpslSession uintptr
 
 type cpslNativeLibrary struct {
-	dll              *syscall.DLL
-	abiVersionProc   *syscall.Proc
-	metadataJSONProc *syscall.Proc
-	sessionNewProc   *syscall.Proc
-	sessionFreeProc  *syscall.Proc
-	evalProc         *syscall.Proc
-	stringFreeProc   *syscall.Proc
-	lastErrorProc    *syscall.Proc
+	dll                               *syscall.DLL
+	abiVersionProc                    *syscall.Proc
+	metadataJSONProc                  *syscall.Proc
+	sessionNewProc                    *syscall.Proc
+	sessionNewWithHostCallbacksV3Proc *syscall.Proc
+	visionRespondProc                 *syscall.Proc
+	sessionFreeProc                   *syscall.Proc
+	evalProc                          *syscall.Proc
+	stringFreeProc                    *syscall.Proc
+	lastErrorProc                     *syscall.Proc
+	visionCallback                    uintptr
+}
+
+type cpslVisionInputFFI struct {
+	data      unsafe.Pointer
+	dataLen   uintptr
+	filename  unsafe.Pointer
+	mediaType unsafe.Pointer
+}
+
+type cpslVisionCallbacksFFI struct {
+	userData     unsafe.Pointer
+	handle       uintptr
+	userDataFree uintptr
 }
 
 func openCPSLNativeLibrary(path string) (*cpslNativeLibrary, error) {
@@ -46,6 +63,8 @@ func openCPSLNativeLibrary(path string) (*cpslNativeLibrary, error) {
 	if lib.sessionNewProc, err = dll.FindProc("cpsl_session_new"); err != nil {
 		return nil, fmt.Errorf("resolve CPSL symbol cpsl_session_new: %w", err)
 	}
+	lib.sessionNewWithHostCallbacksV3Proc, _ = dll.FindProc("cpsl_session_new_with_host_callbacks_v3")
+	lib.visionRespondProc, _ = dll.FindProc("cpsl_vision_respond")
 	if lib.sessionFreeProc, err = dll.FindProc("cpsl_session_free"); err != nil {
 		return nil, fmt.Errorf("resolve CPSL symbol cpsl_session_free: %w", err)
 	}
@@ -83,6 +102,68 @@ func (l *cpslNativeLibrary) sessionNew(configJSON string) (cpslSession, error) {
 		return 0, err
 	}
 	value, _, _ := l.sessionNewProc.Call(uintptr(unsafe.Pointer(config)))
+	if value == 0 {
+		return 0, fmt.Errorf("CPSL session creation failed: %s", l.lastError())
+	}
+	return cpslSession(value), nil
+}
+
+func (l *cpslNativeLibrary) sessionNewWithVision(configJSON string, handler cpslVisionHandler) (cpslSession, error) {
+	if handler == nil || l.sessionNewWithHostCallbacksV3Proc == nil || l.visionRespondProc == nil {
+		return l.sessionNew(configJSON)
+	}
+	config, err := bytePtrFromString(configJSON)
+	if err != nil {
+		return 0, err
+	}
+
+	callback := func(_ uintptr, inputsPointer uintptr, inputCount uintptr, queryPointer uintptr, responseContext uintptr) uintptr {
+		var result string
+		var callbackErr error
+		func() {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					callbackErr = fmt.Errorf("vision callback panicked: %v", recovered)
+				}
+			}()
+			ffiInputs := unsafe.Slice((*cpslVisionInputFFI)(unsafe.Pointer(inputsPointer)), inputCount)
+			inputs := make([]cpslVisionInput, 0, len(ffiInputs))
+			for _, input := range ffiInputs {
+				inputs = append(inputs, cpslVisionInput{
+					Data:      append([]byte(nil), unsafe.Slice((*byte)(input.data), input.dataLen)...),
+					Filename:  stringFromC(input.filename),
+					MediaType: stringFromC(input.mediaType),
+				})
+			}
+			result, callbackErr = handler(inputs, stringFromC(unsafe.Pointer(queryPointer)))
+		}()
+		if callbackErr != nil {
+			result = callbackErr.Error()
+		}
+		bytes := []byte(result)
+		var data uintptr
+		if len(bytes) > 0 {
+			data = uintptr(unsafe.Pointer(&bytes[0]))
+		}
+		isError := uintptr(0)
+		if callbackErr != nil {
+			isError = 1
+		}
+		l.visionRespondProc.Call(responseContext, data, uintptr(len(bytes)), isError)
+		runtime.KeepAlive(bytes)
+		return 0
+	}
+	l.visionCallback = syscall.NewCallback(callback)
+	callbacks := cpslVisionCallbacksFFI{handle: l.visionCallback}
+	value, _, _ := l.sessionNewWithHostCallbacksV3Proc.Call(
+		uintptr(unsafe.Pointer(config)),
+		0,
+		0,
+		0,
+		0,
+		uintptr(unsafe.Pointer(&callbacks)),
+	)
+	runtime.KeepAlive(callbacks)
 	if value == 0 {
 		return 0, fmt.Errorf("CPSL session creation failed: %s", l.lastError())
 	}

--- a/cmd/herm/cpsl_protocol.go
+++ b/cmd/herm/cpsl_protocol.go
@@ -5,22 +5,32 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+
+	"langdag.com/langdag"
 )
 
 const (
-	cpslABIVersion      = 1
+	cpslABIVersion      = 2
 	cpslWorkerOpEval    = "eval"
+	cpslWorkerOpVision  = "configure_vision"
 	cpslLanguageLuau    = "luau"
 	cpslLanguageBash    = "bash"
 	cpslWorkerInitialCW = "/workdir"
 )
 
 type cpslWorkerRequest struct {
-	ID        int64  `json:"id"`
-	Op        string `json:"op"`
-	Language  string `json:"language"`
-	Input     string `json:"input"`
-	TimeoutMS int    `json:"timeout_ms"`
+	ID        int64                    `json:"id"`
+	Op        string                   `json:"op"`
+	Language  string                   `json:"language,omitempty"`
+	Input     string                   `json:"input,omitempty"`
+	TimeoutMS int                      `json:"timeout_ms"`
+	Vision    *cpslVisionRuntimeConfig `json:"vision,omitempty"`
+}
+
+type cpslVisionRuntimeConfig struct {
+	Model   string                `json:"model,omitempty"`
+	Config  Config                `json:"config"`
+	Catalog *langdag.ModelCatalog `json:"catalog,omitempty"`
 }
 
 type cpslEvalResponse struct {
@@ -71,6 +81,15 @@ func cpslErrorResponse(opts cpslErrorResponseOptions) cpslEvalResponse {
 		Stderr:   "",
 		ExitCode: nil,
 		Error:    &cpslEvalError{Code: opts.code, Message: opts.message},
+		Warnings: []string{},
+		CWD:      cpslWorkerInitialCW,
+	}
+}
+
+func cpslOKResponse(id int64) cpslEvalResponse {
+	return cpslEvalResponse{
+		ID:       id,
+		OK:       true,
 		Warnings: []string{},
 		CWD:      cpslWorkerInitialCW,
 	}

--- a/cmd/herm/cpsl_vision.go
+++ b/cmd/herm/cpsl_vision.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"langdag.com/langdag"
+	"langdag.com/langdag/types"
+)
+
+type cpslVisionInput struct {
+	Data      []byte
+	Filename  string
+	MediaType string
+}
+
+type cpslVisionHandler func(inputs []cpslVisionInput, query string) (string, error)
+
+type cpslVisionService struct {
+	mu     sync.Mutex
+	client *langdag.Client
+	model  string
+}
+
+func (s *cpslVisionService) Configure(config cpslVisionRuntimeConfig) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.client != nil {
+		_ = s.client.Close()
+		s.client = nil
+	}
+	s.model = ""
+	if config.Model == "" {
+		return nil
+	}
+
+	client, err := newLangdagClientWithCatalog(config.Config, config.Catalog)
+	if err != nil {
+		return err
+	}
+	if client == nil {
+		return fmt.Errorf("vision model has no configured provider")
+	}
+	s.client = client
+	s.model = config.Model
+	return nil
+}
+
+func (s *cpslVisionService) Read(inputs []cpslVisionInput, query string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.client == nil || s.model == "" {
+		return "", fmt.Errorf("vision model is not configured")
+	}
+
+	blocks := []types.ContentBlock{{Type: "text", Text: query}}
+	for _, input := range inputs {
+		switch {
+		case strings.HasPrefix(input.MediaType, "image/"):
+			blocks = append(blocks, types.ContentBlock{
+				Type:      "image",
+				MediaType: input.MediaType,
+				Data:      base64.StdEncoding.EncodeToString(input.Data),
+			})
+		case input.MediaType == "text/plain" || input.MediaType == "text/markdown" || input.MediaType == "text/csv" || input.MediaType == "application/json" || input.MediaType == "text/html":
+			blocks = append(blocks, types.ContentBlock{Type: "text", Text: string(input.Data)})
+		default:
+			blocks = append(blocks, types.ContentBlock{
+				Type:      "document",
+				MediaType: input.MediaType,
+				Data:      base64.StdEncoding.EncodeToString(input.Data),
+			})
+		}
+	}
+	content, err := json.Marshal(blocks)
+	if err != nil {
+		return "", err
+	}
+	response, err := s.client.Provider().Complete(context.Background(), &types.CompletionRequest{
+		Model:     s.model,
+		Messages:  []types.Message{{Role: "user", Content: content}},
+		MaxTokens: defaultMaxOutputTokens,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	var text []string
+	for _, block := range response.Content {
+		if block.Type == "text" && block.Text != "" {
+			text = append(text, block.Text)
+		}
+	}
+	if len(text) == 0 {
+		return "", fmt.Errorf("vision model returned no text")
+	}
+	return strings.Join(text, ""), nil
+}

--- a/cmd/herm/cpsl_vision.go
+++ b/cmd/herm/cpsl_vision.go
@@ -1,3 +1,4 @@
+// cpsl_vision.go adapts CPSL document inputs to Herm multimodal model requests.
 package main
 
 import (
@@ -18,7 +19,17 @@ type cpslVisionInput struct {
 	MediaType string
 }
 
-type cpslVisionHandler func(inputs []cpslVisionInput, query string) (string, error)
+type cpslVisionReadOptions struct {
+	inputs []cpslVisionInput
+	query  string
+}
+
+type cpslSessionVisionOptions struct {
+	configJSON string
+	handler    cpslVisionHandler
+}
+
+type cpslVisionHandler func(opts cpslVisionReadOptions) (string, error)
 
 type cpslVisionService struct {
 	mu     sync.Mutex
@@ -51,15 +62,15 @@ func (s *cpslVisionService) Configure(config cpslVisionRuntimeConfig) error {
 	return nil
 }
 
-func (s *cpslVisionService) Read(inputs []cpslVisionInput, query string) (string, error) {
+func (s *cpslVisionService) Read(opts cpslVisionReadOptions) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.client == nil || s.model == "" {
 		return "", fmt.Errorf("vision model is not configured")
 	}
 
-	blocks := []types.ContentBlock{{Type: "text", Text: query}}
-	for _, input := range inputs {
+	blocks := []types.ContentBlock{{Type: "text", Text: opts.query}}
+	for _, input := range opts.inputs {
 		switch {
 		case strings.HasPrefix(input.MediaType, "image/"):
 			blocks = append(blocks, types.ContentBlock{

--- a/cmd/herm/cpsl_vision_config.go
+++ b/cmd/herm/cpsl_vision_config.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+func (a *App) configureCPSLVision() {
+	if !a.cpslReady || a.cpslWorker == nil || a.models == nil || a.modelCatalog == nil {
+		return
+	}
+	worker := a.cpslWorker
+	config := cpslVisionRuntimeConfig{
+		Model:   a.config.resolveVisionModel(a.models),
+		Config:  a.config,
+		Catalog: a.modelCatalog,
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := worker.ConfigureVision(ctx, config); err != nil {
+			log.Printf("warning: configuring CPSL vision model: %v", err)
+		}
+	}()
+}

--- a/cmd/herm/cpsl_vision_config.go
+++ b/cmd/herm/cpsl_vision_config.go
@@ -1,3 +1,4 @@
+// cpsl_vision_config.go resolves vision models and configures the CPSL worker.
 package main
 
 import (
@@ -23,4 +24,29 @@ func (a *App) configureCPSLVision() {
 			log.Printf("warning: configuring CPSL vision model: %v", err)
 		}
 	}()
+}
+
+// resolveVisionModel returns the model used by CPSL vision document reads.
+// Vision is optional in config and follows the active model when unset.
+func (c Config) resolveVisionModel(models []ModelDef) string {
+	return c.resolveVisionModelResult(models).ResolvedModelID
+}
+
+func (c Config) resolveVisionModelResult(models []ModelDef) configuredModelResolution {
+	if c.VisionModel == "" {
+		return configuredModelResolution{ResolvedModelID: c.resolveActiveModel(models)}
+	}
+	available := c.availableModels(models)
+	lookup := c.lookupConfiguredModelID(lookupConfiguredModelIDOptions{modelID: c.VisionModel, smartDefault: defaultCanonicalVisionModel, available: available, models: models})
+	if lookup.Status == configuredModelUsable {
+		return lookup
+	}
+	fallback := c.resolveActiveModel(models)
+	return configuredModelResolution{
+		ConfiguredModelID: c.VisionModel,
+		ResolvedModelID:   fallback,
+		Fallback:          true,
+		Status:            lookup.Status,
+		Diagnostic:        configuredModelDiagnostic(configuredModelDiagnosticOptions{field: "vision_model", configured: c.VisionModel, fallback: fallback, status: lookup.Status}),
+	}
 }

--- a/cmd/herm/cpsl_vision_test.go
+++ b/cmd/herm/cpsl_vision_test.go
@@ -13,10 +13,13 @@ func TestCPSLVisionReadSendsMultimodalBlocksToConfiguredModel(t *testing.T) {
 	defer client.Close()
 	service := &cpslVisionService{client: client, model: "xai/grok-4.5"}
 
-	result, err := service.Read([]cpslVisionInput{
-		{Data: []byte{1, 2, 3}, Filename: "page.png", MediaType: "image/png"},
-		{Data: []byte("notes"), Filename: "notes.txt", MediaType: "text/plain"},
-	}, "Extract the text")
+	result, err := service.Read(cpslVisionReadOptions{
+		inputs: []cpslVisionInput{
+			{Data: []byte{1, 2, 3}, Filename: "page.png", MediaType: "image/png"},
+			{Data: []byte("notes"), Filename: "notes.txt", MediaType: "text/plain"},
+		},
+		query: "Extract the text",
+	})
 	if err != nil {
 		t.Fatalf("Read: %v", err)
 	}
@@ -47,7 +50,7 @@ func TestCPSLVisionReadSendsMultimodalBlocksToConfiguredModel(t *testing.T) {
 }
 
 func TestCPSLVisionReadRequiresConfiguration(t *testing.T) {
-	if _, err := (&cpslVisionService{}).Read(nil, "read"); err == nil {
+	if _, err := (&cpslVisionService{}).Read(cpslVisionReadOptions{query: "read"}); err == nil {
 		t.Fatal("Read without configuration returned nil error")
 	}
 }

--- a/cmd/herm/cpsl_vision_test.go
+++ b/cmd/herm/cpsl_vision_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"langdag.com/langdag/types"
+)
+
+func TestCPSLVisionReadSendsMultimodalBlocksToConfiguredModel(t *testing.T) {
+	client := newTestClient("read result")
+	defer client.Close()
+	service := &cpslVisionService{client: client, model: "xai/grok-4.5"}
+
+	result, err := service.Read([]cpslVisionInput{
+		{Data: []byte{1, 2, 3}, Filename: "page.png", MediaType: "image/png"},
+		{Data: []byte("notes"), Filename: "notes.txt", MediaType: "text/plain"},
+	}, "Extract the text")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if result != "read result" {
+		t.Fatalf("result = %q", result)
+	}
+
+	provider := client.Provider().(*mockProvider)
+	provider.mu.Lock()
+	request := provider.lastRequest
+	provider.mu.Unlock()
+	if request == nil || request.Model != "xai/grok-4.5" || len(request.Messages) != 1 {
+		t.Fatalf("request = %#v", request)
+	}
+	var blocks []types.ContentBlock
+	if err := json.Unmarshal(request.Messages[0].Content, &blocks); err != nil {
+		t.Fatalf("decode content blocks: %v", err)
+	}
+	if len(blocks) != 3 || blocks[0].Type != "text" || blocks[0].Text != "Extract the text" {
+		t.Fatalf("blocks = %#v", blocks)
+	}
+	if blocks[1].Type != "image" || blocks[1].MediaType != "image/png" || blocks[1].Data != base64.StdEncoding.EncodeToString([]byte{1, 2, 3}) {
+		t.Fatalf("image block = %#v", blocks[1])
+	}
+	if blocks[2].Type != "text" || blocks[2].Text != "notes" {
+		t.Fatalf("text block = %#v", blocks[2])
+	}
+}
+
+func TestCPSLVisionReadRequiresConfiguration(t *testing.T) {
+	if _, err := (&cpslVisionService{}).Read(nil, "read"); err == nil {
+		t.Fatal("Read without configuration returned nil error")
+	}
+}

--- a/cmd/herm/cpsl_worker.go
+++ b/cmd/herm/cpsl_worker.go
@@ -81,7 +81,10 @@ func runCPSLWorker(opts runCPSLWorkerOptions) int {
 	}
 
 	vision := &cpslVisionService{}
-	session, err := lib.sessionNewWithVision(configJSON, vision.Read)
+	session, err := lib.sessionNewWithVision(cpslSessionVisionOptions{
+		configJSON: configJSON,
+		handler:    vision.Read,
+	})
 	if err != nil {
 		fmt.Fprintf(opts.stderr, "cpsl worker: session: %v\n", err)
 		return 2

--- a/cmd/herm/cpsl_worker.go
+++ b/cmd/herm/cpsl_worker.go
@@ -80,12 +80,14 @@ func runCPSLWorker(opts runCPSLWorkerOptions) int {
 		return 2
 	}
 
-	session, err := lib.sessionNew(configJSON)
+	vision := &cpslVisionService{}
+	session, err := lib.sessionNewWithVision(configJSON, vision.Read)
 	if err != nil {
 		fmt.Fprintf(opts.stderr, "cpsl worker: session: %v\n", err)
 		return 2
 	}
 	defer lib.sessionFree(session)
+	defer func() { _ = vision.Configure(cpslVisionRuntimeConfig{}) }()
 
 	if err := serveCPSLWorkerPlatform(serveCPSLWorkerOptions{
 		evaluator:   lib,
@@ -94,6 +96,7 @@ func runCPSLWorker(opts runCPSLWorkerOptions) int {
 		stdout:      opts.stdout,
 		stderr:      opts.stderr,
 		exitProcess: os.Exit,
+		vision:      vision,
 	}); err != nil {
 		if errors.Is(err, errCPSLWorkerTerminated) {
 			return 0
@@ -148,6 +151,7 @@ type serveCPSLWorkerOptions struct {
 	stdout      io.Writer
 	stderr      io.Writer
 	exitProcess func(int)
+	vision      *cpslVisionService
 }
 
 var errCPSLWorkerTerminated = errors.New("CPSL worker terminated after response")
@@ -180,6 +184,7 @@ func serveCPSLWorker(opts serveCPSLWorkerOptions) error {
 			evaluator: opts.evaluator,
 			session:   opts.session,
 			request:   request,
+			vision:    opts.vision,
 		})
 		if err := encoder.Encode(action.response); err != nil {
 			return err
@@ -202,9 +207,19 @@ type handleCPSLWorkerRequestOptions struct {
 	evaluator cpslSessionEvaluator
 	session   cpslSession
 	request   cpslWorkerRequest
+	vision    *cpslVisionService
 }
 
 func handleCPSLWorkerRequest(opts handleCPSLWorkerRequestOptions) cpslWorkerAction {
+	if opts.request.Op == cpslWorkerOpVision {
+		if opts.vision == nil || opts.request.Vision == nil {
+			return cpslWorkerAction{response: cpslErrorResponse(cpslErrorResponseOptions{id: opts.request.ID, code: "invalid_request", message: "Missing vision configuration"})}
+		}
+		if err := opts.vision.Configure(*opts.request.Vision); err != nil {
+			return cpslWorkerAction{response: cpslErrorResponse(cpslErrorResponseOptions{id: opts.request.ID, code: "vision_config", message: err.Error()})}
+		}
+		return cpslWorkerAction{response: cpslOKResponse(opts.request.ID)}
+	}
 	if opts.request.Op != cpslWorkerOpEval {
 		return cpslWorkerAction{response: cpslErrorResponse(cpslErrorResponseOptions{id: opts.request.ID, code: "invalid_request", message: "Unsupported CPSL worker operation"})}
 	}

--- a/cmd/herm/cpsl_worker_test.go
+++ b/cmd/herm/cpsl_worker_test.go
@@ -93,6 +93,29 @@ func TestServeCPSLWorkerMalformedAndUnsupportedRequests(t *testing.T) {
 	}
 }
 
+func TestServeCPSLWorkerConfiguresVision(t *testing.T) {
+	request := `{"id":8,"op":"configure_vision","timeout_ms":1000,"vision":{"model":"","config":{}}}` + "\n"
+	var stdout bytes.Buffer
+
+	err := serveCPSLWorker(serveCPSLWorkerOptions{
+		evaluator: fakeCPSLEvaluator{evalFunc: func(cpslSessionEvalOptions) (string, error) {
+			t.Fatal("eval should not be called")
+			return "", nil
+		}},
+		vision: &cpslVisionService{},
+		stdin:  strings.NewReader(request),
+		stdout: &stdout,
+		stderr: ioDiscard{},
+	})
+	if err != nil {
+		t.Fatalf("serveCPSLWorker: %v", err)
+	}
+	response := decodeWorkerTestResponse(t, stdout.Bytes())
+	if response.ID != 8 || !response.OK {
+		t.Fatalf("response = %#v", response)
+	}
+}
+
 func TestServeCPSLWorkerTimeoutRespondsAndTerminates(t *testing.T) {
 	request := `{"id":9,"op":"eval","language":"bash","input":"sleep","timeout_ms":5}` + "\n"
 	var stdout bytes.Buffer
@@ -199,17 +222,17 @@ func TestCPSLSessionConfigJSONUsesEmptyDomainArrays(t *testing.T) {
 }
 
 func TestValidateCPSLBackendMetadataJSON(t *testing.T) {
-	valid := `{"name":"cpsl","abi_version":1,"version":"0.1.0","languages":["luau","bash"],"capabilities":{"mounts":true,"network_policy":true}}`
+	valid := `{"name":"cpsl","abi_version":2,"version":"0.1.0","languages":["luau","bash"],"capabilities":{"mounts":true,"network_policy":true}}`
 	if err := validateCPSLBackendMetadataJSON(valid); err != nil {
 		t.Fatalf("valid metadata: %v", err)
 	}
 
 	tests := []string{
-		`{"name":"other","abi_version":1,"languages":["bash"],"capabilities":{"mounts":true,"network_policy":true}}`,
-		`{"name":"cpsl","abi_version":2,"languages":["luau","bash"],"capabilities":{"mounts":true,"network_policy":true}}`,
-		`{"name":"cpsl","abi_version":1,"languages":["python"],"capabilities":{"mounts":true,"network_policy":true}}`,
-		`{"name":"cpsl","abi_version":1,"languages":["luau"],"capabilities":{"mounts":true,"network_policy":true}}`,
-		`{"name":"cpsl","abi_version":1,"languages":["luau","bash"],"capabilities":{"mounts":false,"network_policy":true}}`,
+		`{"name":"other","abi_version":2,"languages":["bash"],"capabilities":{"mounts":true,"network_policy":true}}`,
+		`{"name":"cpsl","abi_version":3,"languages":["luau","bash"],"capabilities":{"mounts":true,"network_policy":true}}`,
+		`{"name":"cpsl","abi_version":2,"languages":["python"],"capabilities":{"mounts":true,"network_policy":true}}`,
+		`{"name":"cpsl","abi_version":2,"languages":["luau"],"capabilities":{"mounts":true,"network_policy":true}}`,
+		`{"name":"cpsl","abi_version":2,"languages":["luau","bash"],"capabilities":{"mounts":false,"network_policy":true}}`,
 		`not-json`,
 	}
 	for _, tt := range tests {

--- a/cmd/herm/deployment_aware_project_model_test.go
+++ b/cmd/herm/deployment_aware_project_model_test.go
@@ -18,6 +18,7 @@ func TestProjectModelProjectConfigSaveLoadNormalizesBareAnthropicIDs(t *testing.
 	project := ProjectConfig{
 		ActiveModel:      "claude-opus-4-6",
 		ExplorationModel: "claude-haiku-4-5",
+		VisionModel:      "grok-4.5",
 		Personality:      "project",
 	}
 
@@ -32,6 +33,9 @@ func TestProjectModelProjectConfigSaveLoadNormalizesBareAnthropicIDs(t *testing.
 	if loaded.ExplorationModel != "anthropic/claude-haiku-4-5" {
 		t.Fatalf("ExplorationModel = %q, want anthropic/claude-haiku-4-5", loaded.ExplorationModel)
 	}
+	if loaded.VisionModel != "xai/grok-4.5" {
+		t.Fatalf("VisionModel = %q, want xai/grok-4.5", loaded.VisionModel)
+	}
 
 	data, err := os.ReadFile(filepath.Join(repoRoot, configDir, configFile))
 	if err != nil {
@@ -41,7 +45,7 @@ func TestProjectModelProjectConfigSaveLoadNormalizesBareAnthropicIDs(t *testing.
 	if err := json.Unmarshal(data, &saved); err != nil {
 		t.Fatalf("Unmarshal saved project config: %v", err)
 	}
-	if saved.ActiveModel != "anthropic/claude-opus-4-6" || saved.ExplorationModel != "anthropic/claude-haiku-4-5" {
+	if saved.ActiveModel != "anthropic/claude-opus-4-6" || saved.ExplorationModel != "anthropic/claude-haiku-4-5" || saved.VisionModel != "xai/grok-4.5" {
 		t.Fatalf("saved project config was not canonicalized: %+v", saved)
 	}
 	if containsJSONKey(data, "deployments") || containsJSONKey(data, "routing") {
@@ -458,12 +462,13 @@ func TestProjectModelProjectConfigUnknownValuesRemainRoundTrippable(t *testing.T
 	project := ProjectConfig{
 		ActiveModel:      "future-native-model",
 		ExplorationModel: "future-fast-model",
+		VisionModel:      "future-vision-model",
 	}
 	if err := saveProjectConfig(saveProjectConfigOptions{repoRoot: repoRoot, pc: project}); err != nil {
 		t.Fatalf("saveProjectConfig: %v", err)
 	}
 	loaded := loadProjectConfig(repoRoot)
-	if loaded.ActiveModel != project.ActiveModel || loaded.ExplorationModel != project.ExplorationModel {
+	if loaded.ActiveModel != project.ActiveModel || loaded.ExplorationModel != project.ExplorationModel || loaded.VisionModel != project.VisionModel {
 		t.Fatalf("loaded = %+v, want unknown values preserved %+v", loaded, project)
 	}
 
@@ -475,7 +480,7 @@ func TestProjectModelProjectConfigUnknownValuesRemainRoundTrippable(t *testing.T
 	if err := json.Unmarshal(data, &raw); err != nil {
 		t.Fatalf("Unmarshal saved project config: %v", err)
 	}
-	if raw["active_model"] != "future-native-model" || raw["exploration_model"] != "future-fast-model" {
+	if raw["active_model"] != "future-native-model" || raw["exploration_model"] != "future-fast-model" || raw["vision_model"] != "future-vision-model" {
 		t.Fatalf("saved JSON did not preserve unknown values: %s", data)
 	}
 }

--- a/cmd/herm/deployment_config.go
+++ b/cmd/herm/deployment_config.go
@@ -57,6 +57,7 @@ type DeploymentAwareConfig struct {
 	PasteCollapseMinChars int                         `json:"paste_collapse_min_chars,omitempty"`
 	ActiveModel           string                      `json:"active_model,omitempty"`
 	ExplorationModel      string                      `json:"exploration_model,omitempty"`
+	VisionModel           string                      `json:"vision_model,omitempty"`
 	Deployments           map[string]DeploymentConfig `json:"deployments,omitempty"`
 	Routing               *RoutingPolicy              `json:"routing,omitempty"`
 	ModelSortCol          string                      `json:"model_sort_col,omitempty"`
@@ -141,23 +142,27 @@ func deploymentAwareConfigFromLegacyConfig(cfg Config) DeploymentAwareConfig {
 		Offerings:               defaultModelIDMigrationOfferings(),
 		ActiveSmartDefault:      defaultCanonicalActiveModel,
 		ExplorationSmartDefault: defaultCanonicalExplorationModel,
+		VisionSmartDefault:      defaultCanonicalVisionModel,
 	}).Config
 }
 
 const defaultCanonicalActiveModel = "openai/gpt-4.1-2025-04-14"
 const defaultCanonicalExplorationModel = "anthropic/claude-haiku-4-5"
+const defaultCanonicalVisionModel = defaultCanonicalActiveModel
 
 type DeploymentAwareConfigMigrationOptions struct {
 	Config                  Config
 	Offerings               []ModelIDMigrationOffering
 	ActiveSmartDefault      string
 	ExplorationSmartDefault string
+	VisionSmartDefault      string
 }
 
 type DeploymentAwareConfigMigrationResult struct {
 	Config           DeploymentAwareConfig
 	ActiveModel      ModelIDMigrationResult
 	ExplorationModel ModelIDMigrationResult
+	VisionModel      ModelIDMigrationResult
 }
 
 func migrateDeploymentAwareConfigFromLegacyConfig(opts DeploymentAwareConfigMigrationOptions) DeploymentAwareConfigMigrationResult {
@@ -173,6 +178,10 @@ func migrateDeploymentAwareConfigFromLegacyConfig(opts DeploymentAwareConfigMigr
 	explorationDefault := opts.ExplorationSmartDefault
 	if explorationDefault == "" {
 		explorationDefault = activeDefault
+	}
+	visionDefault := opts.VisionSmartDefault
+	if visionDefault == "" {
+		visionDefault = activeDefault
 	}
 	active := ModelIDMigrationResult{}
 	if cfg.ActiveModel != "" {
@@ -190,11 +199,20 @@ func migrateDeploymentAwareConfigFromLegacyConfig(opts DeploymentAwareConfigMigr
 			smartDefault: explorationDefault,
 		})
 	}
+	vision := ModelIDMigrationResult{}
+	if cfg.VisionModel != "" {
+		vision = migrateStoredModelIDToCanonical(migrateStoredModelIDToCanonicalOptions{
+			savedModelID: cfg.VisionModel,
+			offerings:    offerings,
+			smartDefault: visionDefault,
+		})
+	}
 	result := DeploymentAwareConfig{
 		ConfigVersion:         hermConfigVersionDeploymentAware,
 		PasteCollapseMinChars: cfg.PasteCollapseMinChars,
 		ActiveModel:           active.CanonicalModelID,
 		ExplorationModel:      exploration.CanonicalModelID,
+		VisionModel:           vision.CanonicalModelID,
 		Deployments:           map[string]DeploymentConfig{},
 		ModelSortCol:          cfg.ModelSortCol,
 		ModelSortDirs:         cloneBoolMap(cfg.ModelSortDirs),
@@ -214,7 +232,7 @@ func migrateDeploymentAwareConfigFromLegacyConfig(opts DeploymentAwareConfigMigr
 	if len(result.Deployments) == 0 {
 		result.Deployments = nil
 	}
-	return DeploymentAwareConfigMigrationResult{Config: result, ActiveModel: active, ExplorationModel: exploration}
+	return DeploymentAwareConfigMigrationResult{Config: result, ActiveModel: active, ExplorationModel: exploration, VisionModel: vision}
 }
 
 func deploymentConfigsForStorage(cfg Config) map[string]DeploymentConfig {
@@ -357,6 +375,9 @@ func mergeDeploymentAwareProjectConfig(opts mergeDeploymentAwareProjectConfigOpt
 	if project.ExplorationModel != "" {
 		merged.ExplorationModel = project.ExplorationModel
 	}
+	if project.VisionModel != "" {
+		merged.VisionModel = project.VisionModel
+	}
 	if project.Personality != "" {
 		merged.Personality = project.Personality
 	}
@@ -415,6 +436,7 @@ func defaultModelIDMigrationOfferings() []ModelIDMigrationOffering {
 		{CanonicalModelID: "google/gemini-2.5-flash", DeploymentID: "gemini-direct", NativeModelID: "gemini-2.5-flash"},
 		{CanonicalModelID: "xai/grok-4-1-fast-reasoning", DeploymentID: "grok-direct", NativeModelID: "grok-4-1-fast-reasoning"},
 		{CanonicalModelID: "xai/grok-4-1-fast-non-reasoning", DeploymentID: "grok-direct", NativeModelID: "grok-4-1-fast-non-reasoning"},
+		{CanonicalModelID: "xai/grok-4.5", DeploymentID: "grok-direct", NativeModelID: "grok-4.5"},
 		{CanonicalModelID: "z-ai/glm-4.5-air:free", DeploymentID: "openrouter", NativeModelID: "z-ai/glm-4.5-air:free"},
 	}
 	offerings = append(offerings, embeddedCatalogModelIDMigrationOfferings()...)

--- a/cmd/herm/deployment_config_test.go
+++ b/cmd/herm/deployment_config_test.go
@@ -19,6 +19,7 @@ func TestDeploymentAwareConfigMigratesLegacyFlatCredentials(t *testing.T) {
 		OllamaBaseURL:         "http://localhost:11434",
 		ActiveModel:           "gpt-4.1-2025-04-14",
 		ExplorationModel:      "claude-haiku-4-5",
+		VisionModel:           "gemini-2.5-pro",
 		ModelSortCol:          "price",
 		ModelSortDirs:         map[string]bool{"price": false, "name": true},
 		SubAgentMaxTurns:      12,
@@ -38,10 +39,10 @@ func TestDeploymentAwareConfigMigratesLegacyFlatCredentials(t *testing.T) {
 	if migrated.ConfigVersion != hermConfigVersionDeploymentAware {
 		t.Fatalf("ConfigVersion = %d", migrated.ConfigVersion)
 	}
-	if result.ActiveModel.Status != ModelIDMigrationUniqueNative || result.ExplorationModel.Status != ModelIDMigrationUniqueNative {
-		t.Fatalf("model migration diagnostics = active:%+v exploration:%+v", result.ActiveModel, result.ExplorationModel)
+	if result.ActiveModel.Status != ModelIDMigrationUniqueNative || result.ExplorationModel.Status != ModelIDMigrationUniqueNative || result.VisionModel.Status != ModelIDMigrationUniqueNative {
+		t.Fatalf("model migration diagnostics = active:%+v exploration:%+v vision:%+v", result.ActiveModel, result.ExplorationModel, result.VisionModel)
 	}
-	if migrated.ActiveModel != "openai/gpt-4.1-2025-04-14" || migrated.ExplorationModel != "anthropic/claude-haiku-4-5" {
+	if migrated.ActiveModel != "openai/gpt-4.1-2025-04-14" || migrated.ExplorationModel != "anthropic/claude-haiku-4-5" || migrated.VisionModel != "google/gemini-2.5-pro" {
 		t.Fatalf("models did not migrate to canonical IDs: %+v", migrated)
 	}
 	if migrated.PasteCollapseMinChars != legacy.PasteCollapseMinChars ||
@@ -140,6 +141,7 @@ func TestDeploymentAwareProjectConfigCannotOverrideDeploymentsOrRouting(t *testi
 		ConfigVersion:    hermConfigVersionDeploymentAware,
 		ActiveModel:      "openai/gpt-4.1-2025-04-14",
 		ExplorationModel: "anthropic/claude-haiku-4-5",
+		VisionModel:      "openai/gpt-4.1-2025-04-14",
 		Deployments: map[string]DeploymentConfig{
 			"openai-direct": {APIKey: "secret"},
 		},
@@ -153,6 +155,7 @@ func TestDeploymentAwareProjectConfigCannotOverrideDeploymentsOrRouting(t *testi
 	project := ProjectConfig{
 		ActiveModel:      "anthropic/claude-sonnet-4-20250514",
 		ExplorationModel: "openai/gpt-4.1-mini-2025-04-14",
+		VisionModel:      "google/gemini-2.5-pro",
 		Personality:      "project",
 		SubAgentMaxTurns: 9,
 		Thinking:         &projectThinking,
@@ -162,7 +165,7 @@ func TestDeploymentAwareProjectConfigCannotOverrideDeploymentsOrRouting(t *testi
 		global:  global,
 		project: project,
 	})
-	if merged.ActiveModel != project.ActiveModel || merged.ExplorationModel != project.ExplorationModel {
+	if merged.ActiveModel != project.ActiveModel || merged.ExplorationModel != project.ExplorationModel || merged.VisionModel != project.VisionModel {
 		t.Fatalf("project model overrides not applied: %+v", merged)
 	}
 	if merged.Personality != project.Personality || merged.SubAgentMaxTurns != project.SubAgentMaxTurns || merged.Thinking == nil || !*merged.Thinking {

--- a/cmd/herm/main.go
+++ b/cmd/herm/main.go
@@ -719,6 +719,7 @@ func (a *App) handleResult(result any) {
 				})
 				a.resultCh <- langdagReadyMsg{client: client, provider: provider, runtimeApple: hasRuntimeAppleModels(models), err: err}
 			}()
+			a.configureCPSLVision()
 		}
 	case ollamaModelsMsg:
 		a.ollamaFetched = true
@@ -841,6 +842,7 @@ func (a *App) handleResult(result any) {
 		a.cpslReady = true
 		a.cpslErr = nil
 		a.cpslStatusText = "ready (/workdir)"
+		a.configureCPSLVision()
 
 	case cpslErrMsg:
 		a.cpslErr = msg.err

--- a/cmd/herm/model_catalog_compat.go
+++ b/cmd/herm/model_catalog_compat.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"time"
+
+	"langdag.com/langdag"
+)
+
+// ensureHermModelCatalogCompatibility fills the short release window between
+// a provider launching a model and the next published LangDAG catalog snapshot.
+// Entries already supplied by LangDAG always win.
+func ensureHermModelCatalogCompatibility(catalog *langdag.ModelCatalog) *langdag.ModelCatalog {
+	if catalog == nil {
+		return nil
+	}
+	const canonicalID = "xai/grok-4.5"
+	if catalog.Models[canonicalID] != nil {
+		return catalog
+	}
+	if catalog.Models == nil {
+		catalog.Models = make(map[string]*langdag.ModelV1)
+	}
+	catalog.Models[canonicalID] = &langdag.ModelV1{
+		ID:            canonicalID,
+		ProviderID:    "xai",
+		Name:          "Grok 4.5",
+		Family:        "grok-4.5",
+		ContextWindow: 500_000,
+	}
+	effectiveAt := time.Date(2026, time.July, 8, 0, 0, 0, 0, time.UTC)
+	catalog.Offerings = append(catalog.Offerings, langdag.ModelOfferingV1{
+		ID:               "grok-direct:grok-4.5",
+		CanonicalModelID: canonicalID,
+		DeploymentID:     "grok-direct",
+		NativeModelID:    "grok-4.5",
+		Pricing: langdag.PricingV1{
+			Status:      langdag.PricingKnown,
+			Currency:    "USD",
+			EffectiveAt: effectiveAt,
+			RatesPer1M: map[string]float64{
+				"input_tokens":            2,
+				"cache_read_input_tokens": 0.5,
+				"output_tokens":           6,
+			},
+		},
+	})
+	if catalog.Aliases == nil {
+		catalog.Aliases = make(map[string]string)
+	}
+	catalog.Aliases["grok-4.5"] = canonicalID
+	return catalog
+}

--- a/cmd/herm/model_catalog_compat.go
+++ b/cmd/herm/model_catalog_compat.go
@@ -1,3 +1,4 @@
+// model_catalog_compat.go supplies short-lived model metadata compatibility entries.
 package main
 
 import (

--- a/cmd/herm/model_catalog_compat_test.go
+++ b/cmd/herm/model_catalog_compat_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"testing"
+
+	"langdag.com/langdag"
+)
+
+func TestEnsureHermModelCatalogCompatibilityAddsGrok45(t *testing.T) {
+	catalog := langdag.ReferenceCatalogV1()
+	delete(catalog.Models, "xai/grok-4.5")
+	catalog = ensureHermModelCatalogCompatibility(catalog)
+
+	model := catalog.Models["xai/grok-4.5"]
+	if model == nil || model.ContextWindow != 500_000 || model.ProviderID != "xai" {
+		t.Fatalf("model = %#v", model)
+	}
+	if catalog.Aliases["grok-4.5"] != "xai/grok-4.5" {
+		t.Fatalf("alias = %q", catalog.Aliases["grok-4.5"])
+	}
+	found := false
+	for _, offering := range catalog.Offerings {
+		if offering.CanonicalModelID == "xai/grok-4.5" && offering.DeploymentID == "grok-direct" && offering.NativeModelID == "grok-4.5" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("missing grok-direct Grok 4.5 offering")
+	}
+	models := modelsFromCatalog(catalog)
+	cfg := Config{GrokAPIKey: "xai-test", VisionModel: "xai/grok-4.5"}
+	if got := cfg.resolveVisionModel(models); got != "xai/grok-4.5" {
+		t.Fatalf("resolveVisionModel = %q, want xai/grok-4.5", got)
+	}
+}
+
+func TestEnsureHermModelCatalogCompatibilityKeepsPublishedEntry(t *testing.T) {
+	catalog := langdag.ReferenceCatalogV1()
+	catalog.Models["xai/grok-4.5"] = &langdag.ModelV1{ID: "xai/grok-4.5", Name: "Published"}
+	offeringCount := len(catalog.Offerings)
+	ensureHermModelCatalogCompatibility(catalog)
+	if catalog.Models["xai/grok-4.5"].Name != "Published" || len(catalog.Offerings) != offeringCount {
+		t.Fatal("published catalog entry should win")
+	}
+}

--- a/cmd/herm/ui_messages.go
+++ b/cmd/herm/ui_messages.go
@@ -10,8 +10,10 @@ import (
 const (
 	uiConfigLabelActiveModel             = "Model"
 	uiConfigLabelExplorationModel        = "Exploration"
+	uiConfigLabelVisionModel             = "Vision"
 	uiConfigLabelProjectActiveModel      = "Project Model"
 	uiConfigLabelProjectExplorationModel = "Project Exploration"
+	uiConfigLabelProjectVisionModel      = "Project Vision"
 )
 
 const uiConfigLabelAPIKeySubstring = "API Key"
@@ -91,6 +93,15 @@ func isExplorationModelConfigLabel(label string) bool {
 	}
 }
 
+func isVisionModelConfigLabel(label string) bool {
+	switch label {
+	case uiConfigLabelVisionModel, uiConfigLabelProjectVisionModel:
+		return true
+	default:
+		return false
+	}
+}
+
 type configChangeLabelForFieldOptions struct {
 	field      cfgField
 	projectTab bool
@@ -105,6 +116,8 @@ func configChangeLabelForField(opts configChangeLabelForFieldOptions) string {
 		return uiConfigLabelProjectActiveModel
 	case uiConfigLabelExplorationModel:
 		return uiConfigLabelProjectExplorationModel
+	case uiConfigLabelVisionModel:
+		return uiConfigLabelProjectVisionModel
 	default:
 		return opts.field.label
 	}

--- a/cmd/herm/wiring.go
+++ b/cmd/herm/wiring.go
@@ -256,9 +256,17 @@ func modelCatalogCachePath() string {
 }
 
 func loadStartupModelCatalog() (*langdag.CatalogLoadResult, error) {
-	return langdag.LoadRuntimeModelCatalogWithOptions(langdag.CatalogLoadOptions{CachePath: modelCatalogCachePath()})
+	result, err := langdag.LoadRuntimeModelCatalogWithOptions(langdag.CatalogLoadOptions{CachePath: modelCatalogCachePath()})
+	if result != nil {
+		result.Catalog = ensureHermModelCatalogCompatibility(result.Catalog)
+	}
+	return result, err
 }
 
 func refreshStartupModelCatalog(ctx context.Context) (*langdag.CatalogRefreshResult, error) {
-	return langdag.RefreshModelCatalogCache(ctx, langdag.CatalogRefreshOptionsFromEnv(modelCatalogCachePath()))
+	result, err := langdag.RefreshModelCatalogCache(ctx, langdag.CatalogRefreshOptionsFromEnv(modelCatalogCachePath()))
+	if result != nil {
+		result.Catalog = ensureHermModelCatalogCompatibility(result.Catalog)
+	}
+	return result, err
 }

--- a/docs/deployment-aware-models.md
+++ b/docs/deployment-aware-models.md
@@ -6,9 +6,10 @@ deployment and native model ID at call time.
 
 ## Config V2
 
-Deployment-aware config uses `config_version: 2`, top-level `active_model` and
-`exploration_model`, global `deployments`, and global `routing`. Project config
-can override active/exploration model and non-secret behavior only. Deployment
+Deployment-aware config uses `config_version: 2`, top-level `active_model`,
+`exploration_model`, and `vision_model`, global `deployments`, and global
+`routing`. Project config can override active/exploration/vision models and
+non-secret behavior only. Deployment
 credentials, deployment-scoped `model_mappings`, and routing are global-only.
 Existing non-secret global settings such as model sort preferences, turn limits,
 personality, history limits, debug mode, and thinking remain top-level config
@@ -38,6 +39,7 @@ Example:
 {
   "config_version": 2,
   "active_model": "openai/gpt-4.1-2025-04-14",
+  "vision_model": "google/gemini-2.5-pro",
   "deployments": {
     "openai-direct": {
       "api_key": "sk-..."
@@ -59,6 +61,14 @@ Example:
   }
 }
 ```
+
+`vision_model` is the provider-agnostic model used by CPSL `doc.read` vision
+mode. It may point to a different configured provider than `active_model`; when
+unset, it follows `active_model`. Select a model that accepts image input. The
+same field is allowed in project config.
+Images and PDFs use vision by default when the host callback is available;
+other supported document types use structural parsing by default. Callers can
+override an individual read with `mode="vision"` or `mode="structural"`.
 
 Environment variables remain fallback input when config fields are empty:
 `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, `XAI_API_KEY`,

--- a/scripts/vet-apple-agent-config.swift
+++ b/scripts/vet-apple-agent-config.swift
@@ -14,7 +14,9 @@ private struct CPSLAgentConfigChecks {
         try assertConfigLoadsGeneratedValues()
         try assertConfigPrefersFileValues()
         try assertEnvironmentFallbacks()
+        try assertDedicatedVisionConfig()
         try assertInvalidBaseURLFails()
+        try assertInvalidVisionBaseURLFails()
         try assertBaseURLQueryFails()
         try assertBaseURLCredentialsFail()
     }
@@ -25,6 +27,9 @@ private struct CPSLAgentConfigChecks {
         guard config.baseURL.absoluteString == "https://api.x.ai/v1",
               config.token == "generated-token",
               config.model == "generated-model",
+              config.visionBaseURL.absoluteString == "https://api.x.ai/v1",
+              config.visionToken == "generated-token",
+              config.visionModel == "generated-model",
               config.maxToolRounds == 200,
               config.maxOutputTokens == 16_384,
               config.contextWindowTokens == nil,
@@ -33,6 +38,24 @@ private struct CPSLAgentConfigChecks {
               config.maxAgentDepth == 1
         else {
             throw CheckFailure("generated constants should load as the default config")
+        }
+    }
+
+    private static func assertDedicatedVisionConfig() throws {
+        let config = try CPSLAgentConfig.make(values: [
+            "OPENAI_BASE_URL": "https://api.x.ai/v1",
+            "OPENAI_API_KEY": "main-token",
+            "OPENAI_MODEL": "grok-4.5",
+            "HERM_VISION_BASE_URL": "https://generativelanguage.googleapis.com/v1beta/openai",
+            "HERM_VISION_API_KEY": "vision-token",
+            "HERM_VISION_MODEL": "gemini-2.5-pro"
+        ])
+
+        guard config.visionBaseURL.absoluteString == "https://generativelanguage.googleapis.com/v1beta/openai",
+              config.visionToken == "vision-token",
+              config.visionModel == "gemini-2.5-pro"
+        else {
+            throw CheckFailure("dedicated vision config should override the main provider")
         }
     }
 
@@ -103,6 +126,20 @@ private struct CPSLAgentConfigChecks {
             return
         }
         throw CheckFailure("relative OPENAI_BASE_URL should fail validation")
+    }
+
+    private static func assertInvalidVisionBaseURLFails() throws {
+        do {
+            _ = try CPSLAgentConfig.make(values: [
+                "OPENAI_BASE_URL": "https://api.x.ai/v1",
+                "OPENAI_API_KEY": "token",
+                "OPENAI_MODEL": "model",
+                "HERM_VISION_BASE_URL": "not-a-url"
+            ])
+        } catch CPSLAgentConfigError.invalidValue("HERM_VISION_BASE_URL") {
+            return
+        }
+        throw CheckFailure("relative HERM_VISION_BASE_URL should fail validation")
     }
 
     private static func assertBaseURLQueryFails() throws {

--- a/scripts/vet-apple-agent-integration.sh
+++ b/scripts/vet-apple-agent-integration.sh
@@ -204,7 +204,7 @@ require_match '"skills"' app/apple/herm/Services/CPSLDebugService.swift
 require_match '"virtual": mount.virtualPath' app/apple/herm/Services/CPSLDebugService.swift
 require_match '"mode": "ro"' app/apple/herm/Services/CPSLDebugService.swift
 require_match 'Copy Bundled Skills' app/apple/herm.xcodeproj/project.pbxproj
-require_match 'alwaysOutOfDate = 1;' app/apple/herm.xcodeproj/project.pbxproj
+reject_match 'alwaysOutOfDate = 1;' app/apple/herm.xcodeproj/project.pbxproj
 require_match 'Skills,' app/apple/herm.xcodeproj/project.pbxproj
 require_match 'SRCROOT.*/herm/Skills' app/apple/herm.xcodeproj/project.pbxproj
 require_match 'UNLOCALIZED_RESOURCES_FOLDER_PATH.*/Skills' app/apple/herm.xcodeproj/project.pbxproj

--- a/scripts/vet-apple-agent-integration.sh
+++ b/scripts/vet-apple-agent-integration.sh
@@ -59,6 +59,7 @@ required_files=(
   app/apple/herm/Resources/env.example
   app/apple/herm/Skills/beautiful-pdfs/SKILL.md
   app/apple/herm/Skills/beautiful-pdfs/print.css
+  app/apple/herm/Skills/image-vision/SKILL.md
   app/apple/herm/herm.entitlements
   app/apple/herm/herm-macOS.entitlements
   app/apple/herm.xcodeproj/project.pbxproj
@@ -191,6 +192,10 @@ require_match 'validatedCompletion\(\)' app/apple/herm/Services/Agent/CPSLOpenAI
 require_match 'toolChoice: streamRequest\.tools\.isEmpty \? nil : "auto"' app/apple/herm/Services/Agent/CPSLOpenAIClient.swift
 require_match 'stream: true' app/apple/herm/Services/Agent/CPSLOpenAIClient.swift
 require_match 'text/event-stream' app/apple/herm/Services/Agent/CPSLOpenAIClient.swift
+require_match 'HERM_VISION_MODEL' app/apple/herm/Services/Agent/CPSLAgentConfig.swift
+require_match 'actor CPSLVisionClient' app/apple/herm/Services/Agent/CPSLOpenAIClient.swift
+require_match 'cpsl_session_new_with_host_callbacks_v3' app/apple/herm/Services/CPSLDebugService.swift
+require_match 'cpsl_vision_respond' app/apple/herm/Services/CPSLDebugService.swift
 require_match 'evaluateLuau' app/apple/herm/Services/CPSLDebugService.swift
 require_match 'currentVirtualDirectory' app/apple/herm/Services/CPSLDebugService.swift
 require_match 'func currentDirectory\(\) -> String' app/apple/herm/Services/CPSLDebugService.swift
@@ -224,6 +229,11 @@ require_match 'fs\.write\("/tmp/report\.html", html\)' app/apple/herm/Skills/bea
 require_match 'print\(fs\.exists\("/home/herm/report\.pdf"\)\)' app/apple/herm/Skills/beautiful-pdfs/SKILL.md
 require_match 'platform not supported' app/apple/herm/Skills/beautiful-pdfs/SKILL.md
 require_match 'no PDF was produced' app/apple/herm/Skills/beautiful-pdfs/SKILL.md
+require_match 'name: image-vision' app/apple/herm/Skills/image-vision/SKILL.md
+require_match 'mode = "vision"' app/apple/herm/Skills/image-vision/SKILL.md
+require_match 'doc\.readAsync' app/apple/herm/Skills/image-vision/SKILL.md
+require_match 'vision callback .* not available' app/apple/herm/Skills/image-vision/SKILL.md
+require_match 'Never claim to have seen or analyzed' app/apple/herm/Skills/image-vision/SKILL.md
 require_match 'target_os = "ios"' external/cpsl/modules/native-webview-pdf/src/lib.rs
 require_match '@page' app/apple/herm/Skills/beautiful-pdfs/print.css
 require_match 'Current CPSL directory' app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
@@ -399,7 +409,9 @@ if command -v swiftc >/dev/null 2>&1; then
     -o /tmp/herm-vet-agent-tool-formatting
   /tmp/herm-vet-agent-tool-formatting
   swiftc \
+    app/apple/herm/Services/Agent/CPSLAgentConfig.swift \
     app/apple/herm/Services/Agent/CPSLOpenAIProtocol.swift \
+    app/apple/herm/Services/Agent/CPSLOpenAIClient.swift \
     app/apple/herm/Services/Agent/CPSLAgentToolFormatting.swift \
     scripts/vet-apple-openai-protocol.swift \
     -o /tmp/herm-vet-openai-protocol

--- a/scripts/vet-apple-openai-protocol.swift
+++ b/scripts/vet-apple-openai-protocol.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+nonisolated enum CPSLEnvConstants {
+    static let values: [String: String] = [:]
+}
+
 @main
 private struct CPSLOpenAIProtocolChecks {
     static func main() throws {
@@ -7,6 +11,7 @@ private struct CPSLOpenAIProtocolChecks {
         try assertChatRequestExposesClientTools()
         try assertSubagentToolCanBeDisabled()
         try assertChatRequestCanDisableTools()
+        try assertVisionRequestEncodesMultimodalContent()
         try assertStreamAccumulatorCollectsTextAndToolCall()
         try assertStreamAccumulatorRejectsIncompleteToolCall()
         try assertStreamAccumulatorSurfacesProviderErrors()
@@ -152,6 +157,40 @@ private struct CPSLOpenAIProtocolChecks {
               object["max_completion_tokens"] as? Int == 2048
         else {
             throw CheckFailure("tools-disabled synthesis request encoded tool fields")
+        }
+    }
+
+    private static func assertVisionRequestEncodesMultimodalContent() throws {
+        let request = CPSLVisionChatRequest(
+            model: "grok-4.5",
+            messages: [CPSLVisionMessage(
+                role: "user",
+                content: [
+                    CPSLVisionContentPart(type: "text", text: "Read this", imageURL: nil),
+                    CPSLVisionContentPart(
+                        type: "image_url",
+                        text: nil,
+                        imageURL: CPSLVisionImageURL(
+                            url: "data:image/png;base64,AQID"
+                        )
+                    )
+                ]
+            )],
+            maxCompletionTokens: 4096
+        )
+        let object = try jsonObject(request)
+        guard object["model"] as? String == "grok-4.5",
+              object["max_completion_tokens"] as? Int == 4096,
+              let messages = object["messages"] as? [[String: Any]],
+              let content = messages.first?["content"] as? [[String: Any]],
+              content.count == 2,
+              content[0]["type"] as? String == "text",
+              content[0]["text"] as? String == "Read this",
+              content[1]["type"] as? String == "image_url",
+              let imageURL = content[1]["image_url"] as? [String: Any],
+              imageURL["url"] as? String == "data:image/png;base64,AQID"
+        else {
+            throw CheckFailure("vision request did not encode OpenAI-compatible multimodal content")
         }
     }
 


### PR DESCRIPTION
## Dependency

Merge fundamental-research-labs/cpsl#37 first. This branch points the CPSL submodule at that PR head; update the pointer before merging if the CPSL merge produces a different commit SHA.

## Summary

- add a dedicated global or project-level vision model that falls back to the active model when unset
- support optional `HERM_VISION_*` provider overrides while reusing `OPENAI_*` configuration by default
- wire CPSL vision callbacks through the CLI worker on Unix and Windows and through the Apple host
- send images, documents, and text inputs to the configured multimodal provider
- bundle an `image-vision` skill that teaches agents the simple, asynchronous, and custom-query `doc.read` workflows
- retain the original Apple compiler-warning cleanup and CPSL build-phase dependency improvements

## Validation

- `go build -o /tmp/herm-build-check ./cmd/herm`
- `go test ./...`
- `git diff --check`
- `plutil -lint app/apple/herm.xcodeproj/project.pbxproj`
- image-vision skill structure and bundle registration checks

The full CPSL PDFium integration suite requires `libpdfium.so`, which is unavailable in the current environment.