### PR TITLE
Polish Apple file, calendar, and attachment UX

### DIFF
--- a/app/apple/herm.xcodeproj/project.pbxproj
+++ b/app/apple/herm.xcodeproj/project.pbxproj
@@ -274,6 +274,7 @@
 		};
 		85A100072FEA000000000007 /* Build CPSL XCFramework */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/app/apple/herm/Models/CPSLChatModel.swift
+++ b/app/apple/herm/Models/CPSLChatModel.swift
@@ -80,7 +80,6 @@ final class CPSLChatModel: ObservableObject {
     let estimatedBytesPerToken = 4
     let toolResultClearThreshold = 0.80
     let recentToolResultsToKeep = 4
-    private static let iCloudRestrictedSkillNames = Set(["beautiful-pdfs", "webbrowser"])
     var activeToolStatusNodeID: String?
     var activeToolStatusPayload: CPSLToolStatusPayload?
     var activeToolStatusStore: CPSLConversationStore?
@@ -111,7 +110,7 @@ final class CPSLChatModel: ObservableObject {
     Every local_sandbox_exec call must include intent: one short high-level user-facing action phrase, such as "Preparing document", "Checking export", or "Saving result". Do not mention code, sandbox details, paths, module names, tool names, API names, file extensions, HTTP, or implementation details in intent.
     When you call tools, assistant content may contain the same kind of high-level status phrase, but never code or implementation details.
     local_sandbox_exec runs Luau source in CPSL. The current CPSL directory is supplied in each request. Never guess CPSL API signatures: call help() and each module's help function, such as fs.help(), before using APIs.
-    Treat CPSL as its own Luau ecosystem. APIs from other Lua/Luau environments may be popular elsewhere but are not expected to exist here. Use only the built-in globals shown by help(); for files use fs, for documents use doc. Do not use require or package-style imports for filesystem or document work.
+    Treat CPSL as its own Luau ecosystem. APIs from other Lua/Luau environments may be popular elsewhere but are not expected to exist here. Use only the built-in globals shown by help(); for files use fs, for documents use doc. Sandbox modules are globals: do not use require to load them, and do not search the filesystem for a module that help() does not list.
     Treat help output as human-readable documentation. Call help() or module.help() as its own sandbox invocation and read the printed text; do not assign help output to a variable or parse it with string.find, string.sub, #, or tostring().
     Follow documented return shapes exactly. For example, fs.list(path) returns an array of entry name strings; it does not return records with name or size fields. Use fs.size(path .. "/" .. entry) only when sizes are needed.
     Calendar and location are available through CPSL only when compiled into the app sandbox and authorized by the user. Use calendar or location only when the user's request materially needs schedule, event, availability, or current-place context. EventKit does not expose native calendar file attachments. When files should be associated with an event, use calendar.attach: it copies them to durable storage and makes them openable from Herm's Calendar view. Describe these as attached in Herm, not as native Calendar.app attachments. Access states are granted, denied, or undefined. If access is undefined, the relevant CPSL request/current function may prompt the user. If access is denied, stop using that capability and tell the user to enable access for Herm in iOS Settings or macOS System Settings.
@@ -158,7 +157,7 @@ final class CPSLChatModel: ObservableObject {
 
         \(mountLines)
 
-        Treat content under `/icloud/*` as personal data. Read from those mounts only as needed for the task. Do not modify read-only mounts. Changes made in read-write mounts affect the original files; iCloud Drive uploads those changes asynchronously. Network access is disabled while these mounts are active.
+        Treat content under `/icloud/*` as personal data. Read from those mounts only as needed for the task. Do not modify read-only mounts. Changes made in read-write mounts affect the original files; iCloud Drive uploads those changes asynchronously.
         """
     }
 
@@ -1209,14 +1208,7 @@ final class CPSLChatModel: ObservableObject {
             activeModel = config.model
             try await store.updateConversationModelIfMissing(conversationID: conversationID, model: config.model)
             let providerMessages = try await store.providerMessages(conversationID: conversationID)
-            // Stored prompts may advertise capabilities that are deliberately
-            // unavailable while personal mounts are connected. Use the live
-            // catalog for an isolated run instead of replaying stale skills.
-            let replayBasePrompt = iCloudMounts.isEmpty
-                ? currentSystemPrompt ?? promptForConversation
-                : systemPrompt(with: availableSkills.filter { skill in
-                    !Self.iCloudRestrictedSkillNames.contains(skill.name.lowercased())
-                })
+            let replayBasePrompt = currentSystemPrompt ?? promptForConversation
             let replaySystemPrompt = addingICloudMountContext(to: replayBasePrompt)
             var providerLoopContext = CPSLProviderLoopContext(
                 client: client,

--- a/app/apple/herm/Models/CPSLChatModel.swift
+++ b/app/apple/herm/Models/CPSLChatModel.swift
@@ -25,6 +25,7 @@ final class CPSLChatModel: ObservableObject {
     @Published private(set) var expandedFilePaths: Set<String> = []
     @Published private(set) var loadingFilePaths: Set<String> = []
     @Published private(set) var fileBrowserError: String?
+    @Published private(set) var isManagingFiles = false
     @Published private(set) var filePreview: CPSLFilePreview? {
         didSet {
             if filePreview == nil {
@@ -47,7 +48,7 @@ final class CPSLChatModel: ObservableObject {
     @Published private(set) var iCloudImportProgress: CPSLICloudImportProgress?
 
     var isBusy: Bool {
-        isRunning || isUpdatingICloudMounts
+        isRunning || isUpdatingICloudMounts || isManagingFiles
     }
 
     let service: CPSLDebugService
@@ -73,6 +74,8 @@ final class CPSLChatModel: ObservableObject {
     private var filePreviewLoadTask: Task<Void, Never>?
     private var filePreviewLifetimeToken: AnyObject?
     private var retiredFilePreviewLifetimeTokens: [UUID: AnyObject] = [:]
+    private var attachmentThumbnailCache: [String: Data] = [:]
+    private var attachmentsWithoutThumbnails: Set<String> = []
     private var iCloudMountChangeObserver: NSObjectProtocol?
     let estimatedBytesPerToken = 4
     let toolResultClearThreshold = 0.80
@@ -652,6 +655,109 @@ final class CPSLChatModel: ObservableObject {
 
     func closeFilePreview() {
         filePreview = nil
+    }
+
+    func isFileReadOnly(_ path: String) -> Bool {
+        iCloudMount(containing: path)?.accessMode == .readOnly
+    }
+
+    func isICloudMountRoot(_ path: String) -> Bool {
+        iCloudMounts.contains { $0.virtualPath == normalizedPath(path) }
+    }
+
+    func canMoveFileEntries(
+        _ entries: [CPSLFileEntry],
+        toDirectory destinationPath: String
+    ) -> Bool {
+        let destination = normalizedPath(destinationPath)
+        guard !entries.isEmpty,
+              destination != CPSLVirtualPath.root,
+              destination != CPSLVirtualPath.iCloudRoot,
+              isBrowserPathAllowed(destination),
+              !isFileReadOnly(destination)
+        else {
+            return false
+        }
+
+        for entry in entries {
+            let source = normalizedPath(entry.path)
+            if isICloudMountRoot(source) ||
+                isFileReadOnly(source) ||
+                parentPath(of: source) == destination ||
+                source == destination ||
+                (entry.isDirectory && destination.hasPrefix("\(source)/")) {
+                return false
+            }
+        }
+        return true
+    }
+
+    func deleteFileEntries(_ entries: [CPSLFileEntry]) {
+        guard !entries.isEmpty, !isBusy else {
+            return
+        }
+        fileBrowserError = nil
+        isManagingFiles = true
+        Task { [weak self, service] in
+            guard let self else {
+                return
+            }
+            defer {
+                self.isManagingFiles = false
+            }
+            let operationError: String?
+            do {
+                try await service.deleteFileEntries(entries)
+                operationError = nil
+            } catch {
+                operationError = "Files: \(error.localizedDescription)"
+            }
+            self.loadBrowserPath(self.browserPath)
+            self.fileBrowserError = operationError
+        }
+    }
+
+    func moveFileEntries(
+        _ entries: [CPSLFileEntry],
+        toDirectory destinationPath: String
+    ) {
+        guard canMoveFileEntries(entries, toDirectory: destinationPath), !isBusy else {
+            return
+        }
+        fileBrowserError = nil
+        isManagingFiles = true
+        Task { [weak self, service] in
+            guard let self else {
+                return
+            }
+            defer {
+                self.isManagingFiles = false
+            }
+            let operationError: String?
+            do {
+                try await service.moveFileEntries(entries, toDirectory: destinationPath)
+                operationError = nil
+            } catch {
+                operationError = "Files: \(error.localizedDescription)"
+            }
+            self.loadBrowserPath(self.browserPath)
+            self.fileBrowserError = operationError
+        }
+    }
+
+    func attachmentThumbnail(for attachment: CPSLAttachment) async -> Data? {
+        if let cached = attachmentThumbnailCache[attachment.id] {
+            return cached
+        }
+        guard !attachmentsWithoutThumbnails.contains(attachment.id) else {
+            return nil
+        }
+        guard let data = await service.attachmentThumbnail(for: attachment) else {
+            attachmentsWithoutThumbnails.insert(attachment.id)
+            return nil
+        }
+        attachmentThumbnailCache[attachment.id] = data
+        return data
     }
 
     func markFileActivity() {

--- a/app/apple/herm/Services/Agent/CPSLConversationStore.swift
+++ b/app/apple/herm/Services/Agent/CPSLConversationStore.swift
@@ -640,10 +640,7 @@ actor CPSLConversationStore {
             .split(whereSeparator: \.isNewline)
             .joined(separator: " ")
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        guard singleLine.count > 44 else {
-            return singleLine.isEmpty ? "Untitled" : singleLine
-        }
-        return "\(singleLine.prefix(41))..."
+        return singleLine.isEmpty ? "Untitled" : singleLine
     }
 }
 

--- a/app/apple/herm/Services/CPSLCalendarService.swift
+++ b/app/apple/herm/Services/CPSLCalendarService.swift
@@ -1,18 +1,38 @@
 import Combine
 import Foundation
+#if canImport(CoreGraphics)
+import CoreGraphics
+#endif
 #if canImport(EventKit)
 import EventKit
 #endif
+
+struct CPSLCalendarColor: Equatable, Sendable {
+    let red: Double
+    let green: Double
+    let blue: Double
+    let alpha: Double
+}
 
 struct CPSLCalendarEvent: Identifiable, Equatable, Sendable {
     let id: String
     let title: String
     let calendarTitle: String
+    let calendarColor: CPSLCalendarColor?
     let startDate: Date
     let endDate: Date
     let isAllDay: Bool
     let location: String?
+    let notes: String?
+    let url: URL?
     let attachments: [CPSLCalendarAttachment]
+}
+
+struct CPSLCalendarDay: Identifiable, Equatable, Sendable {
+    var id: Date { date }
+
+    let date: Date
+    let events: [CPSLCalendarEvent]
 }
 
 struct CPSLCalendarAttachment: Identifiable, Equatable, Sendable {
@@ -28,6 +48,7 @@ final class CPSLCalendarService: ObservableObject {
     @Published private(set) var isRequestingAccess = false
     @Published private(set) var isLoadingEvents = false
     @Published private(set) var upcomingEvents: [CPSLCalendarEvent] = []
+    @Published private(set) var upcomingEventDays: [CPSLCalendarDay] = []
     @Published private(set) var eventError: String?
 
 #if canImport(EventKit)
@@ -79,6 +100,7 @@ final class CPSLCalendarService: ObservableObject {
         let access = await requestAccess()
         guard access == .granted else {
             upcomingEvents = []
+            upcomingEventDays = []
             eventError = "Calendar access is denied. Enable Calendar access for Herm in iOS Settings or macOS System Settings."
             return access
         }
@@ -98,15 +120,17 @@ final class CPSLCalendarService: ObservableObject {
             end: endDate,
             calendars: nil
         )
-        upcomingEvents = eventStore.events(matching: predicate)
+        let events = eventStore.events(matching: predicate)
             .sorted { lhs, rhs in
                 lhs.startDate < rhs.startDate
             }
             .prefix(12)
             .map(Self.event(from:))
-        upcomingEvents = Self.eventsWithUniqueIDs(upcomingEvents)
+        upcomingEvents = Self.eventsWithUniqueIDs(events)
+        upcomingEventDays = Self.groupedByDay(upcomingEvents)
 #else
         upcomingEvents = []
+        upcomingEventDays = []
         eventError = "Calendar is unavailable on this platform."
 #endif
         return access
@@ -128,10 +152,13 @@ final class CPSLCalendarService: ObservableObject {
             id: id,
             title: event.title?.cpslNilIfEmpty ?? "Untitled event",
             calendarTitle: event.calendar?.title ?? "Calendar",
+            calendarColor: Self.calendarColor(from: event.calendar),
             startDate: event.startDate,
             endDate: event.endDate,
             isAllDay: event.isAllDay,
             location: event.location?.cpslNilIfEmpty,
+            notes: Self.visibleNotes(from: event.notes),
+            url: event.url,
             attachments: Self.attachments(from: event.notes)
         )
     }
@@ -148,13 +175,71 @@ final class CPSLCalendarService: ObservableObject {
                 id: "\(event.id)|duplicate-\(count)",
                 title: event.title,
                 calendarTitle: event.calendarTitle,
+                calendarColor: event.calendarColor,
                 startDate: event.startDate,
                 endDate: event.endDate,
                 isAllDay: event.isAllDay,
                 location: event.location,
+                notes: event.notes,
+                url: event.url,
                 attachments: event.attachments
             )
         }
+    }
+
+    private static func groupedByDay(_ events: [CPSLCalendarEvent]) -> [CPSLCalendarDay] {
+        let calendar = Foundation.Calendar.autoupdatingCurrent
+        var groups: [CPSLCalendarDay] = []
+        for event in events {
+            let date = calendar.startOfDay(for: event.startDate)
+            if groups.last?.date == date {
+                let current = groups.removeLast()
+                groups.append(CPSLCalendarDay(date: date, events: current.events + [event]))
+            } else {
+                groups.append(CPSLCalendarDay(date: date, events: [event]))
+            }
+        }
+        return groups
+    }
+
+    private static func calendarColor(from calendar: EKCalendar?) -> CPSLCalendarColor? {
+#if canImport(CoreGraphics)
+        guard let sourceColor = calendar?.cgColor,
+              let colorSpace = CGColorSpace(name: CGColorSpace.sRGB),
+              let color = sourceColor.converted(
+                  to: colorSpace,
+                  intent: .defaultIntent,
+                  options: nil
+              ),
+              let components = color.components,
+              components.count >= 3
+        else {
+            return nil
+        }
+        return CPSLCalendarColor(
+            red: Double(components[0]),
+            green: Double(components[1]),
+            blue: Double(components[2]),
+            alpha: Double(color.alpha)
+        )
+#else
+        _ = calendar
+        return nil
+#endif
+    }
+
+    private static func visibleNotes(from notes: String?) -> String? {
+        guard var notes else {
+            return nil
+        }
+        if let startRange = notes.range(of: "[Herm attachments]"),
+           let endRange = notes.range(
+               of: "[/Herm attachments]",
+               range: startRange.upperBound..<notes.endIndex
+           ) {
+            notes.removeSubrange(startRange.lowerBound..<endRange.upperBound)
+        }
+        return notes.trimmingCharacters(in: .whitespacesAndNewlines).cpslNilIfEmpty
     }
 
     private static func attachments(from notes: String?) -> [CPSLCalendarAttachment] {

--- a/app/apple/herm/Services/CPSLDebugService.swift
+++ b/app/apple/herm/Services/CPSLDebugService.swift
@@ -1583,11 +1583,7 @@ actor CPSLDebugService {
             return "Could not encode session config JSON"
         }
 
-        // A domain policy cannot constrain arbitrary JavaScript inside a WKWebView.
-        // Omit the browser capability entirely while personal mounts are active.
-        let callbackBox = (iCloudMountManager?.mounts.isEmpty ?? true)
-            ? CPSLWebBrowserCallbackBox(service: webBrowser)
-            : nil
+        let callbackBox = CPSLWebBrowserCallbackBox(service: webBrowser)
         let fileActivityCallbackBox = CPSLFileActivityCallbackBox(notifier: fileActivityNotifier)
         let calendarActivityCallbackBox = CPSLCalendarActivityCallbackBox(notifier: calendarActivityNotifier)
         let locationCallbackBox = CPSLLocationCallbackBox(service: location)
@@ -1848,7 +1844,7 @@ actor CPSLDebugService {
             ])
         }
 
-        let allowedDomains: [String] = iCloudMounts.isEmpty ? ["*"] : []
+        let allowedDomains = ["*"]
         let config: [String: Any] = [
             "mounts": mounts,
             "initial_cwd": CPSLVirtualPath.initialDirectory,

--- a/app/apple/herm/Services/CPSLDebugService.swift
+++ b/app/apple/herm/Services/CPSLDebugService.swift
@@ -48,6 +48,35 @@ private nonisolated final class CPSLLocationCallbackBox: @unchecked Sendable {
     }
 }
 
+private nonisolated enum CPSLFileMutationError: LocalizedError {
+    case destinationContainsSource
+    case destinationExists
+    case destinationUnavailable
+    case duplicateName
+    case overlappingSelection
+    case protectedLocation
+    case readOnly
+
+    var errorDescription: String? {
+        switch self {
+        case .destinationContainsSource:
+            return "A folder cannot be moved inside itself."
+        case .destinationExists:
+            return "An item with the same name already exists in that folder."
+        case .destinationUnavailable:
+            return "Choose a folder inside Home, Attachments, Temporary, or a writable iCloud folder."
+        case .duplicateName:
+            return "The selected items include duplicate names."
+        case .overlappingSelection:
+            return "Select either a folder or items inside it, not both."
+        case .protectedLocation:
+            return "This location cannot be moved or deleted."
+        case .readOnly:
+            return "This iCloud folder is read-only in Herm."
+        }
+    }
+}
+
 private nonisolated final class CPSLVisionCallbackBox: @unchecked Sendable {
     let client: CPSLVisionClient?
     let configurationError: String?
@@ -757,6 +786,123 @@ actor CPSLDebugService {
         }
     }
 
+    func deleteFileEntries(_ entries: [CPSLFileEntry]) throws {
+        guard !entries.isEmpty else {
+            return
+        }
+
+        let sandboxURLs = try ensureSandboxURLs()
+        self.sandboxURLs = sandboxURLs
+        let paths = entries.map { Self.normalizedVirtualPath($0.path) }
+        try paths.forEach(validateFileMutationSource)
+        try validateNonoverlappingSelection(entries)
+        let mountUseLease = try iCloudWriteUseLease(forVirtualPaths: paths)
+        defer { mountUseLease?.release() }
+
+        let urls = try paths.map { path in
+            let url = try hostURL(forVirtualPath: path, sandboxURLs: sandboxURLs)
+            guard isBrowserHostURLAllowed(url, sandboxURLs: sandboxURLs) else {
+                throw CPSLFileAccessError.outsideFilesystem
+            }
+            return (path, url)
+        }
+
+        for (path, url) in urls {
+            try FileManager.default.removeItem(at: url)
+            fileActivityNotifier.notify(CPSLFileActivity(path: path, operation: "delete"))
+        }
+    }
+
+    func moveFileEntries(
+        _ entries: [CPSLFileEntry],
+        toDirectory destinationPath: String
+    ) throws {
+        guard !entries.isEmpty else {
+            return
+        }
+
+        let sandboxURLs = try ensureSandboxURLs()
+        self.sandboxURLs = sandboxURLs
+        let normalizedDestination = Self.normalizedVirtualPath(destinationPath)
+        try validateFileMutationDestination(normalizedDestination)
+
+        let sourcePaths = entries.map { Self.normalizedVirtualPath($0.path) }
+        try sourcePaths.forEach(validateFileMutationSource)
+        try validateNonoverlappingSelection(entries)
+        let sourceNames = sourcePaths.map { URL(fileURLWithPath: $0).lastPathComponent }
+        guard Set(sourceNames.map { $0.lowercased() }).count == sourceNames.count else {
+            throw CPSLFileMutationError.duplicateName
+        }
+
+        for entry in entries where entry.isDirectory {
+            let sourcePath = Self.normalizedVirtualPath(entry.path)
+            if normalizedDestination == sourcePath ||
+                normalizedDestination.hasPrefix("\(sourcePath)/") {
+                throw CPSLFileMutationError.destinationContainsSource
+            }
+        }
+
+        let mountUseLease = try iCloudWriteUseLease(
+            forVirtualPaths: sourcePaths + [normalizedDestination]
+        )
+        defer { mountUseLease?.release() }
+
+        let destinationURL = try hostURL(
+            forVirtualPath: normalizedDestination,
+            sandboxURLs: sandboxURLs
+        )
+        guard isBrowserHostURLAllowed(destinationURL, sandboxURLs: sandboxURLs) else {
+            throw CPSLFileAccessError.outsideFilesystem
+        }
+        let destinationValues = try destinationURL.resourceValues(forKeys: [.isDirectoryKey])
+        guard destinationValues.isDirectory == true else {
+            throw CPSLFileMutationError.destinationUnavailable
+        }
+
+        let fileManager = FileManager.default
+        let moves = try zip(sourcePaths, sourceNames).map { sourcePath, sourceName in
+            let sourceURL = try hostURL(
+                forVirtualPath: sourcePath,
+                sandboxURLs: sandboxURLs
+            )
+            guard isBrowserHostURLAllowed(sourceURL, sandboxURLs: sandboxURLs) else {
+                throw CPSLFileAccessError.outsideFilesystem
+            }
+            let targetURL = destinationURL.appendingPathComponent(sourceName)
+            guard !fileManager.fileExists(atPath: targetURL.path) else {
+                throw CPSLFileMutationError.destinationExists
+            }
+            return (sourcePath, sourceURL, targetURL)
+        }
+
+        for (sourcePath, sourceURL, targetURL) in moves {
+            try fileManager.moveItem(at: sourceURL, to: targetURL)
+            fileActivityNotifier.notify(
+                CPSLFileActivity(path: sourcePath, operation: "move")
+            )
+        }
+    }
+
+    func attachmentThumbnail(for attachment: CPSLAttachment) async -> Data? {
+        do {
+            let sandboxURLs = try ensureSandboxURLs()
+            self.sandboxURLs = sandboxURLs
+            let normalizedPath = Self.normalizedVirtualPath(attachment.path)
+            let mountUseLease = try iCloudUseLease(forVirtualPath: normalizedPath)
+            defer { mountUseLease?.release() }
+            if mountUseLease != nil {
+                try await ensureICloudMountManager().materializeFile(at: normalizedPath)
+            }
+            let url = try hostURL(forVirtualPath: normalizedPath, sandboxURLs: sandboxURLs)
+            guard isBrowserHostURLAllowed(url, sandboxURLs: sandboxURLs) else {
+                return nil
+            }
+            return Self.thumbnailData(for: url, maximumPixelSize: 96)
+        } catch {
+            return nil
+        }
+    }
+
     func previewFile(_ entry: CPSLFileEntry) async -> CPSLFilePreviewLoadResult {
         guard !entry.isDirectory else {
             return CPSLFilePreviewLoadResult(preview: nil, error: "Directories cannot be previewed.")
@@ -913,6 +1059,47 @@ actor CPSLDebugService {
             }
         }
         return nil
+    }
+
+    private nonisolated static func thumbnailData(
+        for url: URL,
+        maximumPixelSize: Int
+    ) -> Data? {
+#if canImport(ImageIO) && canImport(UniformTypeIdentifiers)
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
+            return nil
+        }
+        let options: [CFString: Any] = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maximumPixelSize,
+        ]
+        guard let thumbnail = CGImageSourceCreateThumbnailAtIndex(
+            source,
+            0,
+            options as CFDictionary
+        ) else {
+            return nil
+        }
+        let data = NSMutableData()
+        guard let destination = CGImageDestinationCreateWithData(
+            data,
+            UTType.png.identifier as CFString,
+            1,
+            nil
+        ) else {
+            return nil
+        }
+        CGImageDestinationAddImage(destination, thumbnail, nil)
+        guard CGImageDestinationFinalize(destination) else {
+            return nil
+        }
+        return data as Data
+#else
+        _ = url
+        _ = maximumPixelSize
+        return nil
+#endif
     }
 
     private nonisolated static func metadata(
@@ -1439,6 +1626,89 @@ actor CPSLDebugService {
             throw CPSLICloudMountError.sessionBusy
         }
         return lease
+    }
+
+    private func iCloudWriteUseLease(
+        forVirtualPaths virtualPaths: [String]
+    ) throws -> CPSLICloudMountUseLease? {
+        let iCloudPaths = virtualPaths
+            .map { Self.normalizedVirtualPath($0) }
+            .filter { $0.hasPrefix("\(CPSLVirtualPath.iCloudRoot)/") }
+        guard !iCloudPaths.isEmpty else {
+            return nil
+        }
+
+        let manager = try ensureICloudMountManager()
+        for path in iCloudPaths {
+            guard let mount = CPSLICloudMountResolver.mount(
+                containing: path,
+                in: manager.mounts
+            ) else {
+                throw CPSLICloudMountError.mountNotFound
+            }
+            guard mount.accessMode == .readWrite else {
+                throw CPSLFileMutationError.readOnly
+            }
+        }
+        guard let lease = try manager.beginSessionUse() else {
+            throw CPSLICloudMountError.sessionBusy
+        }
+        return lease
+    }
+
+    private func validateFileMutationSource(_ virtualPath: String) throws {
+        let normalized = Self.normalizedVirtualPath(virtualPath)
+        guard Self.isFileMutationPathAllowed(normalized) else {
+            throw CPSLFileMutationError.destinationUnavailable
+        }
+        let isMountRoot: Bool
+        if normalized.hasPrefix("\(CPSLVirtualPath.iCloudRoot)/") {
+            isMountRoot = try ensureICloudMountManager().mounts.contains {
+                $0.virtualPath == normalized
+            }
+        } else {
+            isMountRoot = false
+        }
+        guard normalized != CPSLVirtualPath.home,
+              normalized != CPSLVirtualPath.attachments,
+              normalized != CPSLVirtualPath.temporary,
+              normalized != CPSLVirtualPath.iCloudRoot,
+              !isMountRoot
+        else {
+            throw CPSLFileMutationError.protectedLocation
+        }
+    }
+
+    private func validateFileMutationDestination(_ virtualPath: String) throws {
+        let normalized = Self.normalizedVirtualPath(virtualPath)
+        guard Self.isFileMutationPathAllowed(normalized),
+              normalized != CPSLVirtualPath.root,
+              normalized != CPSLVirtualPath.iCloudRoot
+        else {
+            throw CPSLFileMutationError.destinationUnavailable
+        }
+    }
+
+    private func validateNonoverlappingSelection(_ entries: [CPSLFileEntry]) throws {
+        let directoryPaths = entries
+            .filter(\.isDirectory)
+            .map { Self.normalizedVirtualPath($0.path) }
+        let allPaths = entries.map { Self.normalizedVirtualPath($0.path) }
+        for directoryPath in directoryPaths where allPaths.contains(where: {
+            $0 != directoryPath && $0.hasPrefix("\(directoryPath)/")
+        }) {
+            throw CPSLFileMutationError.overlappingSelection
+        }
+    }
+
+    private nonisolated static func isFileMutationPathAllowed(_ virtualPath: String) -> Bool {
+        virtualPath == CPSLVirtualPath.home ||
+            virtualPath.hasPrefix("\(CPSLVirtualPath.home)/") ||
+            virtualPath == CPSLVirtualPath.attachments ||
+            virtualPath.hasPrefix("\(CPSLVirtualPath.attachments)/") ||
+            virtualPath == CPSLVirtualPath.temporary ||
+            virtualPath.hasPrefix("\(CPSLVirtualPath.temporary)/") ||
+            virtualPath.hasPrefix("\(CPSLVirtualPath.iCloudRoot)/")
     }
 
     private func ensureSandboxURLs() throws -> CPSLSandboxURLs {

--- a/app/apple/herm/Skills/webbrowser/SKILL.md
+++ b/app/apple/herm/Skills/webbrowser/SKILL.md
@@ -17,6 +17,14 @@ WebKit state and may already be signed in. When the user explicitly asks for a
 specific action, use the normal website flow on their behalf before reporting
 that it cannot be completed.
 
+## Availability
+
+`help()` is the authoritative module list. When it lists `webbrowser`, use the
+global directly; do not call `require` or search the filesystem for browser
+code. If `help()` does not list `webbrowser` even though this skill is present,
+the host did not register the browser bridge. Report that runtime mismatch
+after one check instead of trying alternate imports.
+
 ## Background By Default
 
 - Use the browser in the background by default. Do not call `webbrowser.show()` just because you opened, searched, clicked, typed, or inspected a page.

--- a/app/apple/herm/Views/Calendar/CPSLCalendarOverlay.swift
+++ b/app/apple/herm/Views/Calendar/CPSLCalendarOverlay.swift
@@ -1,5 +1,11 @@
 import SwiftUI
 
+private enum CPSLCalendarMotion {
+    static let animation = Animation.easeOut(duration: 0.2)
+    static let listTransition = AnyTransition.move(edge: .leading)
+    static let detailTransition = AnyTransition.move(edge: .trailing)
+}
+
 struct CPSLCalendarOverlay: View {
     private let model: CPSLChatModel
     private let calendar: CPSLCalendarService
@@ -33,59 +39,93 @@ struct CPSLCalendarOverlay: View {
 private struct CPSLCalendarPanel: View {
     let model: CPSLChatModel
     let calendar: CPSLCalendarService
+    @State private var selectedEvent: CPSLCalendarEvent?
 
     var body: some View {
         CPSLFileOverlayPanel {
-            CPSLCalendarHeader(model: model, calendar: calendar)
+            CPSLCalendarHeader(
+                model: model,
+                calendar: calendar,
+                selectedEvent: selectedEvent,
+                onBack: { selectedEvent = nil }
+            )
         } content: {
-            CPSLCalendarContent(model: model, calendar: calendar)
+            CPSLCalendarRouteContent(
+                calendar: calendar,
+                selectedEvent: selectedEvent,
+                onSelect: { selectedEvent = $0 },
+                onOpenAttachment: model.openFilePathFromTimeline
+            )
         }
+    }
+}
+
+private struct CPSLCalendarRouteContent: View {
+    let calendar: CPSLCalendarService
+    let selectedEvent: CPSLCalendarEvent?
+    let onSelect: (CPSLCalendarEvent) -> Void
+    let onOpenAttachment: (String) -> Void
+
+    var body: some View {
+        ZStack {
+            if let selectedEvent {
+                CPSLCalendarEventDetailView(
+                    event: selectedEvent,
+                    onOpenAttachment: onOpenAttachment
+                )
+                .transition(CPSLCalendarMotion.detailTransition)
+                .zIndex(1)
+            } else {
+                CPSLCalendarEventList(calendar: calendar, onSelect: onSelect)
+                    .transition(CPSLCalendarMotion.listTransition)
+                    .zIndex(0)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(CPSLTheme.command)
+        .clipped()
+        .animation(CPSLCalendarMotion.animation, value: selectedEvent?.id)
     }
 }
 
 private struct CPSLCalendarHeader: View {
     let model: CPSLChatModel
     @ObservedObject var calendar: CPSLCalendarService
-
-    private var subtitle: LocalizedStringKey {
-        switch calendar.access {
-        case .granted:
-            return calendar.upcomingEvents.isEmpty ? "No upcoming events loaded" : "Upcoming events"
-        case .denied:
-            return "Access denied"
-        case .undefined:
-            return "Access not requested"
-        }
-    }
+    let selectedEvent: CPSLCalendarEvent?
+    let onBack: () -> Void
 
     var body: some View {
         HStack(spacing: CPSLTheme.medium) {
-            Image(systemName: "calendar")
-                .symbolRenderingMode(.hierarchical)
-                .font(CPSLTheme.iconMediumFont)
-                .foregroundStyle(CPSLTheme.IconPalette.calendar)
-                .frame(width: CPSLTheme.controlSize, height: CPSLTheme.controlSize)
-
-            VStack(alignment: .leading, spacing: CPSLTheme.small / 2) {
-                Text("Calendar")
-                    .font(CPSLTheme.supportingMediumFont)
-                    .foregroundStyle(CPSLTheme.text)
-                    .lineLimit(1)
-                Text(subtitle)
-                    .font(CPSLTheme.captionFont)
-                    .foregroundStyle(CPSLTheme.secondaryText)
-                    .lineLimit(1)
-            }
-
-            Spacer(minLength: CPSLTheme.medium)
-
-            CPSLFileOverlayIconButton(systemName: "arrow.clockwise", accessibilityLabel: "Refresh calendar") {
-                Task {
-                    await calendar.loadUpcomingEvents()
+            if selectedEvent != nil {
+                CPSLFileOverlayIconButton(systemName: "chevron.left", accessibilityLabel: "Back") {
+                    onBack()
                 }
+            } else {
+                Image(systemName: "calendar")
+                    .symbolRenderingMode(.hierarchical)
+                    .font(CPSLTheme.iconMediumFont)
+                    .foregroundStyle(CPSLTheme.IconPalette.calendar)
+                    .frame(width: CPSLTheme.controlSize, height: CPSLTheme.controlSize)
             }
-            .disabled(calendar.isLoadingEvents)
-            .opacity(calendar.isLoadingEvents ? 0.45 : 1)
+
+            CPSLCalendarHeaderTitle(
+                title: selectedEvent?.title,
+                startDate: selectedEvent?.startDate,
+                fallbackSubtitle: listSubtitle
+            )
+
+            if selectedEvent == nil {
+                CPSLFileOverlayIconButton(
+                    systemName: "arrow.clockwise",
+                    accessibilityLabel: "Refresh calendar"
+                ) {
+                    Task {
+                        await calendar.loadUpcomingEvents()
+                    }
+                }
+                .disabled(calendar.isLoadingEvents)
+                .opacity(calendar.isLoadingEvents ? 0.45 : 1)
+            }
 
             CPSLFileOverlayIconButton(systemName: "xmark", accessibilityLabel: "Close calendar") {
                 model.closeCalendar()
@@ -95,26 +135,73 @@ private struct CPSLCalendarHeader: View {
         .padding(.vertical, CPSLTheme.small)
         .frame(minHeight: CPSLTheme.controlSize + CPSLTheme.medium)
     }
+
+    private var listSubtitle: LocalizedStringKey {
+        switch calendar.access {
+        case .granted:
+            return calendar.upcomingEvents.isEmpty ? "No upcoming events loaded" : "Upcoming events"
+        case .denied:
+            return "Access denied"
+        case .undefined:
+            return "Access not requested"
+        }
+    }
 }
 
-private struct CPSLCalendarContent: View {
-    let model: CPSLChatModel
+private struct CPSLCalendarHeaderTitle: View {
+    let title: String?
+    let startDate: Date?
+    let fallbackSubtitle: LocalizedStringKey
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: CPSLTheme.small / 2) {
+            if let title {
+                Text(title)
+                    .font(CPSLTheme.supportingMediumFont)
+                    .foregroundStyle(CPSLTheme.text)
+                    .lineLimit(1)
+            } else {
+                Text("Calendar")
+                    .font(CPSLTheme.supportingMediumFont)
+                    .foregroundStyle(CPSLTheme.text)
+                    .lineLimit(1)
+            }
+
+            if let startDate {
+                Text(startDate, format: .dateTime.weekday(.wide).month(.wide).day())
+                    .font(CPSLTheme.captionFont)
+                    .foregroundStyle(CPSLTheme.secondaryText)
+                    .lineLimit(1)
+            } else {
+                Text(fallbackSubtitle)
+                    .font(CPSLTheme.captionFont)
+                    .foregroundStyle(CPSLTheme.secondaryText)
+                    .lineLimit(1)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct CPSLCalendarEventList: View {
     @ObservedObject var calendar: CPSLCalendarService
+    let onSelect: (CPSLCalendarEvent) -> Void
 
     var body: some View {
         ScrollView {
-            LazyVStack(spacing: CPSLTheme.small) {
+            LazyVStack(alignment: .leading, spacing: CPSLTheme.large) {
                 if calendar.isLoadingEvents {
                     CPSLCalendarStatusRow(systemName: "arrow.clockwise", title: "Loading events")
                 } else if let eventError = calendar.eventError {
                     CPSLCalendarStatusRow(systemName: "exclamationmark.triangle.fill", title: eventError)
-                } else if calendar.upcomingEvents.isEmpty {
+                } else if calendar.upcomingEventDays.isEmpty {
                     CPSLCalendarStatusRow(systemName: "calendar.badge.checkmark", title: "No upcoming events")
                 } else {
-                    ForEach(calendar.upcomingEvents) { event in
-                        CPSLCalendarEventRow(
-                            event: event,
-                            onOpenAttachment: model.openFilePathFromTimeline
+                    ForEach(calendar.upcomingEventDays) { day in
+                        CPSLCalendarDaySection(
+                            date: day.date,
+                            events: day.events,
+                            onSelect: onSelect
                         )
                     }
                 }
@@ -122,6 +209,33 @@ private struct CPSLCalendarContent: View {
             .padding(CPSLTheme.medium)
         }
         .scrollBounceBehavior(.basedOnSize)
+    }
+}
+
+private struct CPSLCalendarDaySection: View {
+    let date: Date
+    let events: [CPSLCalendarEvent]
+    let onSelect: (CPSLCalendarEvent) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: CPSLTheme.small) {
+            Text(date, format: .dateTime.weekday(.wide).month(.wide).day())
+                .font(CPSLTheme.captionMediumFont)
+                .foregroundStyle(CPSLTheme.secondaryText)
+
+            VStack(spacing: CPSLTheme.small) {
+                ForEach(events) { event in
+                    CPSLCalendarEventRow(
+                        title: event.title,
+                        calendarColor: event.calendarColor,
+                        startDate: event.startDate,
+                        isAllDay: event.isAllDay,
+                        location: event.location,
+                        action: { onSelect(event) }
+                    )
+                }
+            }
+        }
     }
 }
 
@@ -152,45 +266,225 @@ private struct CPSLCalendarStatusRow: View {
 }
 
 private struct CPSLCalendarEventRow: View {
+    let title: String
+    let calendarColor: CPSLCalendarColor?
+    let startDate: Date
+    let isAllDay: Bool
+    let location: String?
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            ZStack(alignment: .leading) {
+                HStack(alignment: .top, spacing: CPSLTheme.medium) {
+                    CPSLCalendarEventTime(startDate: startDate, isAllDay: isAllDay)
+
+                    VStack(alignment: .leading, spacing: CPSLTheme.small / 2) {
+                        Text(title)
+                            .font(CPSLTheme.supportingMediumFont)
+                            .foregroundStyle(CPSLTheme.text)
+                            .lineLimit(2)
+
+                        if let location {
+                            Label(location, systemImage: "location")
+                                .font(CPSLTheme.captionFont)
+                                .foregroundStyle(CPSLTheme.secondaryText)
+                                .lineLimit(1)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                    Image(systemName: "chevron.right")
+                        .font(CPSLTheme.iconSmallFont)
+                        .foregroundStyle(CPSLTheme.mutedText)
+                        .frame(height: CPSLTheme.controlSize)
+                }
+                .padding(CPSLTheme.medium)
+
+                CPSLCalendarColorBorder(calendarColor: calendarColor)
+            }
+            .contentShape(Rectangle())
+            .cpslSurfaceBackground(
+                in: RoundedRectangle(cornerRadius: CPSLTheme.rowRadius, style: .continuous),
+                tint: CPSLTheme.background.opacity(0.30),
+                strokeOpacity: 0.045
+            )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct CPSLCalendarColorBorder: View {
+    let calendarColor: CPSLCalendarColor?
+
+    var body: some View {
+        Rectangle()
+            .fill(displayColor)
+            .frame(width: 4)
+            .accessibilityHidden(true)
+    }
+
+    private var displayColor: Color {
+        guard let calendarColor else {
+            return .clear
+        }
+        return Color(
+            .sRGB,
+            red: calendarColor.red,
+            green: calendarColor.green,
+            blue: calendarColor.blue,
+            opacity: calendarColor.alpha
+        )
+    }
+}
+
+private struct CPSLCalendarEventTime: View {
+    let startDate: Date
+    let isAllDay: Bool
+
+    var body: some View {
+        Group {
+            if isAllDay {
+                Text("All day")
+            } else {
+                Text(startDate, format: .dateTime.hour().minute())
+            }
+        }
+        .font(CPSLTheme.captionMediumFont)
+        .foregroundStyle(CPSLTheme.text)
+        .frame(width: 64, alignment: .leading)
+        .padding(.vertical, CPSLTheme.small)
+    }
+}
+
+private struct CPSLCalendarEventDetailView: View {
     let event: CPSLCalendarEvent
     let onOpenAttachment: (String) -> Void
 
     var body: some View {
-        HStack(alignment: .top, spacing: CPSLTheme.medium) {
-            CPSLCalendarEventTimeBadge(
-                startDate: event.startDate,
-                isAllDay: event.isAllDay
-            )
-
-            VStack(alignment: .leading, spacing: CPSLTheme.small / 2) {
-                Text(event.title)
-                    .font(CPSLTheme.supportingMediumFont)
-                    .foregroundStyle(CPSLTheme.text)
-                    .lineLimit(2)
-
-                Text(event.calendarTitle)
-                    .font(CPSLTheme.captionFont)
-                    .foregroundStyle(CPSLTheme.secondaryText)
-                    .lineLimit(1)
-
-                CPSLCalendarEventDetail(event: event)
-
+        ScrollView {
+            VStack(alignment: .leading, spacing: CPSLTheme.large) {
+                CPSLCalendarEventDetailHeader(
+                    title: event.title,
+                    calendarTitle: event.calendarTitle
+                )
+                CPSLCalendarEventSchedule(
+                    startDate: event.startDate,
+                    endDate: event.endDate,
+                    isAllDay: event.isAllDay
+                )
+                if let location = event.location {
+                    CPSLCalendarEventDetailField(
+                        title: "Location",
+                        value: location,
+                        systemName: "location.fill"
+                    )
+                }
+                if let notes = event.notes {
+                    CPSLCalendarEventNotes(notes: notes)
+                }
+                if let url = event.url {
+                    CPSLCalendarEventLink(url: url)
+                }
                 if !event.attachments.isEmpty {
                     CPSLCalendarEventAttachments(
                         attachments: event.attachments,
                         onOpen: onOpenAttachment
                     )
-                    .padding(.top, CPSLTheme.small / 2)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(CPSLTheme.large)
         }
-        .padding(CPSLTheme.medium)
-        .cpslSurfaceBackground(
-            in: RoundedRectangle(cornerRadius: CPSLTheme.rowRadius, style: .continuous),
-            tint: CPSLTheme.background.opacity(0.30),
-            strokeOpacity: 0.045
-        )
+        .scrollBounceBehavior(.basedOnSize)
+    }
+}
+
+private struct CPSLCalendarEventDetailHeader: View {
+    let title: String
+    let calendarTitle: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: CPSLTheme.small) {
+            Text(title)
+                .font(CPSLTheme.headerFont)
+                .foregroundStyle(CPSLTheme.text)
+            Label(calendarTitle, systemImage: "calendar")
+                .font(CPSLTheme.captionFont)
+                .foregroundStyle(CPSLTheme.secondaryText)
+                .lineLimit(nil)
+                .textSelection(.enabled)
+        }
+    }
+}
+
+private struct CPSLCalendarEventSchedule: View {
+    let startDate: Date
+    let endDate: Date
+    let isAllDay: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: CPSLTheme.small) {
+            Label("When", systemImage: "clock.fill")
+                .font(CPSLTheme.captionMediumFont)
+                .foregroundStyle(CPSLTheme.secondaryText)
+
+            if isAllDay {
+                Text(startDate, format: .dateTime.weekday(.wide).month(.wide).day().year())
+                Text("All day")
+            } else {
+                Text(startDate, format: .dateTime.weekday(.wide).month(.wide).day().year().hour().minute())
+                Text("Ends \(endDate, format: .dateTime.weekday(.wide).month(.wide).day().year().hour().minute())")
+            }
+        }
+        .font(CPSLTheme.bodyFont)
+        .foregroundStyle(CPSLTheme.text)
+    }
+}
+
+private struct CPSLCalendarEventDetailField: View {
+    let title: LocalizedStringKey
+    let value: String
+    let systemName: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: CPSLTheme.small) {
+            Label(title, systemImage: systemName)
+                .font(CPSLTheme.captionMediumFont)
+                .foregroundStyle(CPSLTheme.secondaryText)
+            Text(value)
+                .font(CPSLTheme.bodyFont)
+                .foregroundStyle(CPSLTheme.text)
+                .textSelection(.enabled)
+        }
+    }
+}
+
+private struct CPSLCalendarEventNotes: View {
+    let notes: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: CPSLTheme.small) {
+            Label("Notes", systemImage: "note.text")
+                .font(CPSLTheme.captionMediumFont)
+                .foregroundStyle(CPSLTheme.secondaryText)
+            Text(notes)
+                .font(CPSLTheme.bodyFont)
+                .foregroundStyle(CPSLTheme.text)
+                .textSelection(.enabled)
+        }
+    }
+}
+
+private struct CPSLCalendarEventLink: View {
+    let url: URL
+
+    var body: some View {
+        Link(destination: url) {
+            Label(url.absoluteString, systemImage: "link")
+                .font(CPSLTheme.bodyFont)
+                .lineLimit(2)
+        }
     }
 }
 
@@ -199,88 +493,28 @@ private struct CPSLCalendarEventAttachments: View {
     let onOpen: (String) -> Void
 
     var body: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: CPSLTheme.small) {
-                ForEach(attachments) { attachment in
-                    Button {
-                        onOpen(attachment.path)
-                    } label: {
-                        Label(attachment.name, systemImage: "paperclip")
-                            .font(CPSLTheme.captionFont)
-                            .lineLimit(1)
-                            .padding(.horizontal, CPSLTheme.small)
-                            .padding(.vertical, CPSLTheme.small / 2)
-                            .cpslSurfaceBackground(
-                                in: Capsule(),
-                                tint: CPSLTheme.IconPalette.calendar.opacity(0.18),
-                                strokeOpacity: 0.05
-                            )
-                    }
-                    .buttonStyle(.plain)
-                    .foregroundStyle(CPSLTheme.text)
-                    .accessibilityLabel("Open attachment \(attachment.name)")
-                }
-            }
-        }
-    }
-}
-
-private struct CPSLCalendarEventTimeBadge: View {
-    let startDate: Date
-    let isAllDay: Bool
-
-    var body: some View {
-        VStack(spacing: 2) {
-            Text(startDate, format: .dateTime.weekday(.abbreviated))
+        VStack(alignment: .leading, spacing: CPSLTheme.small) {
+            Label("Attachments", systemImage: "paperclip")
                 .font(CPSLTheme.captionMediumFont)
-            Text(startDate, format: .dateTime.day())
-                .font(CPSLTheme.supportingMediumFont)
-            if isAllDay {
-                Text("All day")
-                    .font(CPSLTheme.captionFont)
-            } else {
-                Text(startDate, format: .dateTime.hour().minute())
-                    .font(CPSLTheme.captionFont)
-            }
-        }
-        .foregroundStyle(CPSLTheme.text)
-        .frame(width: 66)
-        .padding(.vertical, CPSLTheme.small)
-        .cpslSurfaceBackground(
-            in: RoundedRectangle(cornerRadius: CPSLTheme.rowRadius, style: .continuous),
-            tint: CPSLTheme.IconPalette.calendar.opacity(0.24),
-            strokeOpacity: 0.06
-        )
-    }
-}
+                .foregroundStyle(CPSLTheme.secondaryText)
 
-private struct CPSLCalendarEventDetail: View {
-    let event: CPSLCalendarEvent
-
-    private var intervalText: String {
-        let start = event.startDate.formatted(.dateTime.month().day().hour().minute())
-        let end = event.endDate.formatted(.dateTime.hour().minute())
-        return "\(start) - \(end)"
-    }
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            if event.isAllDay {
-                Text("All day")
-                    .font(CPSLTheme.captionFont)
-                    .foregroundStyle(CPSLTheme.secondaryText)
-            } else {
-                Text(intervalText)
-                    .font(CPSLTheme.captionFont)
-                    .foregroundStyle(CPSLTheme.secondaryText)
-                    .lineLimit(1)
-            }
-
-            if let location = event.location {
-                Text(location)
-                    .font(CPSLTheme.captionFont)
-                    .foregroundStyle(CPSLTheme.secondaryText)
-                    .lineLimit(1)
+            ForEach(attachments) { attachment in
+                Button {
+                    onOpen(attachment.path)
+                } label: {
+                    HStack(spacing: CPSLTheme.small) {
+                        Image(systemName: "doc")
+                        Text(attachment.name)
+                            .lineLimit(1)
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                    }
+                    .font(CPSLTheme.bodyFont)
+                    .foregroundStyle(CPSLTheme.text)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Open attachment \(attachment.name)")
             }
         }
     }

--- a/app/apple/herm/Views/Chat/CPSLChatScreen.swift
+++ b/app/apple/herm/Views/Chat/CPSLChatScreen.swift
@@ -390,7 +390,7 @@ struct CPSLChatScreen: View {
                     bottomInset: CPSLTheme.medium
                 )
                 .ignoresSafeArea(.container, edges: .vertical)
-                .allowsHitTesting(isDrawerVisible)
+                .allowsHitTesting(isDrawerInteractionEnabled)
                 .offset(x: drawerOffset(width: proxy.size.width))
 
                 CPSLMainContentStage(
@@ -404,6 +404,12 @@ struct CPSLChatScreen: View {
                 .allowsHitTesting(!isDrawerVisible)
                 .zIndex(1)
 
+                CPSLDrawerGestureCapture(
+                    isOpen: model.isDrawerOpen,
+                    drawerGesture: drawerDragGesture(width: proxy.size.width)
+                )
+                .zIndex(2)
+
                 CPSLDrawerToggleButton(isOpen: model.isDrawerOpen) {
                     toggleDrawer()
                 }
@@ -411,9 +417,7 @@ struct CPSLChatScreen: View {
                 .padding(.top, CPSLTheme.topChromeSafeAreaGap)
                 .offset(x: drawerToggleOffset(width: proxy.size.width))
                 .zIndex(3)
-
             }
-            .simultaneousGesture(drawerDragGesture(width: proxy.size.width))
             .onAppear {
                 drawerProgress = drawerTargetProgress
                 isDrawerMotionActive = false
@@ -475,6 +479,12 @@ struct CPSLChatScreen: View {
         isDrawerVisible
     }
 
+    private var isDrawerInteractionEnabled: Bool {
+        model.isDrawerOpen &&
+            !isDrawerMotionActive &&
+            activeDrawerDragStartProgress == nil
+    }
+
     private func drawerTopInset(topSafeAreaInset: CGFloat) -> CGFloat {
         topSafeAreaInset + CPSLTheme.topChromeSafeAreaGap
     }
@@ -502,10 +512,7 @@ struct CPSLChatScreen: View {
         guard width > 0 else {
             return
         }
-        guard let startProgress = activeDrawerDragStartProgress
-            ?? drawerDragStartProgress(value, width: width) else {
-            return
-        }
+        let startProgress = activeDrawerDragStartProgress ?? drawerProgress
 
         activeDrawerDragStartProgress = startProgress
         drawerProgress = clampedDrawerProgress(startProgress + value.translation.width / width)
@@ -516,10 +523,7 @@ struct CPSLChatScreen: View {
             activeDrawerDragStartProgress = nil
             return
         }
-        guard let startProgress = activeDrawerDragStartProgress
-            ?? drawerDragStartProgress(value, width: width) else {
-            return
-        }
+        let startProgress = activeDrawerDragStartProgress ?? drawerProgress
 
         let predictedProgress = clampedDrawerProgress(
             startProgress + value.predictedEndTranslation.width / width
@@ -533,14 +537,6 @@ struct CPSLChatScreen: View {
         if wasOpen == shouldOpen {
             animateDrawerProgress(to: shouldOpen ? 1 : 0)
         }
-    }
-
-    private func drawerDragStartProgress(_ value: DragGesture.Value, width: CGFloat) -> CGFloat? {
-        if model.isDrawerOpen {
-            return value.startLocation.x >= width - CPSLTheme.drawerGestureEdgeWidth ? drawerProgress : nil
-        }
-
-        return value.startLocation.x <= CPSLTheme.drawerGestureEdgeWidth ? drawerProgress : nil
     }
 
     private func clampedDrawerProgress(_ progress: CGFloat) -> CGFloat {
@@ -562,6 +558,28 @@ struct CPSLChatScreen: View {
                 return
             }
             isDrawerMotionActive = false
+        }
+    }
+}
+
+private struct CPSLDrawerGestureCapture<DrawerGesture: Gesture>: View {
+    let isOpen: Bool
+    let drawerGesture: DrawerGesture
+
+    var body: some View {
+        HStack(spacing: 0) {
+            if isOpen {
+                Spacer(minLength: 0)
+            }
+
+            Color.clear
+                .contentShape(Rectangle())
+                .frame(width: CPSLTheme.drawerGestureEdgeWidth)
+                .gesture(drawerGesture)
+
+            if !isOpen {
+                Spacer(minLength: 0)
+            }
         }
     }
 }

--- a/app/apple/herm/Views/Chat/CPSLChatTimelineView.swift
+++ b/app/apple/herm/Views/Chat/CPSLChatTimelineView.swift
@@ -39,6 +39,9 @@ struct CPSLChatTimelineView: View {
                             },
                             openFilePath: { path in
                                 model.openFilePathFromTimeline(path)
+                            },
+                            loadAttachmentThumbnail: { attachment in
+                                await model.attachmentThumbnail(for: attachment)
                             }
                         )
                             .id(message.id)
@@ -287,6 +290,7 @@ private struct CPSLChatMessageView: View {
     let message: CPSLChatMessage
     let openBrowser: (String?) -> Void
     let openFilePath: (String) -> Void
+    let loadAttachmentThumbnail: (CPSLAttachment) async -> Data?
 
     var body: some View {
         HStack {
@@ -342,7 +346,8 @@ private struct CPSLChatMessageView: View {
             if !message.attachments.isEmpty {
                 CPSLMessageAttachmentList(
                     attachments: message.attachments,
-                    openFilePath: openFilePath
+                    openFilePath: openFilePath,
+                    loadThumbnail: loadAttachmentThumbnail
                 )
             }
         }
@@ -389,6 +394,7 @@ private struct CPSLChatMessageView: View {
 private struct CPSLMessageAttachmentList: View {
     let attachments: [CPSLAttachment]
     let openFilePath: (String) -> Void
+    let loadThumbnail: (CPSLAttachment) async -> Data?
 
     var body: some View {
         VStack(alignment: .leading, spacing: CPSLTheme.small) {
@@ -396,7 +402,10 @@ private struct CPSLMessageAttachmentList: View {
                 Button {
                     openFilePath(attachment.path)
                 } label: {
-                    CPSLAttachmentBadge(name: attachment.name)
+                    CPSLAttachmentBadge(
+                        attachment: attachment,
+                        loadThumbnail: loadThumbnail
+                    )
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Open attachment \(attachment.name)")

--- a/app/apple/herm/Views/Composer/CPSLPromptComposerView.swift
+++ b/app/apple/herm/Views/Composer/CPSLPromptComposerView.swift
@@ -223,7 +223,8 @@ struct CPSLPromptComposerView: View {
             if !model.composerAttachments.isEmpty {
                 CPSLComposerAttachmentStrip(
                     attachments: model.composerAttachments,
-                    onRemove: model.removeComposerAttachment
+                    onRemove: model.removeComposerAttachment,
+                    loadThumbnail: model.attachmentThumbnail(for:)
                 )
                 .padding(.bottom, CPSLTheme.small)
             }
@@ -626,14 +627,16 @@ struct CPSLPromptComposerView: View {
 private struct CPSLComposerAttachmentStrip: View {
     let attachments: [CPSLAttachment]
     let onRemove: (CPSLAttachment) -> Void
+    let loadThumbnail: (CPSLAttachment) async -> Data?
 
     var body: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: CPSLTheme.small) {
                 ForEach(attachments) { attachment in
                     CPSLAttachmentBadge(
-                        name: attachment.name,
-                        onRemove: { onRemove(attachment) }
+                        attachment: attachment,
+                        onRemove: { onRemove(attachment) },
+                        loadThumbnail: loadThumbnail
                     )
                 }
             }

--- a/app/apple/herm/Views/Files/CPSLFileBrowserView.swift
+++ b/app/apple/herm/Views/Files/CPSLFileBrowserView.swift
@@ -168,6 +168,12 @@ private struct CPSLFileBrowserDisplayPage: Identifiable, Equatable {
     }
 }
 
+private enum CPSLFileBrowserInteractionMode: Equatable {
+    case browsing
+    case selecting(selectedCount: Int)
+    case moving(itemCount: Int)
+}
+
 struct CPSLFileBrowserView: View {
     @ObservedObject var model: CPSLChatModel
     @State private var isICloudImporterPresented = false
@@ -175,6 +181,11 @@ struct CPSLFileBrowserView: View {
     @State private var isICloudAccessModePickerPresented = false
     @State private var isICloudAccessModePickerPending = false
     @State private var selectedICloudDirectory: URL?
+    @State private var isSelectingFiles = false
+    @State private var selectedEntriesByPath: [String: CPSLFileEntry] = [:]
+    @State private var movingEntries: [CPSLFileEntry] = []
+    @State private var pendingDeletionEntries: [CPSLFileEntry] = []
+    @State private var isDeleteConfirmationPresented = false
 
     var body: some View {
         browserPanel
@@ -219,17 +230,119 @@ struct CPSLFileBrowserView: View {
                     presentICloudImporterIfReady()
                 }
             }
+            .onChange(of: model.browserPath) { _, _ in
+                guard movingEntries.isEmpty else {
+                    return
+                }
+                isSelectingFiles = false
+                selectedEntriesByPath.removeAll()
+            }
+            .confirmationDialog(
+                deleteConfirmationTitle,
+                isPresented: $isDeleteConfirmationPresented,
+                titleVisibility: .visible
+            ) {
+                Button("Delete", role: .destructive) {
+                    let entries = pendingDeletionEntries
+                    pendingDeletionEntries = []
+                    model.deleteFileEntries(entries)
+                }
+                Button("Cancel", role: .cancel) {
+                    pendingDeletionEntries = []
+                }
+            } message: {
+                Text("This permanently deletes the selected items from CPSL storage.")
+            }
     }
 
     private var browserPanel: some View {
         CPSLFileOverlayPanel {
-            CPSLFileBrowserHeader(model: model)
+            CPSLFileBrowserHeader(model: model, actions: actions)
         } content: {
             CPSLFileBrowserRouteStack(
                 model: model,
-                connectICloud: connectICloud
+                actions: actions
             )
         }
+    }
+
+    private var actions: CPSLFileBrowserActions {
+        CPSLFileBrowserActions(
+            model: model,
+            connectICloud: connectICloud,
+            isSelecting: isSelectingFiles,
+            selectedEntryPaths: Set(selectedEntriesByPath.keys),
+            movingEntries: movingEntries,
+            beginSelection: beginSelection,
+            cancelSelection: cancelSelection,
+            toggleSelection: toggleSelection,
+            beginMove: beginMove,
+            cancelMove: cancelMove,
+            completeMove: completeMove,
+            requestDelete: requestDelete
+        )
+    }
+
+    private var deleteConfirmationTitle: String {
+        pendingDeletionEntries.count == 1
+            ? "Delete this item?"
+            : "Delete \(pendingDeletionEntries.count) items?"
+    }
+
+    private func beginSelection() {
+        movingEntries = []
+        selectedEntriesByPath.removeAll()
+        isSelectingFiles = true
+    }
+
+    private func cancelSelection() {
+        isSelectingFiles = false
+        selectedEntriesByPath.removeAll()
+    }
+
+    private func toggleSelection(_ entry: CPSLFileEntry) {
+        if selectedEntriesByPath.removeValue(forKey: entry.path) == nil {
+            if selectedEntriesByPath.values.contains(where: {
+                $0.isDirectory && entry.path.hasPrefix("\($0.path)/")
+            }) {
+                return
+            }
+            if entry.isDirectory {
+                selectedEntriesByPath = selectedEntriesByPath.filter {
+                    !$0.key.hasPrefix("\(entry.path)/")
+                }
+            }
+            selectedEntriesByPath[entry.path] = entry
+        }
+    }
+
+    private func beginMove(_ entries: [CPSLFileEntry]) {
+        guard !entries.isEmpty else {
+            return
+        }
+        isSelectingFiles = false
+        selectedEntriesByPath.removeAll()
+        movingEntries = entries.sorted { $0.path < $1.path }
+    }
+
+    private func cancelMove() {
+        movingEntries = []
+    }
+
+    private func completeMove() {
+        let entries = movingEntries
+        movingEntries = []
+        model.moveFileEntries(entries, toDirectory: model.browserPath)
+    }
+
+    private func requestDelete(_ entries: [CPSLFileEntry]) {
+        guard !entries.isEmpty else {
+            return
+        }
+        isSelectingFiles = false
+        selectedEntriesByPath.removeAll()
+        pendingDeletionEntries = entries.sorted { $0.path < $1.path }
+        isDeleteConfirmationPresented = true
     }
 
     private func connectICloud() {
@@ -268,7 +381,7 @@ struct CPSLFileBrowserView: View {
 
 private struct CPSLFileBrowserRouteStack: View {
     @ObservedObject var model: CPSLChatModel
-    let connectICloud: () -> Void
+    let actions: CPSLFileBrowserActions
     @State private var pages: [CPSLFileBrowserDisplayPage] = []
     @State private var transitionGeneration = 0
 
@@ -298,7 +411,7 @@ private struct CPSLFileBrowserRouteStack: View {
                 ForEach(visiblePages) { page in
                     CPSLFileBrowserRouteContent(
                         route: page.route,
-                        actions: CPSLFileBrowserActions(model: model, connectICloud: connectICloud)
+                        actions: actions
                     )
                     .frame(
                         width: proxy.size.width,
@@ -438,6 +551,16 @@ private struct CPSLFileBrowserRouteContent: View {
 private struct CPSLFileBrowserActions {
     let model: CPSLChatModel
     let connectICloud: () -> Void
+    let isSelecting: Bool
+    let selectedEntryPaths: Set<String>
+    let movingEntries: [CPSLFileEntry]
+    let beginSelection: () -> Void
+    let cancelSelection: () -> Void
+    let toggleSelection: (CPSLFileEntry) -> Void
+    let beginMove: ([CPSLFileEntry]) -> Void
+    let cancelMove: () -> Void
+    let completeMove: () -> Void
+    let requestDelete: ([CPSLFileEntry]) -> Void
 
     var iCloudMounts: [CPSLICloudMount] {
         model.iCloudMounts
@@ -447,11 +570,38 @@ private struct CPSLFileBrowserActions {
         model.isBusy
     }
 
+    var mode: CPSLFileBrowserInteractionMode {
+        if !movingEntries.isEmpty {
+            return .moving(itemCount: movingEntries.count)
+        }
+        if isSelecting {
+            return .selecting(selectedCount: selectedEntryPaths.count)
+        }
+        return .browsing
+    }
+
+    var canEnterSelection: Bool {
+        model.filePreview == nil &&
+            model.browserEntries.contains { canModify($0) }
+    }
+
     func loadPath(_ path: String) {
         model.loadBrowserPath(path)
     }
 
     func openEntry(_ entry: CPSLFileEntry) {
+        if isSelecting {
+            guard canModify(entry) else {
+                return
+            }
+            toggleSelection(entry)
+            return
+        }
+        if !movingEntries.isEmpty {
+            guard entry.isDirectory else {
+                return
+            }
+        }
         model.openFileEntry(entry)
     }
 
@@ -459,9 +609,47 @@ private struct CPSLFileBrowserActions {
         model.toggleExpansion(for: entry)
     }
 
-    init(model: CPSLChatModel, connectICloud: @escaping () -> Void) {
-        self.model = model
-        self.connectICloud = connectICloud
+    func isSelected(_ entry: CPSLFileEntry) -> Bool {
+        selectedEntryPaths.contains(entry.path)
+    }
+
+    func isReadOnly(_ entry: CPSLFileEntry) -> Bool {
+        model.isFileReadOnly(entry.path)
+    }
+
+    func isICloudMountRoot(_ entry: CPSLFileEntry) -> Bool {
+        model.isICloudMountRoot(entry.path)
+    }
+
+    func canModify(_ entry: CPSLFileEntry) -> Bool {
+        !isBusy && !isReadOnly(entry) && !isICloudMountRoot(entry)
+    }
+
+    func canCompleteMove() -> Bool {
+        !isBusy && model.canMoveFileEntries(movingEntries, toDirectory: model.browserPath)
+    }
+
+    func moveSelectedEntries() {
+        beginMove(selectedEntries())
+    }
+
+    func deleteSelectedEntries() {
+        requestDelete(selectedEntries())
+    }
+
+    private func selectedEntries() -> [CPSLFileEntry] {
+        let entriesByPath = dictionaryOfVisibleEntries()
+        return selectedEntryPaths.compactMap { entriesByPath[$0] }
+    }
+
+    private func dictionaryOfVisibleEntries() -> [String: CPSLFileEntry] {
+        var result = Dictionary(uniqueKeysWithValues: model.browserEntries.map { ($0.path, $0) })
+        for entries in model.childEntriesByPath.values {
+            for entry in entries {
+                result[entry.path] = entry
+            }
+        }
+        return result
     }
 
     func removeICloudMount(_ entry: CPSLFileEntry) {
@@ -475,6 +663,7 @@ private struct CPSLFileBrowserActions {
 
 private struct CPSLFileBrowserHeader: View {
     @ObservedObject var model: CPSLChatModel
+    let actions: CPSLFileBrowserActions
 
     var body: some View {
         HStack(spacing: CPSLTheme.medium) {
@@ -501,8 +690,24 @@ private struct CPSLFileBrowserHeader: View {
                 )
             }
 
-            if let preview = model.filePreview, preview.showsHeaderInfoButton {
-                CPSLFilePreviewInfoButton(preview: preview)
+            switch actions.mode {
+            case .browsing:
+                if let preview = model.filePreview, preview.showsHeaderInfoButton {
+                    CPSLFilePreviewInfoButton(preview: preview)
+                } else if actions.canEnterSelection {
+                    Button("Select", action: actions.beginSelection)
+                        .font(CPSLTheme.controlFont)
+                        .buttonStyle(.plain)
+                        .foregroundStyle(CPSLTheme.text)
+                        .padding(.horizontal, CPSLTheme.small)
+                }
+            case .selecting:
+                Button("Cancel", action: actions.cancelSelection)
+                    .font(CPSLTheme.controlFont)
+                    .buttonStyle(.plain)
+                    .foregroundStyle(CPSLTheme.text)
+            case .moving:
+                EmptyView()
             }
 
             CPSLFileOverlayIconButton(
@@ -716,7 +921,7 @@ private struct CPSLFileBrowserHeaderTitle: View {
             return CPSLTheme.IconPalette.temporary
         }
         if path == CPSLVirtualPath.iCloudRoot || path.hasPrefix("\(CPSLVirtualPath.iCloudRoot)/") {
-            return CPSLTheme.IconPalette.cloud
+            return CPSLTheme.IconPalette.primary
         }
         return CPSLTheme.IconPalette.folder
     }
@@ -741,35 +946,150 @@ private struct CPSLICloudMountAccessBadge: View {
     }
 }
 
+private struct CPSLFileReadOnlyBadge: View {
+    var body: some View {
+        Text("Read-only")
+            .font(CPSLTheme.userFont(size: 10, weight: .semibold))
+            .foregroundStyle(CPSLTheme.secondaryText)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(CPSLTheme.elevated, in: Capsule())
+            .fixedSize()
+    }
+}
+
 private struct CPSLFileBrowserPane: View {
     let snapshot: CPSLFileBrowserFolderSnapshot
     let actions: CPSLFileBrowserActions
 
     var body: some View {
-        ScrollView {
-            LazyVStack(spacing: 0) {
-                if let error = snapshot.error {
-                    CPSLFileBrowserErrorView(message: error)
-                }
+        VStack(spacing: 0) {
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    if let error = snapshot.error {
+                        CPSLFileBrowserErrorView(message: error)
+                    }
 
-                if snapshot.isRoot {
-                    CPSLFileLocationsView(actions: actions)
-                } else if snapshot.isLoading && snapshot.rows.isEmpty {
-                    CPSLFileBrowserLoadingView()
-                } else if snapshot.rows.isEmpty && snapshot.error == nil {
-                    CPSLFileBrowserEmptyView()
-                } else {
-                    ForEach(snapshot.rows) { row in
-                        CPSLFileBrowserRowView(row: row, actions: actions)
+                    if snapshot.isRoot {
+                        CPSLFileLocationsView(actions: actions)
+                    } else {
+                        if snapshot.isLoading && snapshot.rows.isEmpty {
+                            CPSLFileBrowserLoadingView()
+                        } else if snapshot.rows.isEmpty && snapshot.error == nil {
+                            CPSLFileBrowserEmptyView()
+                        } else {
+                            ForEach(snapshot.rows) { row in
+                                CPSLFileBrowserRowView(row: row, actions: actions)
+                            }
+                        }
+
+                        if snapshot.path == CPSLVirtualPath.iCloudRoot,
+                           !actions.iCloudMounts.isEmpty,
+                           actions.mode == .browsing {
+                            CPSLAddICloudFolderRow(actions: actions)
+                        }
                     }
                 }
+                .padding(.vertical, CPSLTheme.small)
             }
-            .padding(.vertical, CPSLTheme.small)
+            .scrollDismissesKeyboard(.interactively)
+            .scrollBounceBehavior(.basedOnSize)
+
+            switch actions.mode {
+            case .browsing:
+                EmptyView()
+            case .selecting(let selectedCount):
+                CPSLFileSelectionActionBar(
+                    selectedCount: selectedCount,
+                    isBusy: actions.isBusy,
+                    onMove: actions.moveSelectedEntries,
+                    onDelete: actions.deleteSelectedEntries
+                )
+            case .moving(let itemCount):
+                CPSLFileMoveActionBar(
+                    itemCount: itemCount,
+                    canMoveHere: actions.canCompleteMove(),
+                    onCancel: actions.cancelMove,
+                    onMoveHere: actions.completeMove
+                )
+            }
         }
-        .scrollDismissesKeyboard(.interactively)
-        .scrollBounceBehavior(.basedOnSize)
         .frame(maxWidth: .infinity, alignment: .topLeading)
         .frame(maxHeight: .infinity)
+    }
+}
+
+private struct CPSLFileSelectionActionBar: View {
+    let selectedCount: Int
+    let isBusy: Bool
+    let onMove: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        HStack(spacing: CPSLTheme.small) {
+            Text("\(selectedCount) selected")
+                .font(CPSLTheme.captionFont)
+                .foregroundStyle(CPSLTheme.secondaryText)
+
+            Spacer()
+
+            Button(action: onMove) {
+                Label("Move", systemImage: "folder")
+            }
+            Button(role: .destructive, action: onDelete) {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+        .font(CPSLTheme.controlFont)
+        .buttonStyle(.borderless)
+        .disabled(selectedCount == 0 || isBusy)
+        .padding(.horizontal, CPSLTheme.medium)
+        .frame(minHeight: CPSLTheme.controlSize + CPSLTheme.small)
+        .background(CPSLTheme.elevated)
+    }
+}
+
+private struct CPSLFileMoveActionBar: View {
+    let itemCount: Int
+    let canMoveHere: Bool
+    let onCancel: () -> Void
+    let onMoveHere: () -> Void
+
+    var body: some View {
+        HStack(spacing: CPSLTheme.small) {
+            Text(itemCount == 1 ? "Move 1 item" : "Move \(itemCount) items")
+                .font(CPSLTheme.captionFont)
+                .foregroundStyle(CPSLTheme.secondaryText)
+
+            Spacer()
+
+            Button("Cancel", action: onCancel)
+            Button("Move Here", action: onMoveHere)
+                .disabled(!canMoveHere)
+        }
+        .font(CPSLTheme.controlFont)
+        .buttonStyle(.borderless)
+        .padding(.horizontal, CPSLTheme.medium)
+        .frame(minHeight: CPSLTheme.controlSize + CPSLTheme.small)
+        .background(CPSLTheme.elevated)
+    }
+}
+
+private struct CPSLAddICloudFolderRow: View {
+    let actions: CPSLFileBrowserActions
+
+    var body: some View {
+        CPSLCloudConnectionRow(
+            title: "Add iCloud Folder",
+            actionTitle: "Add",
+            systemName: "icloud.fill",
+            color: CPSLTheme.IconPalette.cloud,
+            accessory: .singleIcon
+        ) {
+            actions.connectICloud()
+        }
+        .disabled(actions.isBusy)
+        .opacity(actions.isBusy ? 0.45 : 1)
     }
 }
 
@@ -810,30 +1130,36 @@ private struct CPSLFileLocationsView: View {
                     title: "iCloud",
                     detail: CPSLVirtualPath.iCloudRoot,
                     systemName: "icloud.fill",
-                    color: CPSLTheme.IconPalette.cloud
+                    color: CPSLTheme.IconPalette.primary
                 ) {
                     actions.loadPath(CPSLVirtualPath.iCloudRoot)
                 }
             }
 
-            CPSLCloudConnectionRow(
-                title: actions.iCloudMounts.isEmpty ? "iCloud" : "Add iCloud Folder",
-                systemName: "icloud.fill",
-                color: CPSLTheme.IconPalette.cloud,
-                accessory: .singleIcon
-            ) {
-                actions.connectICloud()
-            }
-            .disabled(actions.isBusy)
-            .opacity(actions.isBusy ? 0.45 : 1)
+            if actions.mode == .browsing {
+                if actions.iCloudMounts.isEmpty {
+                    CPSLCloudConnectionRow(
+                        title: "iCloud",
+                        actionTitle: "Add",
+                        systemName: "icloud.fill",
+                        color: CPSLTheme.IconPalette.cloud,
+                        accessory: .singleIcon
+                    ) {
+                        actions.connectICloud()
+                    }
+                    .disabled(actions.isBusy)
+                    .opacity(actions.isBusy ? 0.45 : 1)
+                }
 
-            CPSLCloudConnectionRow(
-                title: "Cloud Drives",
-                systemName: "externaldrive.fill",
-                color: CPSLTheme.IconPalette.drive,
-                accessory: .providerIcons
-            ) {
-                actions.showComingSoon("coming soon")
+                CPSLCloudConnectionRow(
+                    title: "Cloud Drives",
+                    actionTitle: "Connect",
+                    systemName: "externaldrive.fill",
+                    color: CPSLTheme.IconPalette.drive,
+                    accessory: .providerIcons
+                ) {
+                    actions.showComingSoon("coming soon")
+                }
             }
         }
     }
@@ -883,6 +1209,7 @@ private enum CPSLCloudAccessory {
 
 private struct CPSLCloudConnectionRow: View {
     let title: LocalizedStringKey
+    let actionTitle: LocalizedStringKey
     let systemName: String
     let color: Color
     let accessory: CPSLCloudAccessory
@@ -901,7 +1228,7 @@ private struct CPSLCloudConnectionRow: View {
 
             Spacer()
 
-            Button("Connect", action: action)
+            Button(actionTitle, action: action)
                 .font(CPSLTheme.controlFont)
                 .buttonStyle(.plain)
                 .foregroundStyle(CPSLTheme.text)
@@ -1017,11 +1344,21 @@ private struct CPSLFileBrowserRowView: View {
                     depth: depth,
                     isExpanded: isExpanded,
                     accessMode: iCloudMountAccessMode(for: entry),
+                    isReadOnly: actions.isReadOnly(entry),
+                    isSelected: actions.isSelected(entry),
+                    mode: actions.mode,
+                    canModify: actions.canModify(entry),
                     onOpen: {
                         actions.openEntry(entry)
                     },
                     onToggleExpansion: {
                         actions.toggleExpansion(entry)
+                    },
+                    onMove: {
+                        actions.beginMove([entry])
+                    },
+                    onDelete: {
+                        actions.requestDelete([entry])
                     },
                     onRemove: iCloudMountRemoval(for: entry)
                 )
@@ -1056,17 +1393,26 @@ private struct CPSLFileRowView: View {
     let depth: Int
     let isExpanded: Bool
     let accessMode: CPSLICloudMountAccessMode?
+    let isReadOnly: Bool
+    let isSelected: Bool
+    let mode: CPSLFileBrowserInteractionMode
+    let canModify: Bool
     let onOpen: () -> Void
     let onToggleExpansion: () -> Void
+    let onMove: () -> Void
+    let onDelete: () -> Void
     let onRemove: (() -> Void)?
 
     var body: some View {
         HStack(spacing: CPSLTheme.small) {
-            if entry.isDirectory {
+            if case .selecting = mode {
+                CPSLFileSelectionControl(isSelected: isSelected, isEnabled: canModify)
+            } else if entry.isDirectory {
                 CPSLFileDisclosureControl(
                     isExpanded: isExpanded,
                     onToggle: onToggleExpansion
                 )
+                .disabled(isMoving)
             }
 
             Button(action: onOpen) {
@@ -1080,6 +1426,8 @@ private struct CPSLFileRowView: View {
 
                     if let accessMode {
                         CPSLICloudMountAccessBadge(accessMode: accessMode)
+                    } else if isReadOnly {
+                        CPSLFileReadOnlyBadge()
                     }
 
                     Spacer()
@@ -1089,17 +1437,20 @@ private struct CPSLFileRowView: View {
             }
             .buttonStyle(.plain)
             .contentShape(Rectangle())
+            .disabled(isMoving && !entry.isDirectory)
 
-            if let onRemove {
+            if case .browsing = mode, let onRemove {
                 Button(action: onRemove) {
-                    Image(systemName: "trash")
+                    Image(systemName: "eject.fill")
                         .font(CPSLTheme.iconSmallFont)
                         .frame(width: CPSLTheme.controlSize, height: CPSLTheme.controlSize)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .foregroundStyle(CPSLTheme.danger)
-                .accessibilityLabel(Text("Remove iCloud Folder"))
+                .foregroundStyle(CPSLTheme.secondaryText)
+                .accessibilityLabel(Text("Unmount iCloud Folder"))
+            } else if case .browsing = mode, canModify {
+                CPSLFileActionMenu(onMove: onMove, onDelete: onDelete)
             }
         }
         .padding(.leading, leadingPadding)
@@ -1109,7 +1460,17 @@ private struct CPSLFileRowView: View {
     }
 
     private var leadingPadding: CGFloat {
-        CPSLFileRowMetrics.leadingPadding(depth: depth, isDirectory: entry.isDirectory)
+        if case .selecting = mode {
+            return CPSLFileRowMetrics.leading + CGFloat(depth) * CPSLFileRowMetrics.indent
+        }
+        return CPSLFileRowMetrics.leadingPadding(depth: depth, isDirectory: entry.isDirectory)
+    }
+
+    private var isMoving: Bool {
+        if case .moving = mode {
+            return true
+        }
+        return false
     }
 
     private var iconName: String {
@@ -1124,6 +1485,47 @@ private struct CPSLFileRowView: View {
             return CPSLTheme.IconPalette.folder
         }
         return entry.previewCategory.iconColor
+    }
+}
+
+private struct CPSLFileSelectionControl: View {
+    let isSelected: Bool
+    let isEnabled: Bool
+
+    var body: some View {
+        Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+            .font(CPSLTheme.iconMediumFont)
+            .foregroundStyle(isEnabled ? CPSLTheme.mauve : CPSLTheme.mutedText)
+            .frame(
+                width: CPSLFileRowMetrics.disclosureWidth,
+                height: CPSLFileRowMetrics.height
+            )
+            .opacity(isEnabled ? 1 : 0.45)
+            .accessibilityHidden(true)
+    }
+}
+
+private struct CPSLFileActionMenu: View {
+    let onMove: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        Menu {
+            Button(action: onMove) {
+                Label("Move…", systemImage: "folder")
+            }
+            Button(role: .destructive, action: onDelete) {
+                Label("Delete", systemImage: "trash")
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(CPSLTheme.iconSmallFont)
+                .frame(width: CPSLTheme.controlSize, height: CPSLTheme.controlSize)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(CPSLTheme.secondaryText)
+        .accessibilityLabel("File actions")
     }
 }
 

--- a/app/apple/herm/Views/Shared/CPSLAttachmentBadge.swift
+++ b/app/apple/herm/Views/Shared/CPSLAttachmentBadge.swift
@@ -1,29 +1,34 @@
+import Foundation
 import SwiftUI
+
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
 
 struct CPSLAttachmentBadge: View {
     private static let maximumDisplayNameLength = 24
     private static let trailingDisplayNameLength = 8
 
-    let name: String
+    let attachment: CPSLAttachment
     let onRemove: (() -> Void)?
+    let loadThumbnail: ((CPSLAttachment) async -> Data?)?
+    @State private var thumbnailData: Data?
 
-    init(name: String, onRemove: (() -> Void)? = nil) {
-        self.name = name
+    init(
+        attachment: CPSLAttachment,
+        onRemove: (() -> Void)? = nil,
+        loadThumbnail: ((CPSLAttachment) async -> Data?)? = nil
+    ) {
+        self.attachment = attachment
         self.onRemove = onRemove
-    }
-
-    private var displayName: String {
-        guard name.count > Self.maximumDisplayNameLength else {
-            return name
-        }
-        let leadingCount = Self.maximumDisplayNameLength - Self.trailingDisplayNameLength - 1
-        return "\(name.prefix(leadingCount))…\(name.suffix(Self.trailingDisplayNameLength))"
+        self.loadThumbnail = loadThumbnail
     }
 
     var body: some View {
         HStack(spacing: CPSLTheme.small) {
-            Image(systemName: "paperclip")
-                .foregroundStyle(CPSLTheme.mauve)
+            CPSLAttachmentVisual(name: attachment.name, thumbnailData: thumbnailData)
 
             Text(displayName)
                 .font(CPSLTheme.captionFont)
@@ -37,7 +42,7 @@ struct CPSLAttachmentBadge: View {
                         .foregroundStyle(CPSLTheme.mutedText)
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("Remove \(name)")
+                .accessibilityLabel("Remove \(attachment.name)")
             }
         }
         .padding(.horizontal, CPSLTheme.small)
@@ -47,5 +52,93 @@ struct CPSLAttachmentBadge: View {
             tint: CPSLGlassTuning.tint(CPSLTheme.card, opacity: 0.38),
             strokeOpacity: 0.045
         )
+        .task(id: attachment.id) {
+            guard previewCategory == .image, let loadThumbnail else {
+                thumbnailData = nil
+                return
+            }
+            thumbnailData = await loadThumbnail(attachment)
+        }
+    }
+
+    private var displayName: String {
+        let name = attachment.name
+        guard name.count > Self.maximumDisplayNameLength else {
+            return name
+        }
+        let leadingCount = Self.maximumDisplayNameLength - Self.trailingDisplayNameLength - 1
+        return "\(name.prefix(leadingCount))…\(name.suffix(Self.trailingDisplayNameLength))"
+    }
+
+    private var previewCategory: CPSLFilePreviewCategory {
+        let fileExtension = URL(fileURLWithPath: attachment.name).pathExtension.lowercased()
+        return CPSLFilePreviewCategory(
+            fileName: attachment.name,
+            fileExtension: fileExtension
+        )
+    }
+}
+
+private struct CPSLAttachmentVisual: View {
+    let name: String
+    let thumbnailData: Data?
+
+    var body: some View {
+        ZStack {
+            if let image = platformImage {
+                image
+                    .resizable()
+                    .scaledToFill()
+            } else {
+                Image(systemName: fallbackSystemImageName)
+                    .symbolRenderingMode(.hierarchical)
+                    .font(CPSLTheme.iconMediumFont)
+                    .foregroundStyle(CPSLTheme.mauve)
+            }
+        }
+        .frame(width: 28, height: 28)
+        .background(CPSLTheme.elevated)
+        .clipShape(RoundedRectangle(cornerRadius: CPSLTheme.small, style: .continuous))
+        .accessibilityHidden(true)
+    }
+
+    private var platformImage: Image? {
+        guard let thumbnailData else {
+            return nil
+        }
+#if canImport(UIKit)
+        guard let image = UIImage(data: thumbnailData) else {
+            return nil
+        }
+        return Image(uiImage: image)
+#elseif canImport(AppKit)
+        guard let image = NSImage(data: thumbnailData) else {
+            return nil
+        }
+        return Image(nsImage: image)
+#else
+        return nil
+#endif
+    }
+
+    private var fallbackSystemImageName: String {
+        switch fileExtension {
+        case "doc", "docx", "odt", "pages", "rtf":
+            return "doc.text.fill"
+        case "key", "odp", "ppt", "pptx":
+            return "rectangle.on.rectangle.angled"
+        case "csv", "numbers", "ods", "xls", "xlsx":
+            return "tablecells.fill"
+        default:
+            return previewCategory.systemImageName
+        }
+    }
+
+    private var fileExtension: String {
+        URL(fileURLWithPath: name).pathExtension.lowercased()
+    }
+
+    private var previewCategory: CPSLFilePreviewCategory {
+        CPSLFilePreviewCategory(fileName: name, fileExtension: fileExtension)
     }
 }

--- a/docs/apple-agent-storage.md
+++ b/docs/apple-agent-storage.md
@@ -43,6 +43,11 @@ website file input; web content never receives or resolves a CPSL path itself.
 Browser downloads are saved under `/tmp/downloads` and reported back as virtual
 paths.
 
+Connected iCloud Drive folders are additional CPSL file mounts. They do not
+change the agent's HTTP policy, native browser availability, or document
+rendering capability. The agent is instructed to treat mounted content as
+personal data and access it only when the task calls for it.
+
 EventKit exposes an event URL and notes but no public file-attachment API. Herm
 therefore provides `calendar.attach(event_id, paths)` as an app-managed layer:
 it copies files under `/home/herm/calendar-attachments`, records their virtual

--- a/scripts/vet-apple-agent-integration.sh
+++ b/scripts/vet-apple-agent-integration.sh
@@ -299,7 +299,13 @@ require_match 'UNLOCALIZED_RESOURCES_FOLDER_PATH.*/Skills' app/apple/herm.xcodep
 require_match 'cp -R.*src.*dst' app/apple/herm.xcodeproj/project.pbxproj
 require_match 'The following skills are available' app/apple/herm/Models/CPSLChatModel.swift
 require_match '\$0\.path' app/apple/herm/Models/CPSLChatModel.swift
-require_match 'iCloudRestrictedSkillNames = Set\(\["beautiful-pdfs", "webbrowser"\]\)' app/apple/herm/Models/CPSLChatModel.swift
+reject_match 'iCloudRestrictedSkillNames|Network access is disabled while these mounts are active' \
+  app/apple/herm/Models/CPSLChatModel.swift
+require_match 'let callbackBox = CPSLWebBrowserCallbackBox\(service: webBrowser\)' \
+  app/apple/herm/Services/CPSLDebugService.swift
+require_match 'let allowedDomains = \["\*"\]' app/apple/herm/Services/CPSLDebugService.swift
+require_match 'do not use require to load them' app/apple/herm/Models/CPSLChatModel.swift
+require_match 'help\(\) is the authoritative module list' app/apple/herm/Skills/webbrowser/SKILL.md
 require_match 'Treat CPSL as its own Luau ecosystem' app/apple/herm/Models/CPSLChatModel.swift
 require_match 'APIs from other Lua/Luau environments' app/apple/herm/Models/CPSLChatModel.swift
 require_match 'do not assign help output to a variable' app/apple/herm/Models/CPSLChatModel.swift


### PR DESCRIPTION
## Summary

- polish the Apple file browser with file-management actions, previews, and attachment thumbnails
- refine calendar navigation, event details, and Herm-managed event attachments
- keep agent browser and network capabilities available with iCloud mounts, with updated docs and integration checks

## Testing

- Not run (not requested)