### PR TITLE
feat(apple): support pasted images and dropped attachments

### DIFF
--- a/app/apple/herm/Views/Composer/CPSLAttachmentDropModifier.swift
+++ b/app/apple/herm/Views/Composer/CPSLAttachmentDropModifier.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+struct CPSLAttachmentDropModifier: ViewModifier {
+    @Binding var isTargeted: Bool
+    let isEnabled: Bool
+    let onDropFiles: ([URL]) -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .dropDestination(for: URL.self, isEnabled: isEnabled) { urls, _ in
+                onDropFiles(urls)
+            }
+#if os(macOS)
+            .onDropSessionUpdated { session in
+                updateTarget(for: session.phase)
+            }
+#endif
+            .overlay {
+                RoundedRectangle(cornerRadius: CPSLTheme.composerRadius, style: .continuous)
+                    .stroke(
+                        CPSLTheme.text.opacity(0.72),
+                        style: StrokeStyle(
+                            lineWidth: 2,
+                            lineCap: .round,
+                            dash: [3, 6]
+                        )
+                    )
+                    .opacity(isTargeted ? 1 : 0)
+                    .allowsHitTesting(false)
+            }
+            .animation(.easeOut(duration: 0.14), value: isTargeted)
+    }
+
+#if os(macOS)
+    private func updateTarget(for phase: DropSession.Phase) {
+        switch phase {
+        case .entering, .active:
+            isTargeted = true
+        case .exiting, .ended, .dataTransferCompleted:
+            isTargeted = false
+        @unknown default:
+            isTargeted = false
+        }
+    }
+#endif
+}
+
+extension View {
+    func cpslAttachmentDropDestination(
+        isTargeted: Binding<Bool>,
+        isEnabled: Bool,
+        onDropFiles: @escaping ([URL]) -> Void
+    ) -> some View {
+        modifier(
+            CPSLAttachmentDropModifier(
+                isTargeted: isTargeted,
+                isEnabled: isEnabled,
+                onDropFiles: onDropFiles
+            )
+        )
+    }
+}

--- a/app/apple/herm/Views/Composer/CPSLMacPromptTextView.swift
+++ b/app/apple/herm/Views/Composer/CPSLMacPromptTextView.swift
@@ -1,0 +1,261 @@
+#if os(macOS)
+import AppKit
+import Dispatch
+import SwiftUI
+
+private final class CPSLPasteAwareTextView: NSTextView {
+    var canPasteAttachments: (() -> Bool)?
+    var pasteAttachments: (() -> Bool)?
+
+    override func paste(_ sender: Any?) {
+        if pasteAttachments?() == true {
+            return
+        }
+        guard let text = NSPasteboard.general.string(forType: .string) else {
+            return
+        }
+        insertText(text, replacementRange: selectedRange())
+    }
+
+    override func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+        if menuItem.action == #selector(NSText.paste(_:)),
+           canPasteAttachments?() == true {
+            return isEditable
+        }
+        return super.validateMenuItem(menuItem)
+    }
+}
+
+final class CPSLDropAwareScrollView: NSScrollView {
+    var isFileDropEnabled = true
+    var onDropFiles: (([URL]) -> Void)?
+    var onDropTargeted: ((Bool) -> Void)?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        registerForDraggedTypes([.fileURL])
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        registerForDraggedTypes([.fileURL])
+    }
+
+    override func draggingEntered(_ sender: any NSDraggingInfo) -> NSDragOperation {
+        dropOperation(for: sender, updateTarget: true)
+    }
+
+    override func draggingUpdated(_ sender: any NSDraggingInfo) -> NSDragOperation {
+        dropOperation(for: sender, updateTarget: true)
+    }
+
+    override func draggingExited(_ sender: (any NSDraggingInfo)?) {
+        onDropTargeted?(false)
+    }
+
+    override func performDragOperation(_ sender: any NSDraggingInfo) -> Bool {
+        let urls = fileURLs(from: sender)
+        guard isFileDropEnabled, !urls.isEmpty else {
+            onDropTargeted?(false)
+            return false
+        }
+        onDropFiles?(urls)
+        onDropTargeted?(false)
+        return true
+    }
+
+    override func concludeDragOperation(_ sender: (any NSDraggingInfo)?) {
+        onDropTargeted?(false)
+    }
+
+    private func dropOperation(
+        for draggingInfo: any NSDraggingInfo,
+        updateTarget: Bool
+    ) -> NSDragOperation {
+        let acceptsDrop = isFileDropEnabled && !fileURLs(from: draggingInfo).isEmpty
+        if updateTarget {
+            onDropTargeted?(acceptsDrop)
+        }
+        return acceptsDrop ? .copy : []
+    }
+
+    private func fileURLs(from draggingInfo: any NSDraggingInfo) -> [URL] {
+        draggingInfo.draggingPasteboard.readObjects(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]
+        ) as? [URL] ?? []
+    }
+}
+
+struct CPSLPromptTextView: NSViewRepresentable {
+    @Binding var text: String
+    let isCommandInput: Bool
+    let isDisabled: Bool
+    let verticalInset: CGFloat
+    let maxHeight: CGFloat
+    let focusPromptRequest: Int
+    let dismissKeyboardRequest: Int
+    let canPasteAttachments: () -> Bool
+    let onPasteAttachments: () -> Bool
+    let onDropFiles: ([URL]) -> Void
+    let onDropTargeted: (Bool) -> Void
+    let onHeightChange: (CGFloat) -> Void
+
+    func makeNSView(context: Context) -> CPSLDropAwareScrollView {
+        let scrollView = CPSLDropAwareScrollView()
+        scrollView.borderType = .noBorder
+        scrollView.drawsBackground = false
+        scrollView.hasHorizontalScroller = false
+        scrollView.hasVerticalScroller = false
+        scrollView.autohidesScrollers = true
+
+        let textView = CPSLPasteAwareTextView()
+        textView.delegate = context.coordinator
+        textView.drawsBackground = false
+        textView.textColor = NSColor(CPSLTheme.text)
+        textView.insertionPointColor = NSColor(CPSLTheme.text)
+        textView.font = .systemFont(ofSize: CPSLTheme.FontSize.body)
+        textView.menu = makeContextMenu(target: textView)
+        textView.isRichText = false
+        textView.importsGraphics = false
+        textView.allowsUndo = true
+        textView.isHorizontallyResizable = false
+        textView.isVerticallyResizable = true
+        textView.autoresizingMask = [.width]
+        textView.unregisterDraggedTypes()
+        textView.minSize = .zero
+        textView.maxSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.textContainer?.widthTracksTextView = true
+        textView.textContainer?.containerSize = NSSize(
+            width: scrollView.contentSize.width,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        scrollView.documentView = textView
+        configure(textView, in: scrollView)
+        context.coordinator.focusPromptRequest = focusPromptRequest
+        context.coordinator.dismissKeyboardRequest = dismissKeyboardRequest
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: CPSLDropAwareScrollView, context: Context) {
+        guard let textView = scrollView.documentView as? CPSLPasteAwareTextView else {
+            return
+        }
+        context.coordinator.parent = self
+        configure(textView, in: scrollView)
+
+        let didChangeText = textView.string != text
+        if didChangeText {
+            textView.string = text
+        }
+
+        if isDisabled && textView.window?.firstResponder === textView {
+            textView.window?.makeFirstResponder(nil)
+        } else if context.coordinator.dismissKeyboardRequest != dismissKeyboardRequest {
+            context.coordinator.dismissKeyboardRequest = dismissKeyboardRequest
+            textView.window?.makeFirstResponder(nil)
+        } else if context.coordinator.focusPromptRequest != focusPromptRequest {
+            context.coordinator.focusPromptRequest = focusPromptRequest
+            DispatchQueue.main.async {
+                textView.window?.makeFirstResponder(textView)
+            }
+        }
+
+        if didChangeText {
+            context.coordinator.reportHeight(for: textView, in: scrollView)
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    private func configure(
+        _ textView: CPSLPasteAwareTextView,
+        in scrollView: CPSLDropAwareScrollView
+    ) {
+        textView.canPasteAttachments = canPasteAttachments
+        textView.pasteAttachments = onPasteAttachments
+        textView.textContainerInset = NSSize(width: CPSLTheme.medium, height: verticalInset)
+        textView.isEditable = !isDisabled
+        textView.isSelectable = !isDisabled
+        textView.unregisterDraggedTypes()
+        textView.isAutomaticQuoteSubstitutionEnabled = !isCommandInput
+        textView.isAutomaticDashSubstitutionEnabled = !isCommandInput
+        textView.isAutomaticSpellingCorrectionEnabled = !isCommandInput
+        textView.isContinuousSpellCheckingEnabled = !isCommandInput
+
+        scrollView.isFileDropEnabled = !isDisabled
+        scrollView.onDropFiles = onDropFiles
+        scrollView.onDropTargeted = onDropTargeted
+    }
+
+    private func makeContextMenu(target: NSTextView) -> NSMenu {
+        let menu = NSMenu()
+        menu.addItem(
+            withTitle: String(localized: "Cut", comment: "Context menu action for the prompt field."),
+            action: #selector(NSText.cut(_:)),
+            keyEquivalent: ""
+        )
+        menu.addItem(
+            withTitle: String(localized: "Copy", comment: "Context menu action for the prompt field."),
+            action: #selector(NSText.copy(_:)),
+            keyEquivalent: ""
+        )
+        menu.addItem(
+            withTitle: String(localized: "Paste", comment: "Context menu action for the prompt field."),
+            action: #selector(NSText.paste(_:)),
+            keyEquivalent: ""
+        )
+        menu.addItem(.separator())
+        menu.addItem(
+            withTitle: String(localized: "Select All", comment: "Context menu action for the prompt field."),
+            action: #selector(NSText.selectAll(_:)),
+            keyEquivalent: ""
+        )
+        for item in menu.items where !item.isSeparatorItem {
+            item.target = target
+        }
+        return menu
+    }
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var parent: CPSLPromptTextView
+        var focusPromptRequest = 0
+        var dismissKeyboardRequest = 0
+
+        init(parent: CPSLPromptTextView) {
+            self.parent = parent
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView,
+                  let scrollView = textView.enclosingScrollView
+            else {
+                return
+            }
+            parent.text = textView.string
+            reportHeight(for: textView, in: scrollView)
+        }
+
+        func reportHeight(for textView: NSTextView, in scrollView: NSScrollView) {
+            guard let textContainer = textView.textContainer,
+                  let layoutManager = textView.layoutManager
+            else {
+                return
+            }
+            layoutManager.ensureLayout(for: textContainer)
+            let height = ceil(
+                layoutManager.usedRect(for: textContainer).height + textView.textContainerInset.height * 2
+            )
+            scrollView.hasVerticalScroller = height > parent.maxHeight
+            DispatchQueue.main.async {
+                self.parent.onHeightChange(height)
+            }
+        }
+    }
+}
+#endif

--- a/app/apple/herm/Views/Composer/CPSLPasteboardAttachmentImporter.swift
+++ b/app/apple/herm/Views/Composer/CPSLPasteboardAttachmentImporter.swift
@@ -1,0 +1,226 @@
+import Foundation
+import UniformTypeIdentifiers
+
+#if canImport(AppKit)
+import AppKit
+#elseif canImport(UIKit)
+import UIKit
+#endif
+
+enum CPSLPasteboardAttachmentImporter {
+    static func canImportCurrent() -> Bool {
+#if os(macOS)
+        let pasteboard = NSPasteboard.general
+        if pasteboard.canReadObject(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]
+        ) {
+            return true
+        }
+        if NSImage(pasteboard: pasteboard) != nil {
+            return true
+        }
+        guard let html = pasteboard.string(forType: .html) else {
+            return false
+        }
+        return imageSource(from: html) != nil
+#elseif canImport(UIKit)
+        let pasteboard = UIPasteboard.general
+        return pasteboard.urls?.contains(where: \.isFileURL) == true ||
+            pasteboard.hasImages
+#else
+        return false
+#endif
+    }
+
+    @discardableResult
+    static func importCurrent(into model: CPSLChatModel) -> Bool {
+#if os(macOS)
+        let pasteboard = NSPasteboard.general
+        let fileURLs = pasteboard.readObjects(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]
+        ) as? [URL] ?? []
+        if !fileURLs.isEmpty {
+            fileURLs.forEach(model.addAttachment)
+            return true
+        }
+        if let image = NSImage(pasteboard: pasteboard),
+           let data = pngData(from: image) {
+            model.addAttachment(data: data, preferredName: pastedImageFileName())
+            return true
+        }
+        guard let html = pasteboard.string(forType: .html),
+              let source = imageSource(from: html)
+        else {
+            return false
+        }
+        importImage(from: source, into: model)
+        return true
+#elseif canImport(UIKit)
+        let pasteboard = UIPasteboard.general
+        let fileURLs = pasteboard.urls?.filter(\.isFileURL) ?? []
+        if !fileURLs.isEmpty {
+            fileURLs.forEach(model.addAttachment)
+            return true
+        }
+        guard let images = pasteboard.images, !images.isEmpty else {
+            return false
+        }
+        for image in images {
+            if let data = image.pngData() {
+                model.addAttachment(data: data, preferredName: pastedImageFileName())
+            }
+        }
+        return true
+#else
+        return false
+#endif
+    }
+
+    static func pasteboardString() -> String? {
+#if os(macOS)
+        NSPasteboard.general.string(forType: .string)
+#elseif canImport(UIKit)
+        UIPasteboard.general.string
+#else
+        nil
+#endif
+    }
+
+#if os(macOS)
+    private enum ImageSource {
+        case data(Data, fileExtension: String)
+        case url(URL)
+    }
+
+    private static func importImage(from source: ImageSource, into model: CPSLChatModel) {
+        switch source {
+        case .data(let data, let fileExtension):
+            model.addAttachment(
+                data: data,
+                preferredName: pastedImageFileName(fileExtension: fileExtension)
+            )
+        case .url(let url) where url.isFileURL:
+            model.addAttachment(from: url)
+        case .url(let url):
+            Task {
+                do {
+                    let (data, response) = try await URLSession.shared.data(from: url)
+                    if let httpResponse = response as? HTTPURLResponse,
+                       !(200...299).contains(httpResponse.statusCode) {
+                        throw URLError(.badServerResponse)
+                    }
+                    guard NSImage(data: data) != nil else {
+                        throw URLError(.cannotDecodeContentData)
+                    }
+                    model.addAttachment(
+                        data: data,
+                        preferredName: pastedImageFileName(
+                            fileExtension: imageFileExtension(for: response, sourceURL: url)
+                        )
+                    )
+                } catch {
+                    model.showComingSoon("Could not paste the copied image: \(error.localizedDescription)")
+                }
+            }
+        }
+    }
+
+    private static func imageSource(from html: String) -> ImageSource? {
+        let pattern = #"<img\b[^>]*\bsrc\s*=\s*(?:\"([^\"]+)\"|'([^']+)'|([^\s>]+))"#
+        guard let expression = try? NSRegularExpression(
+            pattern: pattern,
+            options: [.caseInsensitive, .dotMatchesLineSeparators]
+        ) else {
+            return nil
+        }
+        let searchRange = NSRange(html.startIndex..<html.endIndex, in: html)
+        guard let match = expression.firstMatch(in: html, range: searchRange) else {
+            return nil
+        }
+
+        let htmlString = html as NSString
+        let rawSource = (1..<match.numberOfRanges)
+            .map { match.range(at: $0) }
+            .first { $0.location != NSNotFound }
+            .map { htmlString.substring(with: $0) }
+        guard let rawSource,
+              let decodedSource = decodeHTMLEntities(rawSource)
+        else {
+            return nil
+        }
+
+        if decodedSource.lowercased().hasPrefix("data:image/") {
+            return dataImageSource(from: decodedSource)
+        }
+        guard let url = URL(string: decodedSource),
+              url.isFileURL || url.scheme == "https" || url.scheme == "http"
+        else {
+            return nil
+        }
+        return .url(url)
+    }
+
+    private static func dataImageSource(from source: String) -> ImageSource? {
+        let components = source.split(separator: ",", maxSplits: 1, omittingEmptySubsequences: false)
+        guard components.count == 2,
+              components[0].lowercased().hasSuffix(";base64"),
+              let data = Data(base64Encoded: String(components[1]), options: .ignoreUnknownCharacters)
+        else {
+            return nil
+        }
+        let mimeType = components[0]
+            .dropFirst("data:".count)
+            .split(separator: ";", maxSplits: 1)
+            .first
+            .map(String.init)
+        let fileExtension = mimeType
+            .flatMap { UTType(mimeType: $0) }?
+            .preferredFilenameExtension ?? "png"
+        return .data(data, fileExtension: fileExtension)
+    }
+
+    private static func decodeHTMLEntities(_ string: String) -> String? {
+        guard let data = string.data(using: .utf8),
+              let decoded = try? NSAttributedString(
+                  data: data,
+                  options: [
+                      .documentType: NSAttributedString.DocumentType.html,
+                      .characterEncoding: String.Encoding.utf8.rawValue,
+                  ],
+                  documentAttributes: nil
+              )
+        else {
+            return nil
+        }
+        return decoded.string
+    }
+
+    private static func imageFileExtension(for response: URLResponse, sourceURL: URL) -> String {
+        if let mimeType = response.mimeType,
+           let fileExtension = UTType(mimeType: mimeType)?.preferredFilenameExtension {
+            return fileExtension
+        }
+        if let imageType = UTType(filenameExtension: sourceURL.pathExtension),
+           imageType.conforms(to: .image),
+           let fileExtension = imageType.preferredFilenameExtension {
+            return fileExtension
+        }
+        return "png"
+    }
+
+    private static func pngData(from image: NSImage) -> Data? {
+        guard let tiffData = image.tiffRepresentation,
+              let representation = NSBitmapImageRep(data: tiffData)
+        else {
+            return nil
+        }
+        return representation.representation(using: .png, properties: [:])
+    }
+#endif
+
+    private static func pastedImageFileName(fileExtension: String = "png") -> String {
+        "pasted-image-\(UUID().uuidString.prefix(8)).\(fileExtension)"
+    }
+}

--- a/app/apple/herm/Views/Composer/CPSLPromptComposerView.swift
+++ b/app/apple/herm/Views/Composer/CPSLPromptComposerView.swift
@@ -12,6 +12,20 @@ import AppKit
 #endif
 
 #if canImport(UIKit)
+private final class CPSLPasteAwareTextView: UITextView {
+    var pasteAttachments: (() -> Bool)?
+
+    override func paste(_ sender: Any?) {
+        if pasteAttachments?() == true {
+            return
+        }
+        guard !UIPasteboard.general.hasImages else {
+            return
+        }
+        super.paste(sender)
+    }
+}
+
 private struct CPSLPromptTextView: UIViewRepresentable {
     @Binding var text: String
     let isCommandInput: Bool
@@ -20,11 +34,13 @@ private struct CPSLPromptTextView: UIViewRepresentable {
     let maxHeight: CGFloat
     let focusPromptRequest: Int
     let dismissKeyboardRequest: Int
+    let onPasteAttachments: () -> Bool
     let onHeightChange: (CGFloat) -> Void
 
-    func makeUIView(context: Context) -> UITextView {
-        let textView = UITextView()
+    func makeUIView(context: Context) -> CPSLPasteAwareTextView {
+        let textView = CPSLPasteAwareTextView()
         textView.delegate = context.coordinator
+        textView.pasteAttachments = onPasteAttachments
         textView.backgroundColor = .clear
         textView.textColor = UIColor(CPSLTheme.text)
         textView.tintColor = UIColor(CPSLTheme.text)
@@ -39,10 +55,12 @@ private struct CPSLPromptTextView: UIViewRepresentable {
         return textView
     }
 
-    func updateUIView(_ textView: UITextView, context: Context) {
+    func updateUIView(_ textView: CPSLPasteAwareTextView, context: Context) {
         context.coordinator.parent = self
+        textView.pasteAttachments = onPasteAttachments
 
-        if textView.text != text {
+        let didChangeText = textView.text != text
+        if didChangeText {
             textView.text = text
         }
 
@@ -72,7 +90,9 @@ private struct CPSLPromptTextView: UIViewRepresentable {
             textView.reloadInputViews()
         }
 
-        context.coordinator.reportHeight(for: textView)
+        if didChangeText {
+            context.coordinator.reportHeight(for: textView)
+        }
     }
 
     func makeCoordinator() -> Coordinator {
@@ -157,6 +177,7 @@ struct CPSLPromptComposerView: View {
     @State private var isCameraPresented = false
     @State private var selectedPhotos: [PhotosPickerItem] = []
     @State private var pendingPhotoImportCount = 0
+    @State private var isDropTargeted = false
     @FocusState private var isPromptFocused: Bool
 
     private var dictation: CPSLDictationService {
@@ -225,10 +246,12 @@ struct CPSLPromptComposerView: View {
                     attachments: model.composerAttachments,
                     onRemove: model.removeComposerAttachment
                 )
+                .frame(height: CPSLTheme.controlSize)
                 .padding(.bottom, CPSLTheme.small)
             }
-            if isAddingAttachment {
+            if isAddingAttachment && model.composerAttachments.isEmpty {
                 CPSLAttachmentImportStatus()
+                    .frame(height: CPSLTheme.controlSize)
                     .padding(.bottom, CPSLTheme.small)
             }
             if isCompact {
@@ -245,7 +268,7 @@ struct CPSLPromptComposerView: View {
         .contentShape(RoundedRectangle(cornerRadius: CPSLTheme.composerRadius, style: .continuous))
         .contextMenu {
             Button {
-                pastePromptText()
+                pastePromptContent()
             } label: {
                 Label("Paste", systemImage: "doc.on.clipboard")
             }
@@ -262,6 +285,11 @@ struct CPSLPromptComposerView: View {
             in: RoundedRectangle(cornerRadius: CPSLTheme.composerRadius, style: .continuous),
             tint: CPSLGlassTuning.tint(CPSLTheme.background, opacity: 0.54),
             strokeOpacity: 0.055
+        )
+        .cpslAttachmentDropDestination(
+            isTargeted: $isDropTargeted,
+            isEnabled: !model.isBusy,
+            onDropFiles: importDroppedFiles
         )
     }
 
@@ -283,7 +311,25 @@ struct CPSLPromptComposerView: View {
                 verticalInset: promptVerticalInset,
                 maxHeight: promptMaxTextHeight,
                 focusPromptRequest: focusPromptRequest,
-                dismissKeyboardRequest: dismissKeyboardRequest
+                dismissKeyboardRequest: dismissKeyboardRequest,
+                onPasteAttachments: importPasteboardAttachments
+            ) { height in
+                promptContentHeight = height
+            }
+            .frame(height: promptTextHeight)
+#elseif os(macOS)
+            CPSLPromptTextView(
+                text: $model.promptText,
+                isCommandInput: isCommandInput,
+                isDisabled: model.isBusy,
+                verticalInset: promptVerticalInset,
+                maxHeight: promptMaxTextHeight,
+                focusPromptRequest: focusPromptRequest,
+                dismissKeyboardRequest: dismissKeyboardRequest,
+                canPasteAttachments: canImportPasteboardAttachments,
+                onPasteAttachments: importPasteboardAttachments,
+                onDropFiles: importDroppedFiles,
+                onDropTargeted: { isDropTargeted = $0 }
             ) { height in
                 promptContentHeight = height
             }
@@ -560,17 +606,39 @@ struct CPSLPromptComposerView: View {
         isPromptFocused = true
     }
 
-    private func pastePromptText() {
+    private func pastePromptContent() {
         guard !model.isBusy else {
             return
         }
-        guard let text = Self.pasteboardString(), !text.isEmpty else {
+        if importPasteboardAttachments() {
+            return
+        }
+        guard let text = CPSLPasteboardAttachmentImporter.pasteboardString(), !text.isEmpty else {
             focusPrompt()
             return
         }
 
         model.promptText += text
         focusPrompt()
+    }
+
+    private func importDroppedFiles(_ urls: [URL]) {
+        for url in urls where url.isFileURL {
+            model.addAttachment(from: url)
+        }
+    }
+
+#if os(macOS)
+    private func canImportPasteboardAttachments() -> Bool {
+        !model.isBusy && CPSLPasteboardAttachmentImporter.canImportCurrent()
+    }
+#endif
+
+    private func importPasteboardAttachments() -> Bool {
+        guard !model.isBusy else {
+            return false
+        }
+        return CPSLPasteboardAttachmentImporter.importCurrent(into: model)
     }
 
     private func importFiles(_ result: Result<[URL], Error>) {
@@ -606,16 +674,6 @@ struct CPSLPromptComposerView: View {
                 }
             }
         }
-    }
-
-    private static func pasteboardString() -> String? {
-#if os(macOS)
-        NSPasteboard.general.string(forType: .string)
-#elseif canImport(UIKit)
-        UIPasteboard.general.string
-#else
-        nil
-#endif
     }
 
     private static func photoFileName(fileExtension: String) -> String {


### PR DESCRIPTION
## Summary

<img width="952" height="268" alt="Capture d’écran 2026-07-15 à 18 27 50" src="https://github.com/user-attachments/assets/f46c0015-82b5-4c4b-9ed6-2a3bcdcaa3a9" />

- add image-aware paste handling to the iOS composer
- import clipboard images and file URLs as persistent conversation attachments
- support file drag and drop in the composer on iOS and macOS
- extract the macOS prompt text view to keep platform-specific paste and drop handling isolated
- keep attachment import feedback stable while files are being added

## Testing

- Passed: Debug build for a generic iOS Simulator destination with code signing disabled
- Partial: the macOS Debug build compiled the app changes, then failed in the existing Copy CPSL PDFium phase because the cached PDFium artifact does not contain macOS arm64/x86_64 targets

## Scope

- does not include Xcode project settings or shared scheme changes