### PR TITLE
Polish Apple agent runtime, previews, and conversations

### DIFF
--- a/app/apple/herm.xcodeproj/project.pbxproj
+++ b/app/apple/herm.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		850B3BFA2FE8390E00A21FC8 /* cpsl.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 850B3BF92FE8390E00A21FC8 /* cpsl.xcframework */; };
 		850B3BFB2FE8390E00A21FC8 /* cpsl.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 850B3BF92FE8390E00A21FC8 /* cpsl.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		850B3C062FE8390F00A21FDD /* BuildCPSLAnchor.c in Sources */ = {isa = PBXBuildFile; fileRef = 850B3C052FE8390F00A21FDC /* BuildCPSLAnchor.c */; };
-		85A100012FEA000000000001 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 85A100002FEA000000000001 /* libsqlite3.tbd */; };
 		85A100052FEA000000000005 /* herm/Generated/CPSLEnvConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85A100042FEA000000000004 /* herm/Generated/CPSLEnvConstants.swift */; };
 /* End PBXBuildFile section */
 
@@ -49,7 +48,6 @@
 		850B3BF92FE8390E00A21FC8 /* cpsl.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = cpsl.xcframework; path = "../../scripts/cpsl-xcframework-placeholder/cpsl.xcframework"; sourceTree = "<group>"; };
 		850B3C042FE8390F00A21FDB /* libBuildCPSL.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libBuildCPSL.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		850B3C052FE8390F00A21FDC /* BuildCPSLAnchor.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = BuildCPSLAnchor.c; sourceTree = "<group>"; };
-		85A100002FEA000000000001 /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
 		85A100042FEA000000000004 /* herm/Generated/CPSLEnvConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = herm/Generated/CPSLEnvConstants.swift; sourceTree = SOURCE_ROOT; };
 		85D75D332FE62B6F0095BAB2 /* herm.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = herm.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F1E22F983002D2D100D9F1DD /* hermTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = hermTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -96,7 +94,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				850B3BFA2FE8390E00A21FC8 /* cpsl.xcframework in Frameworks */,
-				85A100012FEA000000000001 /* libsqlite3.tbd in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -122,7 +119,6 @@
 			isa = PBXGroup;
 			children = (
 				850B3BF92FE8390E00A21FC8 /* cpsl.xcframework */,
-				85A100002FEA000000000001 /* libsqlite3.tbd */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/app/apple/herm.xcodeproj/xcshareddata/xcschemes/herm.xcscheme
+++ b/app/apple/herm.xcodeproj/xcshareddata/xcschemes/herm.xcscheme
@@ -44,7 +44,7 @@
       </Testables>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"

--- a/app/apple/herm/Design/CPSLTheme.swift
+++ b/app/apple/herm/Design/CPSLTheme.swift
@@ -14,6 +14,7 @@ enum CPSLTheme {
     static let mutedText = Color(red: 0.345, green: 0.369, blue: 0.447)
     static let mauve = Color(red: 0.49, green: 0.42, blue: 0.78)
     static let success = Color(red: 0.22, green: 0.62, blue: 0.39)
+    static let warning = Color(red: 0.90, green: 0.62, blue: 0.22)
     static let danger = Color(red: 0.86, green: 0.28, blue: 0.32)
     static let command = Color(red: 0.076, green: 0.091, blue: 0.145)
     static let error = Color(red: 0.36, green: 0.16, blue: 0.20)

--- a/app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
+++ b/app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
@@ -3,15 +3,8 @@ import Foundation
 @MainActor
 extension CPSLChatModel {
     func runProviderLoop(_ context: inout CPSLProviderLoopContext) async throws {
-        var toolStatusNodeID: String?
-        var toolStatus = CPSLToolStatusPayload.running()
-        var hasUnresolvedToolFailure = false
+        var pendingFailures: [CPSLToolStatusInvocation] = []
         clearActiveToolStatus()
-        defer {
-            if !Task.isCancelled {
-                clearActiveToolStatus()
-            }
-        }
 
         for iteration in 0..<context.config.maxToolRounds {
             try Task.checkCancellation()
@@ -90,66 +83,47 @@ extension CPSLChatModel {
             }
 
             guard !completion.toolCalls.isEmpty else {
-                if hasUnresolvedToolFailure, let toolStatusNodeID {
-                    toolStatus.state = .failed
-                    try await updateToolStatus(toolStatus, nodeID: toolStatusNodeID, store: context.store)
+                if !pendingFailures.isEmpty {
+                    try await finishActiveToolStatus(as: .failed)
                 }
                 if completion.text.isEmpty {
                     try await appendProviderLoopError("Provider returned an empty response.", context: &context)
                 }
+                clearActiveToolStatus()
                 return
             }
 
-            var statusSummary = completion.toolCalls.first.map {
-                CPSLAgentToolFormatting.statusSummary(for: $0, assistantText: completion.text)
-            } ?? CPSLAgentToolFormatting.defaultStatusSummary
+            var statusSummary = CPSLAgentToolFormatting.defaultStatusSummary
             let assistantToolMessage = CPSLOpenAIMessage.assistant(
                 content: completion.text.isEmpty ? nil : completion.text,
                 toolCalls: completion.toolCalls
             )
-
-            if let toolStatusNodeID {
-                toolStatus.state = .running
-                toolStatus.summary = statusSummary
-                try await updateToolStatus(toolStatus, nodeID: toolStatusNodeID, store: context.store)
-            } else {
-                toolStatus = CPSLToolStatusPayload.running(summary: statusSummary)
-                let statusNode = try await context.store.appendNode(
-                    conversationID: context.conversationID,
-                    parentID: context.parentID,
-                    draft: CPSLNodeAppendDraft(
-                        role: .toolStatus,
-                        title: nil,
-                        body: toolStatus.encodedBody(),
-                        model: completion.model,
-                        providerMessage: nil
-                    )
-                )
-                toolStatusNodeID = statusNode.id
-                activeToolStatusNodeID = statusNode.id
-                activeToolStatusConversationID = context.conversationID
-                activeToolStatusPayload = toolStatus
-                activeToolStatusStore = context.store
-                context.parentID = statusNode.id
-                context.onParentIDChange(context.parentID)
-                if let message = statusNode.chatMessage {
-                    messages.append(message)
-                }
-            }
-
             var executedToolCalls: [(toolCall: CPSLOpenAIToolCall, result: CPSLToolExecutionResult)] = []
 
             for toolCall in completion.toolCalls {
                 try Task.checkCancellation()
+                let retryPresentation: (webVisits: [CPSLWebSearchVisit], activityID: UUID)
+                if pendingFailures.isEmpty {
+                    retryPresentation = ([], UUID())
+                } else {
+                    retryPresentation = try await supersedeActiveToolStatus()
+                }
                 statusSummary = CPSLAgentToolFormatting.statusSummary(
                     for: toolCall,
                     assistantText: completion.text
                 )
-                toolStatus.state = .running
-                toolStatus.summary = statusSummary
-                if let toolStatusNodeID {
-                    try await updateToolStatus(toolStatus, nodeID: toolStatusNodeID, store: context.store)
-                }
+                var toolStatus = CPSLToolStatusPayload(
+                    state: .running,
+                    summary: statusSummary,
+                    invocations: pendingFailures,
+                    webVisits: retryPresentation.webVisits,
+                    activityID: retryPresentation.activityID
+                )
+                let toolStatusNodeID = try await appendToolStatus(
+                    toolStatus,
+                    model: completion.model,
+                    context: &context
+                )
 
                 let toolResult = await executeToolCall(
                     toolCall,
@@ -164,26 +138,27 @@ extension CPSLChatModel {
                 )
                 try Task.checkCancellation()
                 executedToolCalls.append((toolCall, toolResult))
+                toolStatus.invocations.append(
+                    CPSLToolStatusInvocation(traceInvocation: toolResult.traceInvocation)
+                )
+                toolStatus.invocations = Array(toolStatus.invocations.suffix(recentToolResultsToKeep))
+                if toolResult.isError {
+                    pendingFailures = toolStatus.invocations
+                    toolStatus.state = .running
+                } else {
+                    pendingFailures.removeAll(keepingCapacity: true)
+                    toolStatus.state = .succeeded
+                }
+                toolStatus.summary = statusSummary
+                try await updateToolStatus(toolStatus, nodeID: toolStatusNodeID, store: context.store)
+                if !toolResult.isError {
+                    clearActiveToolStatus()
+                }
                 try await context.store.recordToolInvocation(
                     conversationID: context.conversationID,
                     nodeID: toolStatusNodeID,
                     invocation: toolResult.traceInvocation
                 )
-                toolStatus.invocations.append(
-                    CPSLToolStatusInvocation(traceInvocation: toolResult.traceInvocation)
-                )
-                toolStatus.invocations = Array(toolStatus.invocations.suffix(4))
-                if toolResult.isError {
-                    hasUnresolvedToolFailure = true
-                    toolStatus.state = .running
-                } else {
-                    hasUnresolvedToolFailure = false
-                    toolStatus.state = .succeeded
-                }
-                toolStatus.summary = statusSummary
-                if let toolStatusNodeID {
-                    try await updateToolStatus(toolStatus, nodeID: toolStatusNodeID, store: context.store)
-                }
             }
 
             try await appendToolReplayBlock(
@@ -195,19 +170,62 @@ extension CPSLChatModel {
                 ),
                 context: &context
             )
-            toolStatus.summary = statusSummary
-            toolStatus.state = hasUnresolvedToolFailure ? .running : .succeeded
-            if let toolStatusNodeID {
-                try await updateToolStatus(toolStatus, nodeID: toolStatusNodeID, store: context.store)
-            }
         }
 
         try Task.checkCancellation()
-        if hasUnresolvedToolFailure, let toolStatusNodeID {
-            toolStatus.state = .failed
-            try await updateToolStatus(toolStatus, nodeID: toolStatusNodeID, store: context.store)
+        if !pendingFailures.isEmpty {
+            try await finishActiveToolStatus(as: .failed)
         }
         try await synthesizeAfterToolLimit(&context)
+        clearActiveToolStatus()
+    }
+
+    private func appendToolStatus(
+        _ payload: CPSLToolStatusPayload,
+        model: String,
+        context: inout CPSLProviderLoopContext
+    ) async throws -> String {
+        let statusNode = try await context.store.appendNode(
+            conversationID: context.conversationID,
+            parentID: context.parentID,
+            draft: CPSLNodeAppendDraft(
+                role: .toolStatus,
+                title: nil,
+                body: payload.encodedBody(),
+                model: model,
+                providerMessage: nil
+            )
+        )
+        activeToolStatusNodeID = statusNode.id
+        activeToolStatusConversationID = context.conversationID
+        activeToolStatusPayload = payload
+        activeToolStatusStore = context.store
+        context.parentID = statusNode.id
+        context.onParentIDChange(statusNode.id)
+        if let message = statusNode.chatMessage {
+            messages.append(message)
+        }
+        return statusNode.id
+    }
+
+    private func supersedeActiveToolStatus() async throws -> (
+        webVisits: [CPSLWebSearchVisit],
+        activityID: UUID
+    ) {
+        guard let nodeID = activeToolStatusNodeID,
+              var payload = activeToolStatusPayload,
+              let store = activeToolStatusStore
+        else {
+            clearActiveToolStatus()
+            return ([], UUID())
+        }
+        payload.isSuperseded = true
+        try await updateToolStatus(payload, nodeID: nodeID, store: store)
+        let presentation = (
+            webVisits: payload.webVisits,
+            activityID: payload.activityID ?? UUID(uuidString: nodeID) ?? UUID()
+        )
+        return presentation
     }
 
     private func appendToolReplayBlock(
@@ -418,7 +436,10 @@ extension CPSLChatModel {
         activeToolStatusStore = nil
     }
 
-    func markActiveToolStatusStopped() async {
+    private func finishActiveToolStatus(
+        as state: CPSLToolStatusState,
+        summary: String? = nil
+    ) async throws {
         guard let nodeID = activeToolStatusNodeID,
               var payload = activeToolStatusPayload,
               let store = activeToolStatusStore
@@ -426,10 +447,36 @@ extension CPSLChatModel {
             clearActiveToolStatus()
             return
         }
-        payload.state = .failed
-        payload.summary = String(localized: "Stopped")
-        try? await updateToolStatus(payload, nodeID: nodeID, store: store)
+        payload.state = state
+        payload.isSuperseded = false
+        if let summary {
+            payload.summary = summary
+        }
+        try await updateToolStatus(payload, nodeID: nodeID, store: store)
         clearActiveToolStatus()
+    }
+
+    func markActiveToolStatusStopped() async {
+        do {
+            try await finishActiveToolStatus(
+                as: .interrupted,
+                summary: String(localized: "Stopped")
+            )
+        } catch {
+            clearActiveToolStatus()
+        }
+    }
+
+    func markActiveToolStatusFailed() async {
+        guard activeToolStatusPayload?.invocations.last?.isError == true else {
+            clearActiveToolStatus()
+            return
+        }
+        do {
+            try await finishActiveToolStatus(as: .failed)
+        } catch {
+            clearActiveToolStatus()
+        }
     }
 
     private func preparedRequestMessages(_ preparation: CPSLRequestPreparation) async -> [CPSLOpenAIMessage] {

--- a/app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
+++ b/app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
@@ -27,21 +27,35 @@ extension CPSLChatModel {
                 )
             )
             try Task.checkCancellation()
-            isSuppressingAssistantStream = false
-            let completion = try await context.client.streamChat(
-                CPSLOpenAIStreamRequest(
-                    messages: requestMessages,
-                    tools: CPSLOpenAITool.availableTools(
-                        allowsSubagents: context.config.maxAgentDepth > 0,
-                        currentDirectory: sandboxDirectory
-                    ),
-                    maxTokens: context.config.maxOutputTokens
-                )
-            ) { event in
+            let tools = CPSLOpenAITool.availableTools(
+                allowsSubagents: context.config.maxAgentDepth > 0,
+                currentDirectory: sandboxDirectory
+            )
+            isSuppressingAssistantStream = !tools.isEmpty
+            let request = CPSLOpenAIStreamRequest(
+                messages: requestMessages,
+                tools: tools,
+                maxTokens: context.config.maxOutputTokens
+            )
+            try await context.store.recordProviderRequest(
+                conversationID: context.conversationID,
+                model: context.config.model,
+                messages: request.messages,
+                tools: tools,
+                maxTokens: request.maxTokens,
+                scope: "main.turn.\(iteration + 1)"
+            )
+            let completion = try await context.client.streamChat(request) { event in
                 self.handleProviderStreamEvent(event)
             }
+            try await context.store.recordProviderResponse(
+                conversationID: context.conversationID,
+                completion: completion,
+                scope: "main.turn.\(iteration + 1)"
+            )
             try Task.checkCancellation()
 
+            presentCompletedAssistantIfNeeded(completion)
             await finishTypewriter()
             if !completion.toolCalls.isEmpty {
                 discardStreamingAssistantIfNeeded()
@@ -113,6 +127,7 @@ extension CPSLChatModel {
                 )
                 toolStatusNodeID = statusNode.id
                 activeToolStatusNodeID = statusNode.id
+                activeToolStatusConversationID = context.conversationID
                 activeToolStatusPayload = toolStatus
                 activeToolStatusStore = context.store
                 context.parentID = statusNode.id
@@ -142,11 +157,22 @@ extension CPSLChatModel {
                         client: context.client,
                         config: context.config,
                         agentDepth: 0,
-                        requestDirectory: sandboxDirectory
+                        requestDirectory: sandboxDirectory,
+                        traceStore: context.store,
+                        conversationID: context.conversationID
                     )
                 )
                 try Task.checkCancellation()
                 executedToolCalls.append((toolCall, toolResult))
+                try await context.store.recordToolInvocation(
+                    conversationID: context.conversationID,
+                    nodeID: toolStatusNodeID,
+                    invocation: toolResult.traceInvocation
+                )
+                toolStatus.invocations.append(
+                    CPSLToolStatusInvocation(traceInvocation: toolResult.traceInvocation)
+                )
+                toolStatus.invocations = Array(toolStatus.invocations.suffix(4))
                 if toolResult.isError {
                     hasUnresolvedToolFailure = true
                     toolStatus.state = .running
@@ -154,13 +180,10 @@ extension CPSLChatModel {
                     hasUnresolvedToolFailure = false
                     toolStatus.state = .succeeded
                 }
-#if DEBUG
-                toolStatus.invocations.append(toolResult.debugInvocation)
                 toolStatus.summary = statusSummary
                 if let toolStatusNodeID {
                     try await updateToolStatus(toolStatus, nodeID: toolStatusNodeID, store: context.store)
                 }
-#endif
             }
 
             try await appendToolReplayBlock(
@@ -266,15 +289,28 @@ extension CPSLChatModel {
             )
         )
         isSuppressingAssistantStream = false
-        let completion = try await context.client.streamChat(
-            CPSLOpenAIStreamRequest(
-                messages: requestMessages,
-                tools: [],
-                maxTokens: context.config.maxOutputTokens
-            )
-        ) { event in
+        let request = CPSLOpenAIStreamRequest(
+            messages: requestMessages,
+            tools: [],
+            maxTokens: context.config.maxOutputTokens
+        )
+        try await context.store.recordProviderRequest(
+            conversationID: context.conversationID,
+            model: context.config.model,
+            messages: request.messages,
+            tools: [],
+            maxTokens: request.maxTokens,
+            scope: "main.synthesis"
+        )
+        let completion = try await context.client.streamChat(request) { event in
             self.handleProviderStreamEvent(event)
         }
+        try await context.store.recordProviderResponse(
+            conversationID: context.conversationID,
+            completion: completion,
+            scope: "main.synthesis"
+        )
+        presentCompletedAssistantIfNeeded(completion)
         await finishTypewriter()
 
         guard !completion.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -322,22 +358,26 @@ extension CPSLChatModel {
         activeToolStatusStore = store
         activeToolStatusRevision += 1
         let revision = activeToolStatusRevision
-        let payloadForEncoding = effectivePayload
-        let encodedBodies = await Task.detached(priority: .utility) {
-            payloadForEncoding.encodedBodies()
-        }.value
+        let body = effectivePayload.encodedBody()
+        guard let conversationID = activeToolStatusConversationID else {
+            return
+        }
+        try await store.updateNodeBody(
+            conversationID: conversationID,
+            id: nodeID,
+            body: body
+        )
         guard activeToolStatusNodeID == nodeID,
               activeToolStatusRevision == revision
         else {
             return
         }
-        try await store.updateNodeBody(id: nodeID, body: encodedBodies.persisted)
         guard let messageID = UUID(uuidString: nodeID),
                 let index = messages.firstIndex(where: { $0.id == messageID })
         else {
             return
         }
-        messages[index].body = encodedBodies.presentation
+        messages[index].body = body
     }
 
     private func appendUniqueThoughtIfNeeded(
@@ -373,6 +413,7 @@ extension CPSLChatModel {
     private func clearActiveToolStatus() {
         activeToolStatusRevision += 1
         activeToolStatusNodeID = nil
+        activeToolStatusConversationID = nil
         activeToolStatusPayload = nil
         activeToolStatusStore = nil
     }
@@ -513,6 +554,17 @@ extension CPSLChatModel {
         }
     }
 
+    private func presentCompletedAssistantIfNeeded(_ completion: CPSLOpenAICompletion) {
+        guard completion.toolCalls.isEmpty,
+              streamingAssistantMessageID == nil,
+              !completion.text.isEmpty
+        else {
+            return
+        }
+        isSuppressingAssistantStream = false
+        queueAssistantDelta(completion.text)
+    }
+
     private func handleProviderStreamEvent(_ event: CPSLOpenAIStreamEvent) {
         switch event {
         case .textDelta(let delta):
@@ -614,7 +666,7 @@ extension CPSLChatModel {
                 providerContent: #"{"ok":false,"error":"Unsupported tool."}"#,
                 displayBody: "Unsupported tool: \(toolCall.function.name)",
                 isError: true,
-                debugInvocation: debugInvocation(
+                traceInvocation: traceInvocation(
                     for: toolCall,
                     displayBody: "Unsupported tool: \(toolCall.function.name)",
                     isError: true
@@ -635,7 +687,7 @@ extension CPSLChatModel {
             providerContent: providerToolContent(ok: false, output: nil, error: displayBody),
             displayBody: displayBody,
             isError: true,
-            debugInvocation: debugInvocation(for: toolCall, displayBody: displayBody, isError: true)
+            traceInvocation: traceInvocation(for: toolCall, displayBody: displayBody, isError: true)
         )
     }
 
@@ -645,7 +697,7 @@ extension CPSLChatModel {
                 providerContent: #"{"ok":false,"error":"Missing source argument."}"#,
                 displayBody: "Missing source argument.",
                 isError: true,
-                debugInvocation: debugInvocation(
+                traceInvocation: traceInvocation(
                     for: toolCall,
                     displayBody: "Missing source argument.",
                     isError: true
@@ -669,7 +721,11 @@ extension CPSLChatModel {
             providerContent: CPSLAgentToolFormatting.providerContent(output),
             displayBody: displayBody,
             isError: isError,
-            debugInvocation: debugInvocation(for: toolCall, displayBody: displayBody, isError: isError)
+            traceInvocation: traceInvocation(
+                for: toolCall,
+                displayBody: CPSLAgentToolFormatting.completeBody(output),
+                isError: isError
+            )
         )
     }
 
@@ -683,7 +739,7 @@ extension CPSLChatModel {
                 providerContent: providerToolContent(ok: false, output: nil, error: message),
                 displayBody: message,
                 isError: true,
-                debugInvocation: debugInvocation(for: toolCall, displayBody: message, isError: true)
+                traceInvocation: traceInvocation(for: toolCall, displayBody: message, isError: true)
             )
         }
 
@@ -694,7 +750,7 @@ extension CPSLChatModel {
                 providerContent: providerToolContent(ok: false, output: nil, error: message),
                 displayBody: message,
                 isError: true,
-                debugInvocation: debugInvocation(for: toolCall, displayBody: message, isError: true)
+                traceInvocation: traceInvocation(for: toolCall, displayBody: message, isError: true)
             )
         }
 
@@ -704,7 +760,9 @@ extension CPSLChatModel {
                 client: context.client,
                 config: context.config,
                 agentDepth: childDepth,
-                requestDirectory: nil
+                requestDirectory: nil,
+                traceStore: context.traceStore,
+                conversationID: context.conversationID
             )
         )
         return CPSLToolExecutionResult(
@@ -715,7 +773,7 @@ extension CPSLChatModel {
             ),
             displayBody: result.output,
             isError: result.isError,
-            debugInvocation: debugInvocation(for: toolCall, displayBody: result.output, isError: result.isError)
+            traceInvocation: traceInvocation(for: toolCall, displayBody: result.output, isError: result.isError)
         )
     }
 
@@ -757,16 +815,36 @@ extension CPSLChatModel {
                             + "</system-reminder>"
                     )
                 ] + providerMessages
-                let completion = try await context.client.streamChat(
-                    CPSLOpenAIStreamRequest(
-                        messages: requestMessages,
-                        tools: isFinalTurn ? [] : CPSLOpenAITool.availableTools(
-                            allowsSubagents: context.agentDepth < context.config.maxAgentDepth,
-                            currentDirectory: sandboxDirectory
-                        ),
-                        maxTokens: context.config.maxOutputTokens
+                let tools = isFinalTurn ? [] : CPSLOpenAITool.availableTools(
+                    allowsSubagents: context.agentDepth < context.config.maxAgentDepth,
+                    currentDirectory: sandboxDirectory
+                )
+                let request = CPSLOpenAIStreamRequest(
+                    messages: requestMessages,
+                    tools: tools,
+                    maxTokens: context.config.maxOutputTokens
+                )
+                let scope = "subagent.\(input.mode.rawValue).turn.\(turn + 1)"
+                if let traceStore = context.traceStore,
+                   let conversationID = context.conversationID {
+                    try await traceStore.recordProviderRequest(
+                        conversationID: conversationID,
+                        model: context.config.model,
+                        messages: request.messages,
+                        tools: tools,
+                        maxTokens: request.maxTokens,
+                        scope: scope
                     )
-                ) { _ in }
+                }
+                let completion = try await context.client.streamChat(request) { _ in }
+                if let traceStore = context.traceStore,
+                   let conversationID = context.conversationID {
+                    try await traceStore.recordProviderResponse(
+                        conversationID: conversationID,
+                        completion: completion,
+                        scope: scope
+                    )
+                }
 
                 if !completion.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     textParts.append(completion.text)
@@ -813,9 +891,19 @@ extension CPSLChatModel {
                             client: context.client,
                             config: context.config,
                             agentDepth: context.agentDepth,
-                            requestDirectory: sandboxDirectory
+                            requestDirectory: sandboxDirectory,
+                            traceStore: context.traceStore,
+                            conversationID: context.conversationID
                         )
                     )
+                    if let traceStore = context.traceStore,
+                       let conversationID = context.conversationID {
+                        try await traceStore.recordToolInvocation(
+                            conversationID: conversationID,
+                            nodeID: nil,
+                            invocation: toolResult.traceInvocation
+                        )
+                    }
                     providerMessages.append(
                         CPSLOpenAIMessage.tool(id: toolCall.id, content: toolResult.providerContent)
                     )
@@ -834,6 +922,14 @@ extension CPSLChatModel {
                 false
             )
         } catch {
+            if let traceStore = context.traceStore,
+               let conversationID = context.conversationID {
+                try? await traceStore.recordError(
+                    conversationID: conversationID,
+                    message: error.localizedDescription,
+                    scope: "subagent.\(input.mode.rawValue)"
+                )
+            }
             let output = subAgentOutput(
                 CPSLSubAgentOutputDraft(
                     mode: input.mode,
@@ -873,12 +969,12 @@ extension CPSLChatModel {
         return "[agent mode:\(draft.mode.rawValue) turns:\(draft.turnsUsed)/\(draft.maxTurns)]\n\n\(output)"
     }
 
-    private func debugInvocation(
+    private func traceInvocation(
         for toolCall: CPSLOpenAIToolCall,
         displayBody: String,
         isError: Bool
-    ) -> CPSLToolStatusInvocation {
-        CPSLToolStatusInvocation(
+    ) -> CPSLToolTraceInvocation {
+        CPSLToolTraceInvocation(
             id: toolCall.id,
             name: toolCall.function.name,
             summary: CPSLAgentToolFormatting.summary(for: toolCall),

--- a/app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
+++ b/app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
@@ -45,6 +45,12 @@ extension CPSLChatModel {
             await finishTypewriter()
             if !completion.toolCalls.isEmpty {
                 discardStreamingAssistantIfNeeded()
+                try await appendUniqueThoughtIfNeeded(
+                    completion.text,
+                    toolCalls: completion.toolCalls,
+                    model: completion.model,
+                    context: &context
+                )
             }
 
             if !completion.text.isEmpty && completion.toolCalls.isEmpty {
@@ -314,17 +320,58 @@ extension CPSLChatModel {
         activeToolStatusNodeID = nodeID
         activeToolStatusPayload = effectivePayload
         activeToolStatusStore = store
-        let body = effectivePayload.encodedBody()
-        try await store.updateNodeBody(id: nodeID, body: body)
+        activeToolStatusRevision += 1
+        let revision = activeToolStatusRevision
+        let payloadForEncoding = effectivePayload
+        let encodedBodies = await Task.detached(priority: .utility) {
+            payloadForEncoding.encodedBodies()
+        }.value
+        guard activeToolStatusNodeID == nodeID,
+              activeToolStatusRevision == revision
+        else {
+            return
+        }
+        try await store.updateNodeBody(id: nodeID, body: encodedBodies.persisted)
         guard let messageID = UUID(uuidString: nodeID),
                 let index = messages.firstIndex(where: { $0.id == messageID })
         else {
             return
         }
-        messages[index].body = body
+        messages[index].body = encodedBodies.presentation
+    }
+
+    private func appendUniqueThoughtIfNeeded(
+        _ assistantText: String,
+        toolCalls: [CPSLOpenAIToolCall],
+        model: String,
+        context: inout CPSLProviderLoopContext
+    ) async throws {
+        guard let thought = CPSLAgentToolFormatting.uniqueThought(
+            from: assistantText,
+            toolCalls: toolCalls
+        ) else {
+            return
+        }
+        let node = try await context.store.appendNode(
+            conversationID: context.conversationID,
+            parentID: context.parentID,
+            draft: CPSLNodeAppendDraft(
+                role: .thought,
+                title: nil,
+                body: thought,
+                model: model,
+                providerMessage: nil
+            )
+        )
+        context.parentID = node.id
+        context.onParentIDChange(node.id)
+        if let message = node.chatMessage {
+            messages.append(message)
+        }
     }
 
     private func clearActiveToolStatus() {
+        activeToolStatusRevision += 1
         activeToolStatusNodeID = nil
         activeToolStatusPayload = nil
         activeToolStatusStore = nil
@@ -693,9 +740,14 @@ extension CPSLChatModel {
                 turnsUsed = turn + 1
                 let isFinalTurn = turn == maxTurns - 1
                 let sandboxDirectory = await service.currentDirectory()
-                let turnGuidance = isFinalTurn
-                    ? "Budget: turn \(turn + 1)/\(maxTurns). FINAL, produce summary, no tools."
-                    : "Budget: turn \(turn + 1)/\(maxTurns)."
+                let turnGuidance: String
+                if isFinalTurn {
+                    turnGuidance = "Budget: turn \(turn + 1)/\(maxTurns). FINAL: return the best usable result now; no tools."
+                } else if turn >= maxTurns - 3 {
+                    turnGuidance = "Budget: turn \(turn + 1)/\(maxTurns). Synthesize usable findings now; use another tool only for an essential missing fact."
+                } else {
+                    turnGuidance = "Budget: turn \(turn + 1)/\(maxTurns)."
+                }
                 let requestMessages = [
                     CPSLOpenAIMessage.system(
                         subAgentSystemPrompt
@@ -802,6 +854,7 @@ extension CPSLChatModel {
         let basePrompt = """
         You are a Herm sub-agent running inside the same iOS/macOS app.
         Complete the assigned task, then return a concise result. Do not ask questions.
+        Start collecting useful findings immediately and preserve them in your response. Do not spend the whole budget on discovery. For browser research, reuse one browser across queries and return the best verified result you have before the final turn.
         Mode: \(mode.rawValue). Turn budget: \(maxTurns). Agent depth: \(context.agentDepth)/\(context.config.maxAgentDepth).
         CPSL is your execution environment: a Unix-like local environment with Luau as the command interface instead of Bash. Luau is the only supported execution language.
         Use /home/herm as the default home for durable user-created files and /tmp for temporary files. User-added files remain available under /attachments/<conversation-id>. Other Unix-style directories under / remain available when the task calls for them.
@@ -888,18 +941,18 @@ private nonisolated enum CPSLAgentRequestPreparationBuilder {
         toolResultClearThreshold: Double,
         recentToolResultsToKeep: Int
     ) -> [CPSLOpenAIMessage] {
-        guard let contextWindowTokens = config.contextWindowTokens,
-                contextWindowTokens > 0
-        else {
-            return messages
-        }
-
         let estimatedTokens = estimatedTokenCount(
             systemPrompt: systemPrompt,
             messages: messages,
             estimatedBytesPerToken: estimatedBytesPerToken
         )
-        let threshold = Int(Double(contextWindowTokens) * toolResultClearThreshold)
+        let replayThreshold = min(config.maxOutputTokens, Int.max / 4) * 4
+        let contextThreshold = config.contextWindowTokens.flatMap { contextWindowTokens in
+            contextWindowTokens > 0
+                ? Int(Double(contextWindowTokens) * toolResultClearThreshold)
+                : nil
+        }
+        let threshold = min(contextThreshold ?? replayThreshold, replayThreshold)
         guard estimatedTokens >= threshold else {
             return messages
         }
@@ -975,8 +1028,11 @@ private nonisolated enum CPSLAgentRequestPreparationBuilder {
         _ preparation: CPSLRequestPreparation,
         estimatedTokens: Int
     ) -> String {
-        let remainingIterations = max(0, preparation.maxIterations - preparation.iteration)
-        var lines = ["Session: approximately \(estimatedTokens) replay tokens in the current request."]
+        let currentIteration = preparation.iteration + 1
+        var lines = [
+            "Session: approximately \(estimatedTokens) replay tokens in the current request.",
+            "Tool round: \(currentIteration)/\(preparation.maxIterations)."
+        ]
         lines.append(
             "Current CPSL directory: \(CPSLAgentToolFormatting.promptPathLiteral(preparation.sandboxDirectory))."
         )
@@ -984,11 +1040,10 @@ private nonisolated enum CPSLAgentRequestPreparationBuilder {
             let percent = Int((Double(estimatedTokens) * 100 / Double(contextWindowTokens)).rounded())
             lines.append("Context: approximately \(percent)% full (\(estimatedTokens)/\(contextWindowTokens) tokens).")
         }
-        let remainingFraction = Double(remainingIterations) / Double(preparation.maxIterations)
-        if remainingFraction < 0.25 {
-            lines.append("Tool budget: \(remainingIterations) of \(preparation.maxIterations) rounds remain; wrap up efficiently.")
-        } else if remainingFraction < 0.50 {
-            lines.append("Tool budget: past halfway with \(remainingIterations) of \(preparation.maxIterations) rounds remaining.")
+        if currentIteration >= 12 {
+            lines.append("Use the evidence already gathered and finish now unless one essential action is still missing.")
+        } else if currentIteration >= 8 {
+            lines.append("Avoid repeating discovery. Start synthesizing the result and use more tools only for specific gaps.")
         }
         return preparation.systemPrompt
             + "\n\n<system-reminder>\n"

--- a/app/apple/herm/Models/CPSLChatModel+AgentRuntimeTypes.swift
+++ b/app/apple/herm/Models/CPSLChatModel+AgentRuntimeTypes.swift
@@ -39,6 +39,8 @@ struct CPSLToolExecutionContext {
     let config: CPSLAgentConfig
     let agentDepth: Int
     let requestDirectory: String?
+    let traceStore: CPSLConversationStore?
+    let conversationID: String?
 }
 
 struct CPSLSubAgentOutputDraft {

--- a/app/apple/herm/Models/CPSLChatModel.swift
+++ b/app/apple/herm/Models/CPSLChatModel.swift
@@ -1,5 +1,5 @@
-import Combine
 import Foundation
+import Observation
 
 private enum CPSLTransientActivity {
     case file
@@ -8,25 +8,26 @@ private enum CPSLTransientActivity {
 }
 
 @MainActor
-final class CPSLChatModel: ObservableObject {
-    @Published var promptText = ""
-    @Published private(set) var composerAttachments: [CPSLAttachment] = []
-    @Published private(set) var isImportingAttachment = false
-    @Published var comingSoonMessage: String?
-    @Published var messages: [CPSLChatMessage] = []
-    @Published private(set) var conversations: [CPSLConversationSummary] = []
-    @Published private(set) var selectedConversationID: String?
-    @Published private(set) var isRunning = false
-    @Published private(set) var isDrawerOpen = false
-    @Published private(set) var isFileBrowserOpen = false
-    @Published private(set) var browserPath = "/"
-    @Published private(set) var browserEntries: [CPSLFileEntry] = []
-    @Published private(set) var childEntriesByPath: [String: [CPSLFileEntry]] = [:]
-    @Published private(set) var expandedFilePaths: Set<String> = []
-    @Published private(set) var loadingFilePaths: Set<String> = []
-    @Published private(set) var fileBrowserError: String?
-    @Published private(set) var isManagingFiles = false
-    @Published private(set) var filePreview: CPSLFilePreview? {
+@Observable
+final class CPSLChatModel {
+    var promptText = ""
+    private(set) var composerAttachments: [CPSLAttachment] = []
+    private(set) var isImportingAttachment = false
+    var comingSoonMessage: String?
+    var messages: [CPSLChatMessage] = []
+    private(set) var conversations: [CPSLConversationSummary] = []
+    private(set) var selectedConversationID: String?
+    private(set) var isRunning = false
+    private(set) var isDrawerOpen = false
+    private(set) var isFileBrowserOpen = false
+    private(set) var browserPath = "/"
+    private(set) var browserEntries: [CPSLFileEntry] = []
+    private(set) var childEntriesByPath: [String: [CPSLFileEntry]] = [:]
+    private(set) var expandedFilePaths: Set<String> = []
+    private(set) var loadingFilePaths: Set<String> = []
+    private(set) var fileBrowserError: String?
+    private(set) var isManagingFiles = false
+    private(set) var filePreview: CPSLFilePreview? {
         didSet {
             if filePreview == nil {
                 activeFileNavigationRequestID = nil
@@ -37,19 +38,19 @@ final class CPSLChatModel: ObservableObject {
             }
         }
     }
-    @Published private(set) var isWebBrowserOpen = false
-    @Published private(set) var isFileActivityActive = false
-    @Published private(set) var isCalendarOpen = false
-    @Published private(set) var isCalendarActivityActive = false
-    @Published private(set) var isLocationOpen = false
-    @Published private(set) var isLocationActivityActive = false
-    @Published private(set) var iCloudMounts: [CPSLICloudMount] = []
-    @Published private(set) var isUpdatingICloudMounts = true
-    @Published private(set) var iCloudImportProgress: CPSLICloudImportProgress?
-    @Published private(set) var allTags: [CPSLTag] = []
-    @Published var searchText: String = ""
-    @Published private(set) var activeTagIDs: Set<String> = []
-    @Published private(set) var showingArchived = false
+    private(set) var isWebBrowserOpen = false
+    private(set) var isFileActivityActive = false
+    private(set) var isCalendarOpen = false
+    private(set) var isCalendarActivityActive = false
+    private(set) var isLocationOpen = false
+    private(set) var isLocationActivityActive = false
+    private(set) var iCloudMounts: [CPSLICloudMount] = []
+    private(set) var isUpdatingICloudMounts = true
+    private(set) var iCloudImportProgress: CPSLICloudImportProgress?
+    private(set) var allTags: [CPSLTag] = []
+    var searchText: String = ""
+    private(set) var activeTagIDs: Set<String> = []
+    private(set) var showingArchived = false
 
     var isBusy: Bool {
         isRunning || isUpdatingICloudMounts || isManagingFiles
@@ -62,36 +63,37 @@ final class CPSLChatModel: ObservableObject {
     let dictation = CPSLDictationService()
     private let fileActivityNotifier = CPSLFileActivityNotifier()
     private let calendarActivityNotifier = CPSLCalendarActivityNotifier()
-    private var store: CPSLConversationStore?
-    private var storeLoadTask: Task<CPSLConversationStore, Error>?
-    private var activeRunTask: Task<Void, Never>?
-    var currentNodeID: String?
-    private var currentSystemPrompt: String?
+    @ObservationIgnored private var store: CPSLConversationStore?
+    @ObservationIgnored private var storeLoadTask: Task<CPSLConversationStore, Error>?
+    @ObservationIgnored private var activeRunTask: Task<Void, Never>?
+    @ObservationIgnored var currentNodeID: String?
+    @ObservationIgnored private var currentSystemPrompt: String?
     var streamingAssistantMessageID: UUID?
-    var isSuppressingAssistantStream = false
-    var typewriterBuffer = ""
-    var typewriterTask: Task<Void, Never>?
-    private var iCloudImportTask: Task<Void, Never>?
-    private var activeICloudImportID: UUID?
-    private var activeFileNavigationRequestID: UUID?
-    private var activeFilePreviewRequestID: UUID?
-    private var filePreviewLoadTask: Task<Void, Never>?
-    private var filePreviewLifetimeToken: AnyObject?
-    private var retiredFilePreviewLifetimeTokens: [UUID: AnyObject] = [:]
-    private var attachmentThumbnailCache: [String: Data] = [:]
-    private var attachmentsWithoutThumbnails: Set<String> = []
-    private var iCloudMountChangeObserver: NSObjectProtocol?
+    @ObservationIgnored var isSuppressingAssistantStream = false
+    @ObservationIgnored var typewriterBuffer = ""
+    @ObservationIgnored var typewriterTask: Task<Void, Never>?
+    @ObservationIgnored private var iCloudImportTask: Task<Void, Never>?
+    @ObservationIgnored private var activeICloudImportID: UUID?
+    @ObservationIgnored private var activeFileNavigationRequestID: UUID?
+    @ObservationIgnored private var activeFilePreviewRequestID: UUID?
+    @ObservationIgnored private var filePreviewLoadTask: Task<Void, Never>?
+    @ObservationIgnored private var filePreviewLifetimeToken: AnyObject?
+    @ObservationIgnored private var retiredFilePreviewLifetimeTokens: [UUID: AnyObject] = [:]
+    @ObservationIgnored private var attachmentThumbnailCache: [String: Data] = [:]
+    @ObservationIgnored private var attachmentsWithoutThumbnails: Set<String> = []
+    @ObservationIgnored private var iCloudMountChangeObserver: NSObjectProtocol?
     let estimatedBytesPerToken = 4
     let toolResultClearThreshold = 0.80
     let recentToolResultsToKeep = 4
     var activeToolStatusNodeID: String?
-    var activeToolStatusPayload: CPSLToolStatusPayload?
-    var activeToolStatusStore: CPSLConversationStore?
-    private var fileActivityClearTask: Task<Void, Never>?
-    private var calendarActivityClearTask: Task<Void, Never>?
-    private var locationActivityClearTask: Task<Void, Never>?
-    private var draftConversationID = UUID().uuidString
-    private var attachmentImportCount = 0
+    @ObservationIgnored var activeToolStatusPayload: CPSLToolStatusPayload?
+    @ObservationIgnored var activeToolStatusStore: CPSLConversationStore?
+    @ObservationIgnored var activeToolStatusRevision = 0
+    @ObservationIgnored private var fileActivityClearTask: Task<Void, Never>?
+    @ObservationIgnored private var calendarActivityClearTask: Task<Void, Never>?
+    @ObservationIgnored private var locationActivityClearTask: Task<Void, Never>?
+    @ObservationIgnored private var draftConversationID = UUID().uuidString
+    @ObservationIgnored private var attachmentImportCount = 0
     private let activityPulseDuration: TimeInterval = 1.6
     private static let filePreviewRetirementNanoseconds: UInt64 = 300_000_000
 
@@ -112,10 +114,11 @@ final class CPSLChatModel: ObservableObject {
     For tasks involving a website or online service—including account actions, private messages, posts, forms, and file uploads or downloads—the webbrowser skill is relevant and you must read it before deciding how to proceed. The native browser uses persistent WebKit state, so the user may already be signed in. When the user explicitly requests a specific action, try to complete it through the site's normal browser interface on their behalf. Keep ordinary browser work in the background; hand the browser to the user only when authentication, consent, CAPTCHA, payment, or subjective confirmation requires them.
     Use authenticated websites only through their normal browser flow. Do not unhide, relabel, restyle, or inject page controls to manufacture an interaction target. Do not replace normal browser typing with stacked JavaScript input, paste, or synthetic keyboard-event strategies. After a consequential action is confirmed, do not repeat it or send a corrective follow-up unless the user explicitly asks; report every side effect accurately. Never extract, print, copy, or reuse authentication tokens, cookies, or other session secrets from browser storage or page JavaScript, and never use those secrets to call a site's private API.
     Every local_sandbox_exec call must include intent: one short high-level user-facing action phrase, such as "Preparing document", "Checking export", or "Saving result". Do not mention code, sandbox details, paths, module names, tool names, API names, file extensions, HTTP, or implementation details in intent.
+    Every agent call must also include intent: a short user-facing description of its expected work. Describe the action itself; never mention a helper, agent, delegation, tool, code, paths, or implementation details.
     When you call tools, assistant content may contain the same kind of high-level status phrase, but never code or implementation details.
-    local_sandbox_exec runs Luau source in CPSL. The current CPSL directory is supplied in each request. Never guess CPSL API signatures: call help() and each module's help function, such as fs.help(), before using APIs.
+    local_sandbox_exec runs Luau source in CPSL. The current CPSL directory is supplied in each request. Never guess CPSL API signatures. Use signatures documented by a relevant loaded skill directly. Call help() or a module's help function only when availability or an exact signature is still unclear; do not reload documentation already present in the conversation.
     Treat CPSL as its own Luau ecosystem. APIs from other Lua/Luau environments may be popular elsewhere but are not expected to exist here. Use only the built-in globals shown by help(); for files use fs, for documents use doc. Sandbox modules are globals: do not use require to load them, and do not search the filesystem for a module that help() does not list.
-    Treat help output as human-readable documentation. Call help() or module.help() as its own sandbox invocation and read the printed text; do not assign help output to a variable or parse it with string.find, string.sub, #, or tostring().
+    Treat help output as human-readable documentation. When help is actually needed, call help() or module.help() as its own sandbox invocation and read the printed text; do not assign help output to a variable or parse it with string.find, string.sub, #, or tostring().
     Follow documented return shapes exactly. For example, fs.list(path) returns an array of entry name strings; it does not return records with name or size fields. Use fs.size(path .. "/" .. entry) only when sizes are needed.
     Calendar and location are available through CPSL only when compiled into the app sandbox and authorized by the user. Use calendar or location only when the user's request materially needs schedule, event, availability, or current-place context. EventKit does not expose native calendar file attachments. When files should be associated with an event, use calendar.attach: it copies them to durable storage and makes them openable from Herm's Calendar view. Describe these as attached in Herm, not as native Calendar.app attachments. Access states are granted, denied, or undefined. If access is undefined, the relevant CPSL request/current function may prompt the user. If access is denied, stop using that capability and tell the user to enable access for Herm in iOS Settings or macOS System Settings.
     If an API reports that a feature is not supported, unavailable, policy-denied, or missing required system assets, make at most one targeted confirmation call, then stop using that path and explain the limitation plainly. Do not propose installers, package managers, browser printing, online converters, external renderers, shell commands, or OS-specific tools that are not available through CPSL.
@@ -381,7 +384,9 @@ final class CPSLChatModel: ObservableObject {
         let conversationID = selectedConversationID
         do {
             let json = try await conversationDebugJSON(conversationID: conversationID)
-            return try Self.writeConversationJSONTraceFile(json, conversationID: conversationID)
+            return try await Task.detached(priority: .utility) {
+                try Self.writeConversationJSONTraceFile(json, conversationID: conversationID)
+            }.value
         } catch {
             appendErrorMessage(title: "Debug", body: error.localizedDescription)
             return nil
@@ -1179,7 +1184,10 @@ final class CPSLChatModel: ObservableObject {
             selectedConversationID = conversation.summary.id
             currentNodeID = conversation.summary.currentNodeID
             currentSystemPrompt = conversation.systemPrompt.isEmpty ? systemPrompt : conversation.systemPrompt
-            messages = conversation.nodes.compactMap(\.chatMessage)
+            let nodes = conversation.nodes
+            messages = await Task.detached(priority: .userInitiated) {
+                nodes.compactMap(\.chatMessage)
+            }.value
             await reloadConversations()
             isDrawerOpen = false
             isFileBrowserOpen = false
@@ -1555,13 +1563,24 @@ final class CPSLChatModel: ObservableObject {
         }
         payload.webVisits.append(visit)
         activeToolStatusPayload = payload
-        let body = payload.encodedBody()
-        if let messageID = UUID(uuidString: nodeID),
-           let index = messages.firstIndex(where: { $0.id == messageID }) {
-            messages[index].body = body
-        }
-        Task {
-            try? await store.updateNodeBody(id: nodeID, body: body)
+        activeToolStatusRevision += 1
+        let revision = activeToolStatusRevision
+        let payloadForEncoding = payload
+        Task { [weak self] in
+            let encodedBodies = await Task.detached(priority: .utility) {
+                payloadForEncoding.encodedBodies()
+            }.value
+            guard let self,
+                  self.activeToolStatusNodeID == nodeID,
+                  self.activeToolStatusRevision == revision
+            else {
+                return
+            }
+            if let messageID = UUID(uuidString: nodeID),
+               let index = self.messages.firstIndex(where: { $0.id == messageID }) {
+                self.messages[index].body = encodedBodies.presentation
+            }
+            try? await store.updateNodeBody(id: nodeID, body: encodedBodies.persisted)
         }
     }
 

--- a/app/apple/herm/Models/CPSLChatModel.swift
+++ b/app/apple/herm/Models/CPSLChatModel.swift
@@ -1444,6 +1444,7 @@ final class CPSLChatModel {
                 await markActiveToolStatusStopped()
                 currentNodeID = activeParentID
             } else {
+                await markActiveToolStatusFailed()
                 await appendAgentError(
                     error.localizedDescription,
                     context: CPSLPendingConversationContext(

--- a/app/apple/herm/Models/CPSLChatModel.swift
+++ b/app/apple/herm/Models/CPSLChatModel.swift
@@ -86,6 +86,7 @@ final class CPSLChatModel {
     let toolResultClearThreshold = 0.80
     let recentToolResultsToKeep = 4
     var activeToolStatusNodeID: String?
+    @ObservationIgnored var activeToolStatusConversationID: String?
     @ObservationIgnored var activeToolStatusPayload: CPSLToolStatusPayload?
     @ObservationIgnored var activeToolStatusStore: CPSLConversationStore?
     @ObservationIgnored var activeToolStatusRevision = 0
@@ -600,7 +601,6 @@ final class CPSLChatModel {
         closeWebBrowser()
         isCalendarOpen = false
         isLocationOpen = false
-        isFileBrowserOpen = true
         filePreview = nil
         let navigationID = UUID()
         activeFileNavigationRequestID = navigationID
@@ -608,23 +608,37 @@ final class CPSLChatModel {
         Task { [weak self, service] in
             let lookup = await service.fileEntry(at: normalized)
             guard let self,
-                  self.activeFileNavigationRequestID == navigationID,
-                  self.isFileBrowserOpen
+                  self.activeFileNavigationRequestID == navigationID
             else {
                 return
             }
-            self.activeFileNavigationRequestID = nil
             guard let entry = lookup.entry else {
+                self.activeFileNavigationRequestID = nil
                 self.loadBrowserPath(self.parentPath(of: normalized))
                 self.fileBrowserError = "\(normalized): \(lookup.error ?? "File does not exist.")"
+                self.isFileBrowserOpen = true
                 return
             }
 
             if entry.isDirectory {
+                self.activeFileNavigationRequestID = nil
                 self.loadBrowserPath(entry.path)
+                self.isFileBrowserOpen = true
             } else {
+                let previewResult = await service.previewFile(entry)
+                guard self.activeFileNavigationRequestID == navigationID else {
+                    return
+                }
+                self.activeFileNavigationRequestID = nil
                 self.loadBrowserPath(self.parentPath(of: entry.path))
-                self.requestFilePreview(for: entry)
+                if let preview = previewResult.preview {
+                    self.filePreviewLifetimeToken = previewResult.lifetimeToken
+                    self.filePreview = preview
+                } else {
+                    let message = previewResult.error ?? "Preview is not available for this file."
+                    self.fileBrowserError = "\(entry.path): \(message)"
+                }
+                self.isFileBrowserOpen = true
             }
         }
     }
@@ -1185,8 +1199,16 @@ final class CPSLChatModel {
             currentNodeID = conversation.summary.currentNodeID
             currentSystemPrompt = conversation.systemPrompt.isEmpty ? systemPrompt : conversation.systemPrompt
             let nodes = conversation.nodes
+            let toolStatusNodeIDs = Self.toolStatusNodeIDsNeedingInvocations(in: nodes)
+            let toolStatusInvocations = try? await store.toolStatusInvocations(
+                conversationID: conversation.summary.id,
+                nodeIDs: toolStatusNodeIDs
+            )
             messages = await Task.detached(priority: .userInitiated) {
-                nodes.compactMap(\.chatMessage)
+                Self.chatMessages(
+                    from: nodes,
+                    toolStatusInvocations: toolStatusInvocations ?? [:]
+                )
             }.value
             await reloadConversations()
             isDrawerOpen = false
@@ -1196,6 +1218,42 @@ final class CPSLChatModel {
             filePreview = nil
         } catch {
             appendErrorMessage(title: "Conversation", body: error.localizedDescription)
+        }
+    }
+
+    private nonisolated static func toolStatusNodeIDsNeedingInvocations(
+        in nodes: [CPSLStoredNode]
+    ) -> Set<String> {
+        Set(nodes.compactMap { node in
+            guard node.role == .toolStatus,
+                  let payload = CPSLToolStatusPayload.decode(from: node.body),
+                  payload.invocations.isEmpty
+            else {
+                return nil
+            }
+            return node.id
+        })
+    }
+
+    private nonisolated static func chatMessages(
+        from nodes: [CPSLStoredNode],
+        toolStatusInvocations: [String: [CPSLToolStatusInvocation]]
+    ) -> [CPSLChatMessage] {
+        nodes.compactMap { node in
+            guard var message = node.chatMessage else {
+                return nil
+            }
+            guard node.role == .toolStatus,
+                  var payload = CPSLToolStatusPayload.decode(from: message.body),
+                  payload.invocations.isEmpty,
+                  let invocations = toolStatusInvocations[node.id],
+                  !invocations.isEmpty
+            else {
+                return message
+            }
+            payload.invocations = invocations
+            message.body = payload.encodedBody()
+            return message
         }
     }
 
@@ -1235,6 +1293,7 @@ final class CPSLChatModel {
         }
 
         let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let data = try encoder.encode(CPSLDebugConversationSnapshot(messages: messages))
         return String(decoding: data, as: UTF8.self)
@@ -1367,6 +1426,13 @@ final class CPSLChatModel {
             currentNodeID = parentID
             await reloadConversations()
         } catch {
+            if let activeConversationID {
+                try? await store.recordError(
+                    conversationID: activeConversationID,
+                    message: error.localizedDescription,
+                    scope: "agent.run"
+                )
+            }
             let pendingContext = CPSLPendingConversationContext(
                 store: store,
                 conversationID: activeConversationID,
@@ -1556,20 +1622,29 @@ final class CPSLChatModel {
 
     func appendWebSearchVisit(_ visit: CPSLWebSearchVisit) {
         guard let nodeID = activeToolStatusNodeID,
+              let conversationID = activeToolStatusConversationID,
               let store = activeToolStatusStore,
               var payload = activeToolStatusPayload
         else {
             return
         }
         payload.webVisits.append(visit)
+        payload.webVisits = Array(payload.webVisits.suffix(12))
         activeToolStatusPayload = payload
         activeToolStatusRevision += 1
         let revision = activeToolStatusRevision
-        let payloadForEncoding = payload
+        let body = payload.encodedBody()
         Task { [weak self] in
-            let encodedBodies = await Task.detached(priority: .utility) {
-                payloadForEncoding.encodedBodies()
-            }.value
+            try? await store.recordWebVisit(
+                conversationID: conversationID,
+                nodeID: nodeID,
+                visit: visit
+            )
+            try? await store.updateNodeBody(
+                conversationID: conversationID,
+                id: nodeID,
+                body: body
+            )
             guard let self,
                   self.activeToolStatusNodeID == nodeID,
                   self.activeToolStatusRevision == revision
@@ -1578,9 +1653,8 @@ final class CPSLChatModel {
             }
             if let messageID = UUID(uuidString: nodeID),
                let index = self.messages.firstIndex(where: { $0.id == messageID }) {
-                self.messages[index].body = encodedBodies.presentation
+                self.messages[index].body = body
             }
-            try? await store.updateNodeBody(id: nodeID, body: encodedBodies.persisted)
         }
     }
 
@@ -1660,6 +1734,44 @@ final class CPSLChatModel {
 
 #if DEBUG
 private nonisolated struct CPSLDebugConversationSnapshot: Encodable {
+    let format = "herm.debug-export"
+    let schemaVersion = 1
+    let generatedAt = Date()
+    let documentation = [
+        "overview": "Unsaved draft snapshot. Persisted exports also contain chronological conversationEvents and traceEvents.",
+        "jq": ".conversation.messages[] | {role, title, body}",
+    ]
+    let messages: [CPSLChatMessage]
+    let conversationEvents: [String] = []
+    let traceEvents: [String] = []
+
+    private enum CodingKeys: String, CodingKey {
+        case format
+        case schemaVersion
+        case generatedAt
+        case documentation
+        case conversation
+        case conversationEvents
+        case traceEvents
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(format, forKey: .format)
+        try container.encode(schemaVersion, forKey: .schemaVersion)
+        try container.encode(generatedAt, forKey: .generatedAt)
+        try container.encode(documentation, forKey: .documentation)
+        try container.encode(
+            CPSLDebugDraftConversation(state: "draft", messages: messages),
+            forKey: .conversation
+        )
+        try container.encode(conversationEvents, forKey: .conversationEvents)
+        try container.encode(traceEvents, forKey: .traceEvents)
+    }
+}
+
+private nonisolated struct CPSLDebugDraftConversation: Encodable {
+    let state: String
     let messages: [CPSLChatMessage]
 }
 #endif

--- a/app/apple/herm/Models/CPSLTypes.swift
+++ b/app/apple/herm/Models/CPSLTypes.swift
@@ -693,7 +693,7 @@ struct CPSLFilePreviewLoadResult: @unchecked Sendable {
     let error: String?
     let lifetimeToken: AnyObject?
 
-    init(
+    nonisolated init(
         preview: CPSLFilePreview?,
         error: String?,
         lifetimeToken: AnyObject? = nil

--- a/app/apple/herm/Models/CPSLTypes.swift
+++ b/app/apple/herm/Models/CPSLTypes.swift
@@ -69,7 +69,7 @@ nonisolated enum CPSLChatRole: String, Codable, Equatable, Sendable {
     }
 
     var isFramed: Bool {
-        self != .assistant && self != .thought
+        self != .assistant
     }
 
     var displaysTitle: Bool {
@@ -86,7 +86,7 @@ nonisolated enum CPSLChatRole: String, Codable, Equatable, Sendable {
         case .assistant:
             return .clear
         case .thought:
-            return .clear
+            return CPSLTheme.surface
         case .user:
             return CPSLTheme.elevated
         case .command:

--- a/app/apple/herm/Models/CPSLTypes.swift
+++ b/app/apple/herm/Models/CPSLTypes.swift
@@ -688,12 +688,12 @@ struct CPSLFilePreview: Identifiable, Equatable, Sendable {
     let kind: CPSLFilePreviewKind
 }
 
-struct CPSLFilePreviewLoadResult: @unchecked Sendable {
+nonisolated struct CPSLFilePreviewLoadResult: @unchecked Sendable {
     let preview: CPSLFilePreview?
     let error: String?
     let lifetimeToken: AnyObject?
 
-    nonisolated init(
+    init(
         preview: CPSLFilePreview?,
         error: String?,
         lifetimeToken: AnyObject? = nil

--- a/app/apple/herm/Models/CPSLTypes.swift
+++ b/app/apple/herm/Models/CPSLTypes.swift
@@ -44,6 +44,7 @@ enum CPSLFeatureAccessState: String, Equatable, Sendable {
 
 nonisolated enum CPSLChatRole: String, Codable, Equatable, Sendable {
     case assistant
+    case thought
     case user
     case command
     case output
@@ -56,7 +57,7 @@ nonisolated enum CPSLChatRole: String, Codable, Equatable, Sendable {
     }
 
     var isFullWidth: Bool {
-        self == .assistant || self == .command || self == .toolStatus
+        self == .assistant || self == .thought || self == .command || self == .toolStatus
     }
 
     var usesMonospaceBody: Bool {
@@ -68,11 +69,11 @@ nonisolated enum CPSLChatRole: String, Codable, Equatable, Sendable {
     }
 
     var isFramed: Bool {
-        self != .assistant
+        self != .assistant && self != .thought
     }
 
     var displaysTitle: Bool {
-        self != .assistant
+        self != .assistant && self != .thought
     }
 
     var isVisible: Bool {
@@ -83,6 +84,8 @@ nonisolated enum CPSLChatRole: String, Codable, Equatable, Sendable {
     var fill: Color {
         switch self {
         case .assistant:
+            return .clear
+        case .thought:
             return .clear
         case .user:
             return CPSLTheme.elevated

--- a/app/apple/herm/Services/Agent/CPSLAgentToolFormatting.swift
+++ b/app/apple/herm/Services/Agent/CPSLAgentToolFormatting.swift
@@ -358,6 +358,7 @@ nonisolated enum CPSLToolStatusState: String, Codable, Equatable, Sendable {
     case running
     case succeeded
     case failed
+    case interrupted
 }
 
 nonisolated struct CPSLToolTraceInvocation: Identifiable, Codable, Equatable, Sendable {
@@ -392,17 +393,23 @@ nonisolated struct CPSLToolStatusPayload: Codable, Equatable, Sendable {
     var summary: String
     var invocations: [CPSLToolStatusInvocation]
     var webVisits: [CPSLWebSearchVisit]
+    var isSuperseded: Bool
+    var activityID: UUID?
 
     init(
         state: CPSLToolStatusState,
         summary: String,
         invocations: [CPSLToolStatusInvocation] = [],
-        webVisits: [CPSLWebSearchVisit] = []
+        webVisits: [CPSLWebSearchVisit] = [],
+        isSuperseded: Bool = false,
+        activityID: UUID? = nil
     ) {
         self.state = state
         self.summary = summary
         self.invocations = invocations
         self.webVisits = webVisits
+        self.isSuperseded = isSuperseded
+        self.activityID = activityID
     }
 
     static func running(summary: String = "Preparing tools") -> CPSLToolStatusPayload {
@@ -428,6 +435,8 @@ nonisolated struct CPSLToolStatusPayload: Codable, Equatable, Sendable {
         case summary
         case invocations
         case webVisits
+        case isSuperseded
+        case activityID
     }
 
     init(from decoder: Decoder) throws {
@@ -439,6 +448,8 @@ nonisolated struct CPSLToolStatusPayload: Codable, Equatable, Sendable {
             forKey: .invocations
         ) ?? []
         webVisits = try container.decodeIfPresent([CPSLWebSearchVisit].self, forKey: .webVisits) ?? []
+        isSuperseded = try container.decodeIfPresent(Bool.self, forKey: .isSuperseded) ?? false
+        activityID = try container.decodeIfPresent(UUID.self, forKey: .activityID)
     }
 }
 

--- a/app/apple/herm/Services/Agent/CPSLAgentToolFormatting.swift
+++ b/app/apple/herm/Services/Agent/CPSLAgentToolFormatting.swift
@@ -256,6 +256,10 @@ nonisolated enum CPSLAgentToolFormatting {
     }
 
     static func displayBody(_ output: CPSLAgentToolOutput) -> String {
+        truncatedText(completeBody(output))
+    }
+
+    static func completeBody(_ output: CPSLAgentToolOutput) -> String {
         var sections: [String] = []
         appendTrimmed(output.stdout, to: &sections)
         appendTrimmed(output.stderr, to: &sections)
@@ -269,7 +273,7 @@ nonisolated enum CPSLAgentToolFormatting {
         if sections.isEmpty {
             sections.append(output.exitCode.map { "exit \($0)" } ?? "done")
         }
-        return truncatedText(sections.joined(separator: "\n\n"))
+        return sections.joined(separator: "\n\n")
     }
 
     static func truncatedText(_ text: String) -> String {
@@ -356,6 +360,15 @@ nonisolated enum CPSLToolStatusState: String, Codable, Equatable, Sendable {
     case failed
 }
 
+nonisolated struct CPSLToolTraceInvocation: Identifiable, Codable, Equatable, Sendable {
+    let id: String
+    let name: String
+    let summary: String
+    let input: String
+    let output: String
+    let isError: Bool
+}
+
 nonisolated struct CPSLToolStatusInvocation: Identifiable, Codable, Equatable, Sendable {
     let id: String
     let name: String
@@ -363,6 +376,15 @@ nonisolated struct CPSLToolStatusInvocation: Identifiable, Codable, Equatable, S
     let input: String
     let output: String
     let isError: Bool
+
+    init(traceInvocation: CPSLToolTraceInvocation) {
+        id = traceInvocation.id
+        name = traceInvocation.name
+        summary = traceInvocation.summary
+        input = CPSLAgentToolFormatting.truncatedText(traceInvocation.input)
+        output = CPSLAgentToolFormatting.truncatedText(traceInvocation.output)
+        isError = traceInvocation.isError
+    }
 }
 
 nonisolated struct CPSLToolStatusPayload: Codable, Equatable, Sendable {
@@ -374,7 +396,7 @@ nonisolated struct CPSLToolStatusPayload: Codable, Equatable, Sendable {
     init(
         state: CPSLToolStatusState,
         summary: String,
-        invocations: [CPSLToolStatusInvocation],
+        invocations: [CPSLToolStatusInvocation] = [],
         webVisits: [CPSLWebSearchVisit] = []
     ) {
         self.state = state
@@ -384,7 +406,7 @@ nonisolated struct CPSLToolStatusPayload: Codable, Equatable, Sendable {
     }
 
     static func running(summary: String = "Preparing tools") -> CPSLToolStatusPayload {
-        CPSLToolStatusPayload(state: .running, summary: summary, invocations: [])
+        CPSLToolStatusPayload(state: .running, summary: summary)
     }
 
     static func decode(from body: String) -> CPSLToolStatusPayload? {
@@ -401,24 +423,6 @@ nonisolated struct CPSLToolStatusPayload: Codable, Equatable, Sendable {
         return String(decoding: data, as: UTF8.self)
     }
 
-    func presentationEncodedBody() -> String {
-        var presentation = self
-#if DEBUG
-        presentation.invocations = Array(presentation.invocations.suffix(4))
-#else
-        presentation.invocations = []
-#endif
-        presentation.webVisits = Array(presentation.webVisits.suffix(12))
-        return presentation.encodedBody()
-    }
-
-    func encodedBodies() -> CPSLToolStatusEncodedBodies {
-        CPSLToolStatusEncodedBodies(
-            persisted: encodedBody(),
-            presentation: presentationEncodedBody()
-        )
-    }
-
     private enum CodingKeys: String, CodingKey {
         case state
         case summary
@@ -430,14 +434,12 @@ nonisolated struct CPSLToolStatusPayload: Codable, Equatable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         state = try container.decode(CPSLToolStatusState.self, forKey: .state)
         summary = try container.decode(String.self, forKey: .summary)
-        invocations = try container.decodeIfPresent([CPSLToolStatusInvocation].self, forKey: .invocations) ?? []
+        invocations = try container.decodeIfPresent(
+            [CPSLToolStatusInvocation].self,
+            forKey: .invocations
+        ) ?? []
         webVisits = try container.decodeIfPresent([CPSLWebSearchVisit].self, forKey: .webVisits) ?? []
     }
-}
-
-nonisolated struct CPSLToolStatusEncodedBodies: Sendable {
-    let persisted: String
-    let presentation: String
 }
 
 nonisolated struct CPSLAgentToolOutput: Equatable, Sendable {
@@ -454,5 +456,5 @@ nonisolated struct CPSLToolExecutionResult {
     let providerContent: String
     let displayBody: String
     let isError: Bool
-    let debugInvocation: CPSLToolStatusInvocation
+    let traceInvocation: CPSLToolTraceInvocation
 }

--- a/app/apple/herm/Services/Agent/CPSLAgentToolFormatting.swift
+++ b/app/apple/herm/Services/Agent/CPSLAgentToolFormatting.swift
@@ -29,7 +29,7 @@ nonisolated enum CPSLAgentToolFormatting {
     static func agentInput(from arguments: String) -> CPSLAgentToolInput? {
         guard let data = arguments.data(using: .utf8),
                 let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-                Set(object.keys).isSubset(of: ["task", "mode"]),
+                Set(object.keys).isSubset(of: ["task", "mode", "intent"]),
                 let task = object["task"] as? String,
                 !task.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         else {
@@ -43,7 +43,9 @@ nonisolated enum CPSLAgentToolFormatting {
 
         return CPSLAgentToolInput(
             task: task.trimmingCharacters(in: .whitespacesAndNewlines),
-            mode: subAgentMode
+            mode: subAgentMode,
+            intent: sanitizedStatusSentence(from: object["intent"] as? String)
+                ?? sanitizedStatusSentence(from: task)
         )
     }
 
@@ -64,11 +66,9 @@ nonisolated enum CPSLAgentToolFormatting {
             return input.intent ?? inferredSandboxIntent(from: input.source)
         case agentName:
             guard let input = agentInput(from: toolCall.function.arguments) else {
-                return "Checking with a helper"
+                return defaultStatusSummary
             }
-            return input.mode == .explore
-                ? "Asking a helper to inspect this"
-                : "Asking a helper to work on this"
+            return input.intent ?? defaultStatusSummary
         default:
             return defaultStatusSummary
         }
@@ -87,6 +87,25 @@ nonisolated enum CPSLAgentToolFormatting {
 
     static func statusSentence(from assistantText: String, fallback: String = defaultStatusSummary) -> String {
         sanitizedStatusSentence(from: assistantText) ?? fallback
+    }
+
+    static func uniqueThought(
+        from assistantText: String,
+        toolCalls: [CPSLOpenAIToolCall]
+    ) -> String? {
+        let summaries = toolCalls.map {
+            statusSummary(for: $0, assistantText: assistantText)
+        }
+        let uniqueLines = assistantText
+            .split(whereSeparator: \.isNewline)
+            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { line in
+                !line.isEmpty && !summaries.contains { isEquivalentStatus(line, $0) }
+            }
+        guard !uniqueLines.isEmpty else {
+            return nil
+        }
+        return uniqueLines.joined(separator: "\n")
     }
 
     static func promptPathLiteral(_ path: String) -> String {
@@ -152,6 +171,34 @@ nonisolated enum CPSLAgentToolFormatting {
             line = "\(line.prefix(157))..."
         }
         return line
+    }
+
+    private static func isEquivalentStatus(_ lhs: String, _ rhs: String) -> Bool {
+        let leftWords = normalizedStatusWords(lhs)
+        let rightWords = normalizedStatusWords(rhs)
+        guard !leftWords.isEmpty, !rightWords.isEmpty else {
+            return false
+        }
+        let overlap = leftWords.intersection(rightWords).count
+        return Double(overlap) / Double(min(leftWords.count, rightWords.count)) >= 0.75
+    }
+
+    private static func normalizedStatusWords(_ text: String) -> Set<String> {
+        let stopWords: Set<String> = [
+            "a", "am", "an", "and", "i", "ill", "im", "let", "me", "next", "now", "the", "this", "to", "will"
+        ]
+        let words = text.lowercased().split { !$0.isLetter && !$0.isNumber }
+        return Set(words.compactMap { rawWord in
+            var word = String(rawWord)
+            if word.count > 5, word.hasSuffix("ing") {
+                word.removeLast(3)
+            } else if word.count > 4, word.hasSuffix("ed") {
+                word.removeLast(2)
+            } else if word.count > 3, word.hasSuffix("s") {
+                word.removeLast()
+            }
+            return stopWords.contains(word) ? nil : word
+        })
     }
 
     private static func inferredSandboxIntent(from source: String) -> String {
@@ -295,6 +342,7 @@ nonisolated enum CPSLSubAgentMode: String, Codable, Equatable, Sendable {
 nonisolated struct CPSLAgentToolInput: Equatable, Sendable {
     let task: String
     let mode: CPSLSubAgentMode
+    let intent: String?
 }
 
 nonisolated struct CPSLSandboxToolInput: Equatable, Sendable {
@@ -353,6 +401,24 @@ nonisolated struct CPSLToolStatusPayload: Codable, Equatable, Sendable {
         return String(decoding: data, as: UTF8.self)
     }
 
+    func presentationEncodedBody() -> String {
+        var presentation = self
+#if DEBUG
+        presentation.invocations = Array(presentation.invocations.suffix(4))
+#else
+        presentation.invocations = []
+#endif
+        presentation.webVisits = Array(presentation.webVisits.suffix(12))
+        return presentation.encodedBody()
+    }
+
+    func encodedBodies() -> CPSLToolStatusEncodedBodies {
+        CPSLToolStatusEncodedBodies(
+            persisted: encodedBody(),
+            presentation: presentationEncodedBody()
+        )
+    }
+
     private enum CodingKeys: String, CodingKey {
         case state
         case summary
@@ -367,6 +433,11 @@ nonisolated struct CPSLToolStatusPayload: Codable, Equatable, Sendable {
         invocations = try container.decodeIfPresent([CPSLToolStatusInvocation].self, forKey: .invocations) ?? []
         webVisits = try container.decodeIfPresent([CPSLWebSearchVisit].self, forKey: .webVisits) ?? []
     }
+}
+
+nonisolated struct CPSLToolStatusEncodedBodies: Sendable {
+    let persisted: String
+    let presentation: String
 }
 
 nonisolated struct CPSLAgentToolOutput: Equatable, Sendable {

--- a/app/apple/herm/Services/Agent/CPSLConversationStore.swift
+++ b/app/apple/herm/Services/Agent/CPSLConversationStore.swift
@@ -1,6 +1,13 @@
 import Foundation
 
 actor CPSLConversationStore {
+    private nonisolated static let iso8601FractionalSecondsFormat = Date.ISO8601FormatStyle(
+        includingFractionalSeconds: true
+    )
+    private nonisolated static let iso8601SecondPrecisionFormat = Date.ISO8601FormatStyle(
+        includingFractionalSeconds: false
+    )
+
     let conversationLogURL: URL
     let traceLogURL: URL
     let usesICloudContainer: Bool
@@ -641,11 +648,9 @@ actor CPSLConversationStore {
 
     private static func jsonEncoder(prettyPrinted: Bool = false) -> JSONEncoder {
         let encoder = JSONEncoder()
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         encoder.dateEncodingStrategy = .custom { date, encoder in
             var container = encoder.singleValueContainer()
-            try container.encode(formatter.string(from: date))
+            try container.encode(Self.iso8601FractionalSecondsFormat.format(date))
         }
         encoder.outputFormatting = prettyPrinted ? [.prettyPrinted, .sortedKeys] : [.sortedKeys]
         return encoder
@@ -653,14 +658,10 @@ actor CPSLConversationStore {
 
     private static func jsonDecoder() -> JSONDecoder {
         let decoder = JSONDecoder()
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        let secondPrecisionFormatter = ISO8601DateFormatter()
-        secondPrecisionFormatter.formatOptions = [.withInternetDateTime]
         decoder.dateDecodingStrategy = .custom { decoder in
             let value = try decoder.singleValueContainer().decode(String.self)
-            guard let date = formatter.date(from: value)
-                ?? secondPrecisionFormatter.date(from: value)
+            guard let date = (try? Self.iso8601FractionalSecondsFormat.parse(value))
+                ?? (try? Self.iso8601SecondPrecisionFormat.parse(value))
             else {
                 throw DecodingError.dataCorrupted(
                     .init(codingPath: decoder.codingPath, debugDescription: "Invalid ISO-8601 date.")

--- a/app/apple/herm/Services/Agent/CPSLConversationStore.swift
+++ b/app/apple/herm/Services/Agent/CPSLConversationStore.swift
@@ -854,12 +854,19 @@ nonisolated struct CPSLStoredNode: Identifiable, Equatable, Sendable, Encodable 
         guard role.isVisible else {
             return nil
         }
+        let presentationBody: String
+        if role == .toolStatus,
+           let payload = CPSLToolStatusPayload.decode(from: body) {
+            presentationBody = payload.presentationEncodedBody()
+        } else {
+            presentationBody = body
+        }
         let providerParts: (displayText: String, attachments: [CPSLAttachment]) = role == .user
             ? CPSLAttachmentPrompt.parse(providerMessage?.content)
             : (displayText: "", attachments: [])
         let bodyParts: (displayText: String, attachments: [CPSLAttachment]) = role == .user
-            ? CPSLAttachmentPrompt.parse(body)
-            : (displayText: body, attachments: [])
+            ? CPSLAttachmentPrompt.parse(presentationBody)
+            : (displayText: presentationBody, attachments: [])
         let attachments = providerParts.attachments.isEmpty
             ? bodyParts.attachments
             : providerParts.attachments
@@ -867,7 +874,7 @@ nonisolated struct CPSLStoredNode: Identifiable, Equatable, Sendable, Encodable 
             id: UUID(uuidString: id) ?? UUID(),
             role: role,
             title: title,
-            body: bodyParts.attachments.isEmpty ? body : bodyParts.displayText,
+            body: bodyParts.attachments.isEmpty ? presentationBody : bodyParts.displayText,
             attachments: attachments
         )
     }

--- a/app/apple/herm/Services/Agent/CPSLConversationStore.swift
+++ b/app/apple/herm/Services/Agent/CPSLConversationStore.swift
@@ -1,144 +1,88 @@
 import Foundation
-import SQLite3
 
 actor CPSLConversationStore {
-    private nonisolated static let sqliteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
-
-    let databaseURL: URL
+    let conversationLogURL: URL
+    let traceLogURL: URL
     let usesICloudContainer: Bool
 
-    private var database: OpaquePointer?
-
     init() throws {
-        let location = try CPSLConversationDatabaseLocation.resolve()
-        try self.init(location: location)
+        try self.init(location: CPSLConversationLogLocation.resolve())
     }
 
-    init(databaseURL: URL, usesICloudContainer: Bool) throws {
+    init(logURL: URL, usesICloudContainer: Bool) throws {
+        let stem = logURL.deletingPathExtension().lastPathComponent
         try self.init(
-            location: CPSLConversationDatabaseLocation(
-                url: databaseURL,
+            location: CPSLConversationLogLocation(
+                conversationLogURL: logURL,
+                traceLogURL: logURL.deletingLastPathComponent()
+                    .appendingPathComponent("\(stem)-traces.jsonl"),
                 usesICloudContainer: usesICloudContainer
             )
         )
     }
 
-    private init(location: CPSLConversationDatabaseLocation) throws {
-        databaseURL = location.url
+    private init(location: CPSLConversationLogLocation) throws {
+        conversationLogURL = location.conversationLogURL
+        traceLogURL = location.traceLogURL
         usesICloudContainer = location.usesICloudContainer
-
-        if sqlite3_open(location.url.path, &database) != SQLITE_OK {
-            let message = database.map { String(cString: sqlite3_errmsg($0)) } ?? "unknown SQLite error"
-            throw CPSLConversationStoreError.openFailed(message)
-        }
-        sqlite3_busy_timeout(database, 5_000)
-        try Self.migrate(database: database)
-    }
-
-    deinit {
-        sqlite3_close(database)
+        try Self.prepareLog(at: conversationLogURL)
+        try Self.prepareLog(at: traceLogURL)
     }
 
     func fetchConversationSummaries(
         archiveScope: CPSLArchiveScope,
         tagIDs: Set<String>
     ) throws -> [CPSLConversationSummary] {
-        let archivedValue = archiveScope == .archived ? 1 : 0
-        var sql = """
-            SELECT c.id, c.title, c.current_node_id, c.model, c.created_at, c.updated_at, c.pinned, c.archived
-            FROM conversations c
-            """
-        var bindings: [CPSLSQLiteBinding] = []
-
-        if !tagIDs.isEmpty {
-            let placeholders = Array(repeating: "?", count: tagIDs.count).joined(separator: ", ")
-            sql += """
-            \nJOIN conversation_tags ct ON ct.conversation_id = c.id
-            WHERE c.archived = ? AND ct.tag_id IN (\(placeholders))
-            GROUP BY c.id
-            HAVING COUNT(DISTINCT ct.tag_id) = ?
-            ORDER BY c.updated_at DESC
-            """
-            bindings.append(.int(archivedValue))
-            bindings.append(contentsOf: tagIDs.map { CPSLSQLiteBinding.text($0) })
-            bindings.append(.int(tagIDs.count))
-        } else {
-            sql += "\nWHERE c.archived = ?\nORDER BY c.updated_at DESC"
-            bindings.append(.int(archivedValue))
-        }
-
-        return try query(sql, bindings: bindings) { statement in
-            CPSLConversationSummary(
-                id: columnString(statement, 0) ?? "",
-                title: columnString(statement, 1) ?? "Untitled",
-                currentNodeID: columnString(statement, 2),
-                model: columnString(statement, 3),
-                createdAt: columnDate(statement, 4),
-                updatedAt: columnDate(statement, 5),
-                pinned: columnBool(statement, 6),
-                archived: columnBool(statement, 7)
-            )
-        }
+        let state = try loadState()
+        let isArchived = archiveScope == .archived
+        return state.conversations.values
+            .filter { conversation in
+                conversation.archived == isArchived
+                    && tagIDs.isSubset(of: state.conversationTags[conversation.id] ?? [])
+            }
+            .map(\.summary)
+            .sorted { $0.updatedAt > $1.updatedAt }
     }
 
     func loadNodes(conversationID: String) throws -> [CPSLStoredNode] {
-        try query(
-            """
-            SELECT id, conversation_id, parent_id, role, title, body, model, provider_message_json, sequence, created_at
-            FROM nodes
-            WHERE conversation_id = ?
-            ORDER BY sequence ASC, created_at ASC
-            """,
-            bindings: [.text(conversationID)]
-        ) { statement in
-            storedNode(from: statement)
-        }
+        try loadState().conversations[conversationID]?.nodes.sorted(by: Self.nodeOrder) ?? []
     }
 
     func loadConversation(id: String) throws -> CPSLLoadedConversation? {
-        let loadedHeaders = try query(
-            """
-            SELECT id, title, current_node_id, model, system_prompt, created_at, updated_at, pinned, archived
-            FROM conversations
-            WHERE id = ?
-            LIMIT 1
-            """,
-            bindings: [.text(id)]
-        ) { statement in
-            (
-                summary: CPSLConversationSummary(
-                    id: columnString(statement, 0) ?? "",
-                    title: columnString(statement, 1) ?? "Untitled",
-                    currentNodeID: columnString(statement, 2),
-                    model: columnString(statement, 3),
-                    createdAt: columnDate(statement, 5),
-                    updatedAt: columnDate(statement, 6),
-                    pinned: columnBool(statement, 7),
-                    archived: columnBool(statement, 8)
-                ),
-                systemPrompt: columnString(statement, 4) ?? ""
-            )
-        }
-        guard let loadedHeader = loadedHeaders.first else {
+        guard let conversation = try loadState().conversations[id] else {
             return nil
         }
-        return CPSLLoadedConversation(
-            summary: loadedHeader.summary,
-            systemPrompt: loadedHeader.systemPrompt,
-            nodes: try loadNodes(conversationID: id)
-        )
+        return conversation.loadedConversation
     }
 
 #if DEBUG
     func exportConversationJSON(id: String) throws -> String {
-        guard let conversation = try loadConversation(id: id) else {
+        let conversationEvents = try loadConversationEvents()
+        let state = Self.replay(conversationEvents)
+        guard let conversation = state.conversations[id] else {
             throw CPSLConversationStoreError.conversationNotFound
         }
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        let data = try encoder.encode(conversation)
-        return String(decoding: data, as: UTF8.self)
+        let traceEvents = try Self.readJSONLines(CPSLTraceEvent.self, from: traceLogURL)
+            .filter { $0.conversationID == id }
+        let relevantConversationEvents = conversationEvents.filter { event in
+            if event.conversationID == id {
+                return true
+            }
+            if let tagID = event.tag?.id ?? event.tagID {
+                return state.conversationTags[id]?.contains(tagID) == true
+            }
+            return false
+        }
+        let export = CPSLConversationDebugExport(
+            generatedAt: Date(),
+            conversation: conversation.loadedConversation,
+            tags: (state.conversationTags[id] ?? []).compactMap { state.tags[$0] }
+                .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending },
+            conversationEvents: relevantConversationEvents,
+            traceEvents: traceEvents
+        )
+        let encoder = Self.jsonEncoder(prettyPrinted: true)
+        return String(decoding: try encoder.encode(export), as: UTF8.self)
     }
 #endif
 
@@ -149,58 +93,14 @@ actor CPSLConversationStore {
         model: String?,
         systemPrompt: String
     ) throws -> (summary: CPSLConversationSummary, userNode: CPSLStoredNode) {
+        let state = try loadState()
         let now = Date()
         let conversationID = id ?? UUID().uuidString
         let userNodeID = UUID().uuidString
-        let title = Self.generateTitle(from: userText)
-        let providerMessage = CPSLOpenAIMessage.user(providerText ?? userText)
-        let providerJSON = try encodeProviderMessage(providerMessage)
-
-        try withTransaction {
-            try execute(
-                """
-                INSERT INTO conversations (id, title, root_node_id, current_node_id, model, system_prompt, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                bindings: [
-                    .text(conversationID),
-                    .text(title),
-                    .text(userNodeID),
-                    .text(userNodeID),
-                    .nullableText(model),
-                    .text(systemPrompt),
-                    .date(now),
-                    .date(now)
-                ]
-            )
-            try execute(
-                """
-                INSERT INTO nodes (id, conversation_id, parent_id, role, title, body, model, provider_message_json, sequence, created_at)
-                VALUES (?, ?, NULL, ?, NULL, ?, ?, ?, 0, ?)
-                """,
-                bindings: [
-                    .text(userNodeID),
-                    .text(conversationID),
-                    .text(CPSLChatRole.user.rawValue),
-                    .text(userText),
-                    .nullableText(model),
-                    .text(providerJSON),
-                    .date(now)
-                ]
-            )
+        guard state.conversations[conversationID] == nil else {
+            throw CPSLConversationStoreError.conversationAlreadyExists
         }
-
-        let summary = CPSLConversationSummary(
-            id: conversationID,
-            title: title,
-            currentNodeID: userNodeID,
-            model: model,
-            createdAt: now,
-            updatedAt: now,
-            pinned: false,
-            archived: false
-        )
-        let node = CPSLStoredNode(
+        let userNode = CPSLStoredNode(
             id: userNodeID,
             conversationID: conversationID,
             parentID: nil,
@@ -208,11 +108,31 @@ actor CPSLConversationStore {
             title: nil,
             body: userText,
             model: model,
-            providerMessage: providerMessage,
+            providerMessage: .user(providerText ?? userText),
             sequence: 0,
             createdAt: now
         )
-        return (summary, node)
+        let conversation = CPSLConversationLogRecord(
+            id: conversationID,
+            title: Self.generateTitle(from: userText),
+            currentNodeID: userNodeID,
+            model: model,
+            systemPrompt: systemPrompt,
+            createdAt: now,
+            updatedAt: now,
+            pinned: false,
+            archived: false,
+            nodes: [userNode]
+        )
+        try appendConversationEvent(
+            CPSLConversationLogEvent(
+                timestamp: now,
+                kind: .conversationCreated,
+                conversationID: conversationID,
+                conversation: conversation
+            )
+        )
+        return (conversation.summary, userNode)
     }
 
     func appendNode(
@@ -220,50 +140,7 @@ actor CPSLConversationStore {
         parentID: String?,
         draft: CPSLNodeAppendDraft
     ) throws -> CPSLStoredNode {
-        var sequence = 0
-        let now = Date()
-        let nodeID = UUID().uuidString
-        let providerJSON = try draft.providerMessage.map(encodeProviderMessage)
-
-        try withTransaction {
-            guard let parentID else {
-                throw CPSLConversationStoreError.parentRequired
-            }
-            try assertParentBelongsToConversation(parentID: parentID, conversationID: conversationID)
-            sequence = try nextSequence(conversationID: conversationID)
-            try execute(
-                """
-                INSERT INTO nodes (id, conversation_id, parent_id, role, title, body, model, provider_message_json, sequence, created_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                bindings: [
-                    .text(nodeID),
-                    .text(conversationID),
-                    .nullableText(parentID),
-                    .text(draft.role.rawValue),
-                    .nullableText(draft.title),
-                    .text(draft.body),
-                    .nullableText(draft.model),
-                    .nullableText(providerJSON),
-                    .int(sequence),
-                    .date(now)
-                ]
-            )
-            try updateConversationCurrentNode(conversationID: conversationID, currentNodeID: nodeID, updatedAt: now)
-        }
-
-        return CPSLStoredNode(
-            id: nodeID,
-            conversationID: conversationID,
-            parentID: parentID,
-            role: draft.role,
-            title: draft.title,
-            body: draft.body,
-            model: draft.model,
-            providerMessage: draft.providerMessage,
-            sequence: sequence,
-            createdAt: now
-        )
+        try appendNodes(conversationID: conversationID, parentID: parentID, drafts: [draft])[0]
     }
 
     func appendNodes(
@@ -274,110 +151,97 @@ actor CPSLConversationStore {
         guard !drafts.isEmpty else {
             return []
         }
+        guard let parentID else {
+            throw CPSLConversationStoreError.parentRequired
+        }
+        let state = try loadState()
+        guard let conversation = state.conversations[conversationID],
+              conversation.nodes.contains(where: { $0.id == parentID })
+        else {
+            throw CPSLConversationStoreError.parentConversationMismatch
+        }
 
         let now = Date()
-        let prepared = try drafts.map { draft in
-            (
+        var nextSequence = (conversation.nodes.map(\.sequence).max() ?? -1) + 1
+        var currentParentID = parentID
+        let nodes = drafts.map { draft in
+            defer { nextSequence += 1 }
+            let node = CPSLStoredNode(
                 id: UUID().uuidString,
-                draft: draft,
-                providerJSON: try draft.providerMessage.map(encodeProviderMessage)
-            )
-        }
-        var insertedNodes: [CPSLStoredNode] = []
-
-        try withTransaction {
-            guard let parentID else {
-                throw CPSLConversationStoreError.parentRequired
-            }
-            try assertParentBelongsToConversation(parentID: parentID, conversationID: conversationID)
-
-            var sequence = try nextSequence(conversationID: conversationID)
-            var currentParentID = parentID
-            for item in prepared {
-                try execute(
-                    """
-                    INSERT INTO nodes (id, conversation_id, parent_id, role, title, body, model, provider_message_json, sequence, created_at)
-                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                    """,
-                    bindings: [
-                        .text(item.id),
-                        .text(conversationID),
-                        .nullableText(currentParentID),
-                        .text(item.draft.role.rawValue),
-                        .nullableText(item.draft.title),
-                        .text(item.draft.body),
-                        .nullableText(item.draft.model),
-                        .nullableText(item.providerJSON),
-                        .int(sequence),
-                        .date(now)
-                    ]
-                )
-                insertedNodes.append(
-                    CPSLStoredNode(
-                        id: item.id,
-                        conversationID: conversationID,
-                        parentID: currentParentID,
-                        role: item.draft.role,
-                        title: item.draft.title,
-                        body: item.draft.body,
-                        model: item.draft.model,
-                        providerMessage: item.draft.providerMessage,
-                        sequence: sequence,
-                        createdAt: now
-                    )
-                )
-                currentParentID = item.id
-                sequence += 1
-            }
-
-            try updateConversationCurrentNode(
                 conversationID: conversationID,
-                currentNodeID: currentParentID,
-                updatedAt: now
+                parentID: currentParentID,
+                role: draft.role,
+                title: draft.title,
+                body: draft.body,
+                model: draft.model,
+                providerMessage: draft.providerMessage,
+                sequence: nextSequence,
+                createdAt: now
             )
+            currentParentID = node.id
+            return node
         }
-
-        return insertedNodes
+        try appendConversationEvent(
+            CPSLConversationLogEvent(
+                timestamp: now,
+                kind: .nodesAppended,
+                conversationID: conversationID,
+                nodes: nodes
+            )
+        )
+        return nodes
     }
 
-    func updateNodeBody(id: String, body: String) throws {
-        try execute(
-            "UPDATE nodes SET body = ? WHERE id = ?",
-            bindings: [.text(body), .text(id)]
-        )
-        if let conversationID = try conversationID(forNode: id) {
-            try execute(
-                "UPDATE conversations SET updated_at = ? WHERE id = ?",
-                bindings: [.date(Date()), .text(conversationID)]
+    func updateNodeBody(conversationID: String, id: String, body: String) throws {
+        try appendConversationEvent(
+            CPSLConversationLogEvent(
+                kind: .nodeBodyUpdated,
+                conversationID: conversationID,
+                nodeID: id,
+                body: body
             )
-        }
+        )
     }
 
     func updateConversationModelIfMissing(conversationID: String, model: String) throws {
-        try execute(
-            "UPDATE conversations SET model = ? WHERE id = ? AND model IS NULL",
-            bindings: [.text(model), .text(conversationID)]
+        guard let conversation = try loadState().conversations[conversationID] else {
+            throw CPSLConversationStoreError.conversationNotFound
+        }
+        guard conversation.model == nil else {
+            return
+        }
+        try appendConversationEvent(
+            CPSLConversationLogEvent(
+                kind: .conversationModelSet,
+                conversationID: conversationID,
+                model: model
+            )
         )
     }
 
     func deleteConversation(id: String) throws {
-        try execute(
-            "DELETE FROM conversations WHERE id = ?",
-            bindings: [.text(id)]
+        try appendConversationEvent(
+            CPSLConversationLogEvent(kind: .conversationDeleted, conversationID: id)
         )
     }
 
     func setPinned(conversationID: String, pinned: Bool) throws {
-        try execute(
-            "UPDATE conversations SET pinned = ? WHERE id = ?",
-            bindings: [.int(pinned ? 1 : 0), .text(conversationID)]
+        try appendConversationEvent(
+            CPSLConversationLogEvent(
+                kind: .conversationPinned,
+                conversationID: conversationID,
+                flag: pinned
+            )
         )
     }
 
     func setArchived(conversationID: String, archived: Bool) throws {
-        try execute(
-            "UPDATE conversations SET archived = ? WHERE id = ?",
-            bindings: [.int(archived ? 1 : 0), .text(conversationID)]
+        try appendConversationEvent(
+            CPSLConversationLogEvent(
+                kind: .conversationArchived,
+                conversationID: conversationID,
+                flag: archived
+            )
         )
     }
 
@@ -386,9 +250,12 @@ actor CPSLConversationStore {
         guard !trimmed.isEmpty else {
             throw CPSLConversationStoreError.invalidTitle
         }
-        try execute(
-            "UPDATE conversations SET title = ?, title_is_custom = 1 WHERE id = ?",
-            bindings: [.text(trimmed), .text(id)]
+        try appendConversationEvent(
+            CPSLConversationLogEvent(
+                kind: .conversationRenamed,
+                conversationID: id,
+                title: trimmed
+            )
         )
     }
 
@@ -401,403 +268,275 @@ actor CPSLConversationStore {
     }
 
     func allTags() throws -> [CPSLTag] {
-        try query(
-            "SELECT id, name, color, created_at FROM tags ORDER BY name COLLATE NOCASE ASC"
-        ) { statement in
-            CPSLTag(
-                id: columnString(statement, 0) ?? "",
-                name: columnString(statement, 1) ?? "",
-                color: columnString(statement, 2) ?? "",
-                createdAt: columnDate(statement, 3)
-            )
+        try loadState().tags.values.sorted {
+            $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
         }
-    }
-
-    private func tagNameExists(_ name: String, excludingID: String?) throws -> Bool {
-        let rows = try query(
-            "SELECT id FROM tags WHERE name = ? COLLATE NOCASE",
-            bindings: [.text(name)]
-        ) { statement in
-            columnString(statement, 0) ?? ""
-        }
-        return rows.contains { $0 != excludingID }
     }
 
     func createTag(name: String, color: String) throws -> CPSLTag {
         let clean = try Self.normalizedTagName(name)
-        guard try !tagNameExists(clean, excludingID: nil) else {
+        let state = try loadState()
+        guard !Self.tagNameExists(clean, in: state, excludingID: nil) else {
             throw CPSLConversationStoreError.duplicateTagName
         }
         let tag = CPSLTag(id: UUID().uuidString, name: clean, color: color, createdAt: Date())
-        try execute(
-            "INSERT INTO tags (id, name, color, created_at) VALUES (?, ?, ?, ?)",
-            bindings: [.text(tag.id), .text(tag.name), .text(tag.color), .date(tag.createdAt)]
-        )
+        try appendConversationEvent(CPSLConversationLogEvent(kind: .tagCreated, tag: tag))
         return tag
     }
 
     func renameTag(id: String, name: String) throws {
         let clean = try Self.normalizedTagName(name)
-        guard try !tagNameExists(clean, excludingID: id) else {
+        let state = try loadState()
+        guard !Self.tagNameExists(clean, in: state, excludingID: id) else {
             throw CPSLConversationStoreError.duplicateTagName
         }
-        try execute("UPDATE tags SET name = ? WHERE id = ?", bindings: [.text(clean), .text(id)])
+        try appendConversationEvent(
+            CPSLConversationLogEvent(kind: .tagRenamed, title: clean, tagID: id)
+        )
     }
 
     func deleteTag(id: String) throws {
-        try execute("DELETE FROM tags WHERE id = ?", bindings: [.text(id)])
+        try appendConversationEvent(CPSLConversationLogEvent(kind: .tagDeleted, tagID: id))
     }
 
     func tagIDs(forConversation id: String) throws -> Set<String> {
-        let rows = try query(
-            "SELECT tag_id FROM conversation_tags WHERE conversation_id = ?",
-            bindings: [.text(id)]
-        ) { statement in
-            columnString(statement, 0) ?? ""
-        }
-        return Set(rows)
+        try loadState().conversationTags[id] ?? []
     }
 
     func setTags(conversationID: String, tagIDs: Set<String>) throws {
-        try withTransaction {
-            try execute(
-                "DELETE FROM conversation_tags WHERE conversation_id = ?",
-                bindings: [.text(conversationID)]
+        try appendConversationEvent(
+            CPSLConversationLogEvent(
+                kind: .conversationTagsSet,
+                conversationID: conversationID,
+                tagIDs: tagIDs.sorted()
             )
-            for tagID in tagIDs {
-                try execute(
-                    "INSERT INTO conversation_tags (conversation_id, tag_id) VALUES (?, ?)",
-                    bindings: [.text(conversationID), .text(tagID)]
-                )
-            }
-        }
+        )
     }
 
     func providerMessages(conversationID: String) throws -> [CPSLOpenAIMessage] {
         try loadNodes(conversationID: conversationID).compactMap(\.providerMessage)
     }
 
-    private nonisolated static func migrate(database: OpaquePointer?) throws {
-        try execute("PRAGMA journal_mode=DELETE", database: database)
-        try execute("PRAGMA synchronous=FULL", database: database)
-        try execute("PRAGMA foreign_keys=ON", database: database)
-        try execute(
-            """
-            CREATE TABLE IF NOT EXISTS conversations (
-                id TEXT PRIMARY KEY,
-                title TEXT NOT NULL,
-                root_node_id TEXT,
-                current_node_id TEXT,
-                model TEXT,
-                system_prompt TEXT,
-                created_at REAL NOT NULL,
-                updated_at REAL NOT NULL
-            )
-            """,
-            database: database
-        )
-        try addColumnIfMissing(.init(table: "conversations", column: "root_node_id", definition: "TEXT"), database: database)
-        try addColumnIfMissing(.init(table: "conversations", column: "current_node_id", definition: "TEXT"), database: database)
-        try addColumnIfMissing(.init(table: "conversations", column: "model", definition: "TEXT"), database: database)
-        try addColumnIfMissing(.init(table: "conversations", column: "system_prompt", definition: "TEXT"), database: database)
-        try execute(
-            """
-            CREATE TABLE IF NOT EXISTS nodes (
-                id TEXT PRIMARY KEY,
-                conversation_id TEXT NOT NULL,
-                parent_id TEXT,
-                role TEXT NOT NULL,
-                title TEXT,
-                body TEXT NOT NULL,
-                model TEXT,
-                provider_message_json TEXT,
-                sequence INTEGER NOT NULL,
-                created_at REAL NOT NULL,
-                FOREIGN KEY(conversation_id) REFERENCES conversations(id) ON DELETE CASCADE,
-                FOREIGN KEY(parent_id) REFERENCES nodes(id) ON DELETE SET NULL
-            )
-            """,
-            database: database
-        )
-        try addColumnIfMissing(.init(table: "nodes", column: "title", definition: "TEXT"), database: database)
-        try addColumnIfMissing(.init(table: "nodes", column: "model", definition: "TEXT"), database: database)
-        try addColumnIfMissing(.init(table: "nodes", column: "provider_message_json", definition: "TEXT"), database: database)
-        try backfillLegacyConversationPointers(database: database)
-
-        try addColumnIfMissing(.init(table: "conversations", column: "pinned", definition: "INTEGER NOT NULL DEFAULT 0"), database: database)
-        try addColumnIfMissing(.init(table: "conversations", column: "archived", definition: "INTEGER NOT NULL DEFAULT 0"), database: database)
-        try addColumnIfMissing(.init(table: "conversations", column: "title_is_custom", definition: "INTEGER NOT NULL DEFAULT 0"), database: database)
-
-        try execute(
-            """
-            CREATE TABLE IF NOT EXISTS tags (
-                id TEXT PRIMARY KEY,
-                name TEXT NOT NULL,
-                color TEXT NOT NULL,
-                created_at REAL NOT NULL
-            )
-            """,
-            database: database
-        )
-        try execute(
-            """
-            CREATE TABLE IF NOT EXISTS conversation_tags (
-                conversation_id TEXT NOT NULL,
-                tag_id TEXT NOT NULL,
-                PRIMARY KEY (conversation_id, tag_id),
-                FOREIGN KEY(conversation_id) REFERENCES conversations(id) ON DELETE CASCADE,
-                FOREIGN KEY(tag_id) REFERENCES tags(id) ON DELETE CASCADE
-            )
-            """,
-            database: database
-        )
-
-        try execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_nodes_conversation_sequence_unique ON nodes(conversation_id, sequence)", database: database)
-        try execute("CREATE INDEX IF NOT EXISTS idx_nodes_parent ON nodes(parent_id)", database: database)
-        try execute("CREATE INDEX IF NOT EXISTS idx_conversations_updated_at ON conversations(updated_at)", database: database)
-        try execute("CREATE INDEX IF NOT EXISTS idx_conversations_archived_updated ON conversations(archived, updated_at DESC)", database: database)
-        try execute("CREATE INDEX IF NOT EXISTS idx_conversations_pinned_updated ON conversations(pinned, updated_at DESC)", database: database)
-        try execute("CREATE INDEX IF NOT EXISTS idx_conversation_tags_tag ON conversation_tags(tag_id, conversation_id)", database: database)
-    }
-
-    private nonisolated static func backfillLegacyConversationPointers(database: OpaquePointer?) throws {
-        try execute(
-            """
-            UPDATE conversations
-            SET root_node_id = (
-                SELECT id
-                FROM nodes
-                WHERE nodes.conversation_id = conversations.id
-                ORDER BY sequence ASC, created_at ASC
-                LIMIT 1
-            )
-            WHERE NULLIF(root_node_id, '') IS NULL
-            """,
-            database: database
-        )
-        try execute(
-            """
-            UPDATE conversations
-            SET current_node_id = (
-                SELECT id
-                FROM nodes
-                WHERE nodes.conversation_id = conversations.id
-                ORDER BY sequence DESC, created_at DESC
-                LIMIT 1
-            )
-            WHERE NULLIF(current_node_id, '') IS NULL
-            """,
-            database: database
-        )
-        try execute("UPDATE conversations SET system_prompt = '' WHERE system_prompt IS NULL", database: database)
-    }
-
-    private nonisolated static func addColumnIfMissing(
-        _ column: CPSLSQLiteColumnMigration,
-        database: OpaquePointer?
-    ) throws {
-        guard !column.table.contains("\""),
-                !column.name.contains("\""),
-                !column.definition.contains(";")
-        else {
-            throw CPSLConversationStoreError.sqlite("Invalid migration identifier.")
-        }
-
-        let columns = try query(.init("PRAGMA table_info(\"\(column.table)\")"), database: database) { statement in
-            columnString(statement, 1) ?? ""
-        }
-        guard !columns.contains(column.name) else {
-            return
-        }
-
-        try execute(
-            "ALTER TABLE \"\(column.table)\" ADD COLUMN \"\(column.name)\" \(column.definition)",
-            database: database
-        )
-    }
-
-    private func nextSequence(conversationID: String) throws -> Int {
-        let values = try query(
-            "SELECT COALESCE(MAX(sequence), -1) + 1 FROM nodes WHERE conversation_id = ?",
-            bindings: [.text(conversationID)]
-        ) { statement in
-            Int(sqlite3_column_int(statement, 0))
-        }
-        return values.first ?? 0
-    }
-
-    private func assertParentBelongsToConversation(parentID: String, conversationID: String) throws {
-        let values = try query(
-            "SELECT 1 FROM nodes WHERE id = ? AND conversation_id = ? LIMIT 1",
-            bindings: [.text(parentID), .text(conversationID)]
-        ) { _ in
-            true
-        }
-        if values.first != true {
-            throw CPSLConversationStoreError.parentConversationMismatch
-        }
-    }
-
-    private func conversationID(forNode id: String) throws -> String? {
-        try query(
-            "SELECT conversation_id FROM nodes WHERE id = ? LIMIT 1",
-            bindings: [.text(id)]
-        ) { statement in
-            columnString(statement, 0)
-        }
-        .first ?? nil
-    }
-
-    private func updateConversationCurrentNode(
+    func recordProviderRequest(
         conversationID: String,
-        currentNodeID: String,
-        updatedAt: Date
+        model: String,
+        messages: [CPSLOpenAIMessage],
+        tools: [CPSLOpenAITool],
+        maxTokens: Int?,
+        scope: String
     ) throws {
-        try execute(
-            "UPDATE conversations SET current_node_id = ?, updated_at = ? WHERE id = ?",
-            bindings: [.text(currentNodeID), .date(updatedAt), .text(conversationID)]
+        try appendTraceEvent(
+            CPSLTraceEvent(
+                conversationID: conversationID,
+                kind: .providerRequest,
+                scope: scope,
+                providerRequest: CPSLProviderRequestTrace(
+                    model: model,
+                    messages: messages,
+                    tools: tools,
+                    maxTokens: maxTokens
+                )
+            )
         )
     }
 
-    private func encodeProviderMessage(_ message: CPSLOpenAIMessage) throws -> String {
-        let data = try JSONEncoder().encode(message)
-        return String(decoding: data, as: UTF8.self)
-    }
-
-    private func decodeProviderMessage(_ json: String?) -> CPSLOpenAIMessage? {
-        guard let json, let data = json.data(using: .utf8) else {
-            return nil
-        }
-        return try? JSONDecoder().decode(CPSLOpenAIMessage.self, from: data)
-    }
-
-    private func execute(_ sql: String, bindings: [CPSLSQLiteBinding] = []) throws {
-        try Self.execute(sql, bindings: bindings, database: database)
-    }
-
-    private func withTransaction(_ work: () throws -> Void) throws {
-        try execute("BEGIN IMMEDIATE TRANSACTION")
-        do {
-            try work()
-            try execute("COMMIT")
-        } catch {
-            try? execute("ROLLBACK")
-            throw error
-        }
-    }
-
-    private func query<T>(
-        _ sql: String,
-        bindings: [CPSLSQLiteBinding] = [],
-        row: (OpaquePointer?) throws -> T
-    ) throws -> [T] {
-        try Self.query(.init(sql, bindings: bindings), database: database, row: row)
-    }
-
-    private nonisolated static func execute(
-        _ sql: String,
-        bindings: [CPSLSQLiteBinding] = [],
-        database: OpaquePointer?
+    func recordProviderResponse(
+        conversationID: String,
+        completion: CPSLOpenAICompletion,
+        scope: String
     ) throws {
-        let statement = try prepare(sql, bindings: bindings, database: database)
-        defer {
-            sqlite3_finalize(statement)
+        try appendTraceEvent(
+            CPSLTraceEvent(
+                conversationID: conversationID,
+                kind: .providerResponse,
+                scope: scope,
+                providerResponse: CPSLProviderResponseTrace(completion: completion)
+            )
+        )
+    }
+
+    func recordToolInvocation(
+        conversationID: String,
+        nodeID: String?,
+        invocation: CPSLToolTraceInvocation
+    ) throws {
+        try appendTraceEvent(
+            CPSLTraceEvent(
+                conversationID: conversationID,
+                kind: .toolInvocation,
+                nodeID: nodeID,
+                toolInvocation: invocation
+            )
+        )
+    }
+
+    func toolStatusInvocations(
+        conversationID: String,
+        nodeIDs: Set<String>,
+        limitPerNode: Int = 4
+    ) throws -> [String: [CPSLToolStatusInvocation]] {
+        guard !nodeIDs.isEmpty, limitPerNode > 0 else {
+            return [:]
         }
-        while true {
-            let result = sqlite3_step(statement)
-            if result == SQLITE_DONE {
+
+        var result: [String: [CPSLToolStatusInvocation]] = [:]
+        try Self.forEachJSONLine(CPSLToolInvocationTraceEnvelope.self, from: traceLogURL) { event in
+            guard event.conversationID == conversationID,
+                  event.kind == .toolInvocation,
+                  let nodeID = event.nodeID,
+                  nodeIDs.contains(nodeID),
+                  let invocation = event.toolInvocation
+            else {
                 return
             }
-            if result != SQLITE_ROW {
-                throw lastError(database: database)
-            }
+
+            var invocations = result[nodeID, default: []]
+            invocations.append(CPSLToolStatusInvocation(traceInvocation: invocation))
+            result[nodeID] = Array(invocations.suffix(limitPerNode))
         }
+        return result
     }
 
-    private nonisolated static func query<T>(
-        _ request: CPSLSQLiteStatementRequest,
-        database: OpaquePointer?,
-        row: (OpaquePointer?) throws -> T
-    ) throws -> [T] {
-        let statement = try prepare(request.sql, bindings: request.bindings, database: database)
-        defer {
-            sqlite3_finalize(statement)
-        }
-
-        var values: [T] = []
-        while true {
-            let result = sqlite3_step(statement)
-            if result == SQLITE_ROW {
-                values.append(try row(statement))
-            } else if result == SQLITE_DONE {
-                return values
-            } else {
-                throw lastError(database: database)
-            }
-        }
-    }
-
-    private nonisolated static func prepare(
-        _ sql: String,
-        bindings: [CPSLSQLiteBinding],
-        database: OpaquePointer?
-    ) throws -> OpaquePointer? {
-        var statement: OpaquePointer?
-        guard sqlite3_prepare_v2(database, sql, -1, &statement, nil) == SQLITE_OK else {
-            throw lastError(database: database)
-        }
-        for (index, binding) in bindings.enumerated() {
-            try bind(
-                CPSLSQLiteBindOperation(
-                    binding: binding,
-                    statement: statement,
-                    index: Int32(index + 1)
-                ),
-                database: database
-            )
-        }
-        return statement
-    }
-
-    private nonisolated static func bind(
-        _ operation: CPSLSQLiteBindOperation,
-        database: OpaquePointer?
+    func recordWebVisit(
+        conversationID: String,
+        nodeID: String,
+        visit: CPSLWebSearchVisit
     ) throws {
-        let result: Int32
-        switch operation.binding {
-        case .null:
-            result = sqlite3_bind_null(operation.statement, operation.index)
-        case .text(let value):
-            result = sqlite3_bind_text(operation.statement, operation.index, value, -1, sqliteTransient)
-        case .int(let value):
-            result = sqlite3_bind_int(operation.statement, operation.index, Int32(value))
-        case .date(let value):
-            result = sqlite3_bind_double(operation.statement, operation.index, value.timeIntervalSince1970)
-        }
-        guard result == SQLITE_OK else {
-            throw lastError(database: database)
-        }
-    }
-
-    private func storedNode(from statement: OpaquePointer?) -> CPSLStoredNode {
-        let providerJSON = columnString(statement, 7)
-        return CPSLStoredNode(
-            id: columnString(statement, 0) ?? "",
-            conversationID: columnString(statement, 1) ?? "",
-            parentID: columnString(statement, 2),
-            role: CPSLChatRole(rawValue: columnString(statement, 3) ?? "") ?? .assistant,
-            title: columnString(statement, 4),
-            body: columnString(statement, 5) ?? "",
-            model: columnString(statement, 6),
-            providerMessage: decodeProviderMessage(providerJSON),
-            sequence: Int(sqlite3_column_int(statement, 8)),
-            createdAt: columnDate(statement, 9)
+        try appendTraceEvent(
+            CPSLTraceEvent(
+                conversationID: conversationID,
+                kind: .webVisit,
+                nodeID: nodeID,
+                webVisit: visit
+            )
         )
     }
 
-    private nonisolated static func lastError(database: OpaquePointer?) -> CPSLConversationStoreError {
-        let message = database.map { String(cString: sqlite3_errmsg($0)) } ?? "unknown SQLite error"
-        return .sqlite(message)
+    func recordError(conversationID: String, message: String, scope: String) throws {
+        try appendTraceEvent(
+            CPSLTraceEvent(
+                conversationID: conversationID,
+                kind: .error,
+                scope: scope,
+                message: message
+            )
+        )
+    }
+
+    private func loadState() throws -> CPSLConversationLogState {
+        Self.replay(try loadConversationEvents())
+    }
+
+    private func loadConversationEvents() throws -> [CPSLConversationLogEvent] {
+        try Self.readJSONLines(CPSLConversationLogEvent.self, from: conversationLogURL)
+    }
+
+    private func appendConversationEvent(_ event: CPSLConversationLogEvent) throws {
+        try Self.appendJSONLine(event, to: conversationLogURL)
+    }
+
+    private func appendTraceEvent(_ event: CPSLTraceEvent) throws {
+        try Self.appendJSONLine(event, to: traceLogURL)
+    }
+
+    private static func replay(_ events: [CPSLConversationLogEvent]) -> CPSLConversationLogState {
+        var state = CPSLConversationLogState()
+        for event in events {
+            switch event.kind {
+            case .conversationCreated:
+                guard let conversation = event.conversation,
+                      let conversationID = event.conversationID
+                else { continue }
+                state.conversations[conversationID] = conversation
+            case .nodesAppended:
+                guard let conversationID = event.conversationID,
+                      var conversation = state.conversations[conversationID],
+                      let nodes = event.nodes,
+                      let lastNode = nodes.last
+                else { continue }
+                conversation.nodes.append(contentsOf: nodes)
+                conversation.currentNodeID = lastNode.id
+                conversation.updatedAt = event.timestamp
+                state.conversations[conversationID] = conversation
+            case .nodeBodyUpdated:
+                guard let conversationID = event.conversationID,
+                      let nodeID = event.nodeID,
+                      let body = event.body,
+                      var conversation = state.conversations[conversationID],
+                      let index = conversation.nodes.firstIndex(where: { $0.id == nodeID })
+                else { continue }
+                conversation.nodes[index].body = body
+                conversation.updatedAt = event.timestamp
+                state.conversations[conversationID] = conversation
+            case .conversationModelSet:
+                guard let conversationID = event.conversationID,
+                      let model = event.model,
+                      var conversation = state.conversations[conversationID],
+                      conversation.model == nil
+                else { continue }
+                conversation.model = model
+                state.conversations[conversationID] = conversation
+            case .conversationDeleted:
+                guard let conversationID = event.conversationID else { continue }
+                state.conversations.removeValue(forKey: conversationID)
+                state.conversationTags.removeValue(forKey: conversationID)
+            case .conversationPinned:
+                guard let conversationID = event.conversationID,
+                      let flag = event.flag,
+                      var conversation = state.conversations[conversationID]
+                else { continue }
+                conversation.pinned = flag
+                state.conversations[conversationID] = conversation
+            case .conversationArchived:
+                guard let conversationID = event.conversationID,
+                      let flag = event.flag,
+                      var conversation = state.conversations[conversationID]
+                else { continue }
+                conversation.archived = flag
+                state.conversations[conversationID] = conversation
+            case .conversationRenamed:
+                guard let conversationID = event.conversationID,
+                      let title = event.title,
+                      var conversation = state.conversations[conversationID]
+                else { continue }
+                conversation.title = title
+                state.conversations[conversationID] = conversation
+            case .tagCreated:
+                guard let tag = event.tag else { continue }
+                state.tags[tag.id] = tag
+            case .tagRenamed:
+                guard let tagID = event.tagID,
+                      let name = event.title,
+                      var tag = state.tags[tagID]
+                else { continue }
+                tag.name = name
+                state.tags[tagID] = tag
+            case .tagDeleted:
+                guard let tagID = event.tagID else { continue }
+                state.tags.removeValue(forKey: tagID)
+                for conversationID in Array(state.conversationTags.keys) {
+                    state.conversationTags[conversationID]?.remove(tagID)
+                }
+            case .conversationTagsSet:
+                guard let conversationID = event.conversationID else { continue }
+                state.conversationTags[conversationID] = Set(event.tagIDs ?? [])
+            }
+        }
+        return state
+    }
+
+    private static func nodeOrder(_ lhs: CPSLStoredNode, _ rhs: CPSLStoredNode) -> Bool {
+        lhs.sequence == rhs.sequence ? lhs.createdAt < rhs.createdAt : lhs.sequence < rhs.sequence
+    }
+
+    private static func tagNameExists(
+        _ name: String,
+        in state: CPSLConversationLogState,
+        excludingID: String?
+    ) -> Bool {
+        state.tags.values.contains {
+            $0.id != excludingID && $0.name.caseInsensitiveCompare(name) == .orderedSame
+        }
     }
 
     private static func generateTitle(from text: String) -> String {
@@ -807,15 +546,139 @@ actor CPSLConversationStore {
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return singleLine.isEmpty ? "Untitled" : singleLine
     }
+
+    private static func prepareLog(at url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        guard !FileManager.default.fileExists(atPath: url.path) else {
+            return
+        }
+        guard FileManager.default.createFile(atPath: url.path, contents: nil) else {
+            throw CPSLConversationStoreError.couldNotCreateLog(url.lastPathComponent)
+        }
+    }
+
+    private static func appendJSONLine<Value: Encodable>(_ value: Value, to url: URL) throws {
+        var data = try jsonEncoder().encode(value)
+        data.append(0x0A)
+        let handle = try FileHandle(forUpdating: url)
+        defer { try? handle.close() }
+        try repairPartialTail(in: handle, at: url)
+        try handle.seekToEnd()
+        try handle.write(contentsOf: data)
+        try handle.synchronize()
+    }
+
+    private static func repairPartialTail(in handle: FileHandle, at url: URL) throws {
+        let endOffset = try handle.seekToEnd()
+        guard endOffset > 0 else {
+            return
+        }
+        try handle.seek(toOffset: endOffset - 1)
+        guard try handle.read(upToCount: 1) != Data([0x0A]) else {
+            return
+        }
+        let data = try Data(contentsOf: url, options: [.mappedIfSafe])
+        let validEnd = data.lastIndex(of: 0x0A).map { $0 + 1 } ?? 0
+        try handle.truncate(atOffset: UInt64(validEnd))
+    }
+
+    private static func readJSONLines<Value: Decodable>(_ type: Value.Type, from url: URL) throws -> [Value] {
+        var values: [Value] = []
+        try forEachJSONLine(type, from: url) { value in
+            values.append(value)
+        }
+        return values
+    }
+
+    private static func forEachJSONLine<Value: Decodable>(
+        _ type: Value.Type,
+        from url: URL,
+        consume: (Value) -> Void
+    ) throws {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+
+        let decoder = jsonDecoder()
+        var buffer = Data()
+        var lineNumber = 0
+
+        while let chunk = try handle.read(upToCount: 64 * 1_024), !chunk.isEmpty {
+            buffer.append(chunk)
+            var lineStart = buffer.startIndex
+
+            while let newline = buffer[lineStart...].firstIndex(of: 0x0A) {
+                lineNumber += 1
+                if lineStart < newline {
+                    do {
+                        consume(try decoder.decode(type, from: Data(buffer[lineStart..<newline])))
+                    } catch {
+                        throw CPSLConversationStoreError.corruptLogLine(
+                            lineNumber,
+                            url.lastPathComponent
+                        )
+                    }
+                }
+                lineStart = buffer.index(after: newline)
+            }
+
+            if lineStart > buffer.startIndex {
+                buffer.removeSubrange(buffer.startIndex..<lineStart)
+            }
+        }
+
+        guard !buffer.isEmpty else {
+            return
+        }
+
+        // A valid final line without a newline is accepted. An undecodable tail is an interrupted append.
+        if let value = try? decoder.decode(type, from: buffer) {
+            consume(value)
+        }
+    }
+
+    private static func jsonEncoder(prettyPrinted: Bool = false) -> JSONEncoder {
+        let encoder = JSONEncoder()
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        encoder.dateEncodingStrategy = .custom { date, encoder in
+            var container = encoder.singleValueContainer()
+            try container.encode(formatter.string(from: date))
+        }
+        encoder.outputFormatting = prettyPrinted ? [.prettyPrinted, .sortedKeys] : [.sortedKeys]
+        return encoder
+    }
+
+    private static func jsonDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let secondPrecisionFormatter = ISO8601DateFormatter()
+        secondPrecisionFormatter.formatOptions = [.withInternetDateTime]
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let value = try decoder.singleValueContainer().decode(String.self)
+            guard let date = formatter.date(from: value)
+                ?? secondPrecisionFormatter.date(from: value)
+            else {
+                throw DecodingError.dataCorrupted(
+                    .init(codingPath: decoder.codingPath, debugDescription: "Invalid ISO-8601 date.")
+                )
+            }
+            return date
+        }
+        return decoder
+    }
 }
 
-nonisolated struct CPSLLoadedConversation: Equatable, Sendable, Encodable {
+nonisolated struct CPSLLoadedConversation: Equatable, Sendable, Codable {
     let summary: CPSLConversationSummary
     let systemPrompt: String
     let nodes: [CPSLStoredNode]
 }
 
-nonisolated struct CPSLConversationSummary: Identifiable, Equatable, Sendable, Encodable {
+nonisolated struct CPSLConversationSummary: Identifiable, Equatable, Sendable, Codable {
     let id: String
     let title: String
     let currentNodeID: String?
@@ -826,7 +689,7 @@ nonisolated struct CPSLConversationSummary: Identifiable, Equatable, Sendable, E
     let archived: Bool
 }
 
-nonisolated struct CPSLTag: Identifiable, Equatable, Sendable, Encodable {
+nonisolated struct CPSLTag: Identifiable, Equatable, Sendable, Codable {
     let id: String
     var name: String
     var color: String
@@ -838,7 +701,7 @@ nonisolated enum CPSLArchiveScope: Sendable, Equatable {
     case archived
 }
 
-nonisolated struct CPSLStoredNode: Identifiable, Equatable, Sendable, Encodable {
+nonisolated struct CPSLStoredNode: Identifiable, Equatable, Sendable, Codable {
     let id: String
     let conversationID: String
     let parentID: String?
@@ -854,19 +717,12 @@ nonisolated struct CPSLStoredNode: Identifiable, Equatable, Sendable, Encodable 
         guard role.isVisible else {
             return nil
         }
-        let presentationBody: String
-        if role == .toolStatus,
-           let payload = CPSLToolStatusPayload.decode(from: body) {
-            presentationBody = payload.presentationEncodedBody()
-        } else {
-            presentationBody = body
-        }
         let providerParts: (displayText: String, attachments: [CPSLAttachment]) = role == .user
             ? CPSLAttachmentPrompt.parse(providerMessage?.content)
             : (displayText: "", attachments: [])
         let bodyParts: (displayText: String, attachments: [CPSLAttachment]) = role == .user
-            ? CPSLAttachmentPrompt.parse(presentationBody)
-            : (displayText: presentationBody, attachments: [])
+            ? CPSLAttachmentPrompt.parse(body)
+            : (displayText: body, attachments: [])
         let attachments = providerParts.attachments.isEmpty
             ? bodyParts.attachments
             : providerParts.attachments
@@ -874,7 +730,7 @@ nonisolated struct CPSLStoredNode: Identifiable, Equatable, Sendable, Encodable 
             id: UUID(uuidString: id) ?? UUID(),
             role: role,
             title: title,
-            body: bodyParts.attachments.isEmpty ? presentationBody : bodyParts.displayText,
+            body: bodyParts.attachments.isEmpty ? body : bodyParts.displayText,
             attachments: attachments
         )
     }
@@ -888,90 +744,259 @@ nonisolated struct CPSLNodeAppendDraft: Equatable, Sendable {
     let providerMessage: CPSLOpenAIMessage?
 }
 
-private nonisolated struct CPSLSQLiteColumnMigration {
-    let table: String
-    let name: String
-    let definition: String
-
-    init(table: String, column: String, definition: String) {
-        self.table = table
-        name = column
-        self.definition = definition
-    }
-}
-
-private nonisolated struct CPSLSQLiteStatementRequest {
-    let sql: String
-    let bindings: [CPSLSQLiteBinding]
-
-    init(_ sql: String, bindings: [CPSLSQLiteBinding] = []) {
-        self.sql = sql
-        self.bindings = bindings
-    }
-}
-
-private nonisolated struct CPSLSQLiteBindOperation {
-    let binding: CPSLSQLiteBinding
-    let statement: OpaquePointer?
-    let index: Int32
-}
-
 nonisolated enum CPSLConversationStoreError: LocalizedError {
     case conversationNotFound
-    case openFailed(String)
+    case conversationAlreadyExists
     case parentRequired
     case parentConversationMismatch
-    case sqlite(String)
     case invalidTagName
     case duplicateTagName
     case invalidTitle
+    case couldNotCreateLog(String)
+    case corruptLogLine(Int, String)
 
     var errorDescription: String? {
         switch self {
         case .conversationNotFound:
             return "Conversation was not found."
-        case .openFailed(let message):
-            return "Could not open conversations database: \(message)"
+        case .conversationAlreadyExists:
+            return "Conversation already exists."
         case .parentRequired:
             return "Conversation nodes must have a parent node."
         case .parentConversationMismatch:
             return "Parent node does not belong to the conversation."
-        case .sqlite(let message):
-            return "SQLite error: \(message)"
         case .invalidTagName:
             return "Tag name is empty or too long."
         case .duplicateTagName:
             return "A tag with this name already exists."
         case .invalidTitle:
             return "Conversation title is empty."
+        case .couldNotCreateLog(let name):
+            return "Could not create JSONL log \(name)."
+        case .corruptLogLine(let line, let name):
+            return "Could not decode line \(line) of JSONL log \(name)."
         }
     }
 }
 
-private nonisolated enum CPSLSQLiteBinding {
-    case null
-    case text(String)
-    case int(Int)
-    case date(Date)
+private nonisolated struct CPSLConversationLogState {
+    var conversations: [String: CPSLConversationLogRecord] = [:]
+    var tags: [String: CPSLTag] = [:]
+    var conversationTags: [String: Set<String>] = [:]
+}
 
-    static func nullableText(_ value: String?) -> CPSLSQLiteBinding {
-        value.map(CPSLSQLiteBinding.text) ?? .null
+private nonisolated struct CPSLConversationLogRecord: Codable {
+    let id: String
+    var title: String
+    var currentNodeID: String?
+    var model: String?
+    let systemPrompt: String
+    let createdAt: Date
+    var updatedAt: Date
+    var pinned: Bool
+    var archived: Bool
+    var nodes: [CPSLStoredNode]
+
+    var summary: CPSLConversationSummary {
+        CPSLConversationSummary(
+            id: id,
+            title: title,
+            currentNodeID: currentNodeID,
+            model: model,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            pinned: pinned,
+            archived: archived
+        )
+    }
+
+    var loadedConversation: CPSLLoadedConversation {
+        CPSLLoadedConversation(summary: summary, systemPrompt: systemPrompt, nodes: nodes)
     }
 }
 
-private nonisolated struct CPSLConversationDatabaseLocation {
-    let url: URL
+private nonisolated enum CPSLConversationLogEventKind: String, Codable {
+    case conversationCreated = "conversation.created"
+    case nodesAppended = "nodes.appended"
+    case nodeBodyUpdated = "node.body_updated"
+    case conversationModelSet = "conversation.model_set"
+    case conversationDeleted = "conversation.deleted"
+    case conversationPinned = "conversation.pinned"
+    case conversationArchived = "conversation.archived"
+    case conversationRenamed = "conversation.renamed"
+    case tagCreated = "tag.created"
+    case tagRenamed = "tag.renamed"
+    case tagDeleted = "tag.deleted"
+    case conversationTagsSet = "conversation.tags_set"
+}
+
+private nonisolated struct CPSLConversationLogEvent: Codable {
+    let schemaVersion: Int
+    let id: String
+    let timestamp: Date
+    let kind: CPSLConversationLogEventKind
+    let conversationID: String?
+    let conversation: CPSLConversationLogRecord?
+    let nodes: [CPSLStoredNode]?
+    let nodeID: String?
+    let body: String?
+    let model: String?
+    let flag: Bool?
+    let title: String?
+    let tag: CPSLTag?
+    let tagID: String?
+    let tagIDs: [String]?
+
+    init(
+        timestamp: Date = Date(),
+        kind: CPSLConversationLogEventKind,
+        conversationID: String? = nil,
+        conversation: CPSLConversationLogRecord? = nil,
+        nodes: [CPSLStoredNode]? = nil,
+        nodeID: String? = nil,
+        body: String? = nil,
+        model: String? = nil,
+        flag: Bool? = nil,
+        title: String? = nil,
+        tag: CPSLTag? = nil,
+        tagID: String? = nil,
+        tagIDs: [String]? = nil
+    ) {
+        schemaVersion = 1
+        id = UUID().uuidString
+        self.timestamp = timestamp
+        self.kind = kind
+        self.conversationID = conversationID
+        self.conversation = conversation
+        self.nodes = nodes
+        self.nodeID = nodeID
+        self.body = body
+        self.model = model
+        self.flag = flag
+        self.title = title
+        self.tag = tag
+        self.tagID = tagID
+        self.tagIDs = tagIDs
+    }
+}
+
+private nonisolated enum CPSLTraceEventKind: String, Codable {
+    case providerRequest = "provider.request"
+    case providerResponse = "provider.response"
+    case toolInvocation = "tool.invocation"
+    case webVisit = "web.visit"
+    case error
+}
+
+private nonisolated struct CPSLProviderRequestTrace: Codable {
+    let model: String
+    let messages: [CPSLOpenAIMessage]
+    let tools: [CPSLOpenAITool]
+    let maxTokens: Int?
+}
+
+private nonisolated struct CPSLProviderResponseTrace: Codable {
+    let text: String
+    let toolCalls: [CPSLOpenAIToolCall]
+    let finishReason: String?
+    let model: String
+
+    init(completion: CPSLOpenAICompletion) {
+        text = completion.text
+        toolCalls = completion.toolCalls
+        finishReason = completion.finishReason
+        model = completion.model
+    }
+}
+
+private nonisolated struct CPSLToolInvocationTraceEnvelope: Decodable {
+    let conversationID: String
+    let kind: CPSLTraceEventKind
+    let nodeID: String?
+    let toolInvocation: CPSLToolTraceInvocation?
+}
+
+private nonisolated struct CPSLTraceEvent: Codable {
+    let schemaVersion: Int
+    let id: String
+    let timestamp: Date
+    let conversationID: String
+    let kind: CPSLTraceEventKind
+    let scope: String?
+    let nodeID: String?
+    let providerRequest: CPSLProviderRequestTrace?
+    let providerResponse: CPSLProviderResponseTrace?
+    let toolInvocation: CPSLToolTraceInvocation?
+    let webVisit: CPSLWebSearchVisit?
+    let message: String?
+
+    init(
+        conversationID: String,
+        kind: CPSLTraceEventKind,
+        scope: String? = nil,
+        nodeID: String? = nil,
+        providerRequest: CPSLProviderRequestTrace? = nil,
+        providerResponse: CPSLProviderResponseTrace? = nil,
+        toolInvocation: CPSLToolTraceInvocation? = nil,
+        webVisit: CPSLWebSearchVisit? = nil,
+        message: String? = nil
+    ) {
+        schemaVersion = 1
+        id = UUID().uuidString
+        timestamp = Date()
+        self.conversationID = conversationID
+        self.kind = kind
+        self.scope = scope
+        self.nodeID = nodeID
+        self.providerRequest = providerRequest
+        self.providerResponse = providerResponse
+        self.toolInvocation = toolInvocation
+        self.webVisit = webVisit
+        self.message = message
+    }
+}
+
+#if DEBUG
+private nonisolated struct CPSLConversationDebugExport: Encodable {
+    let format = "herm.debug-export"
+    let schemaVersion = 1
+    let generatedAt: Date
+    let documentation = CPSLConversationDebugExportDocumentation()
+    let conversation: CPSLLoadedConversation
+    let tags: [CPSLTag]
+    let conversationEvents: [CPSLConversationLogEvent]
+    let traceEvents: [CPSLTraceEvent]
+}
+
+private nonisolated struct CPSLConversationDebugExportDocumentation: Encodable {
+    let overview = "Reconstructed conversation plus the append-only JSONL events used to build and debug it."
+    let ordering = "conversationEvents and traceEvents are chronological. timestamp is ISO-8601 UTC; schemaVersion versions each entry."
+    let conversationEvents = "Durable state mutations from conversations.jsonl. Replay kind in order to reconstruct state."
+    let traceEvents = "Detailed provider, tool, web, and error records from traces.jsonl. These are not required to render the conversation."
+    let jqExamples = [
+        ".conversation.summary",
+        ".conversation.nodes[] | {sequence, role, title, body}",
+        ".traceEvents[] | select(.kind == \"tool.invocation\") | .toolInvocation",
+        ".traceEvents[] | select(.kind == \"provider.response\") | .providerResponse",
+    ]
+}
+#endif
+
+private nonisolated struct CPSLConversationLogLocation {
+    let conversationLogURL: URL
+    let traceLogURL: URL
     let usesICloudContainer: Bool
 
-    static func resolve() throws -> CPSLConversationDatabaseLocation {
+    static func resolve() throws -> CPSLConversationLogLocation {
         let fileManager = FileManager.default
         if let ubiquityURL = fileManager.url(forUbiquityContainerIdentifier: nil) {
             let directory = ubiquityURL
                 .appendingPathComponent("Documents", isDirectory: true)
                 .appendingPathComponent("Herm", isDirectory: true)
             try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
-            return CPSLConversationDatabaseLocation(
-                url: directory.appendingPathComponent("conversations.sqlite"),
+            return CPSLConversationLogLocation(
+                conversationLogURL: directory.appendingPathComponent("conversations.jsonl"),
+                traceLogURL: directory.appendingPathComponent("traces.jsonl"),
                 usesICloudContainer: true
             )
         }
@@ -987,26 +1012,10 @@ private nonisolated struct CPSLConversationDatabaseLocation {
             .appendingPathComponent(bundleID, isDirectory: true)
             .appendingPathComponent("Conversations", isDirectory: true)
         try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
-        return CPSLConversationDatabaseLocation(
-            url: directory.appendingPathComponent("conversations.sqlite"),
+        return CPSLConversationLogLocation(
+            conversationLogURL: directory.appendingPathComponent("conversations.jsonl"),
+            traceLogURL: directory.appendingPathComponent("traces.jsonl"),
             usesICloudContainer: false
         )
     }
-}
-
-private nonisolated func columnString(_ statement: OpaquePointer?, _ index: Int32) -> String? {
-    guard sqlite3_column_type(statement, index) != SQLITE_NULL,
-            let text = sqlite3_column_text(statement, index)
-    else {
-        return nil
-    }
-    return String(cString: text)
-}
-
-private nonisolated func columnDate(_ statement: OpaquePointer?, _ index: Int32) -> Date {
-    Date(timeIntervalSince1970: sqlite3_column_double(statement, index))
-}
-
-private nonisolated func columnBool(_ statement: OpaquePointer?, _ index: Int32) -> Bool {
-    sqlite3_column_int(statement, index) != 0
 }

--- a/app/apple/herm/Services/Agent/CPSLOpenAIProtocol.swift
+++ b/app/apple/herm/Services/Agent/CPSLOpenAIProtocol.swift
@@ -129,7 +129,7 @@ nonisolated struct CPSLOpenAIChatRequest: Encodable, Sendable {
     }
 }
 
-nonisolated struct CPSLOpenAITool: Encodable, Sendable {
+nonisolated struct CPSLOpenAITool: Codable, Sendable {
     let type: String
     let function: CPSLOpenAIToolFunction
 
@@ -202,13 +202,13 @@ nonisolated struct CPSLOpenAITool: Encodable, Sendable {
     }
 }
 
-nonisolated struct CPSLOpenAIToolFunction: Encodable, Sendable {
+nonisolated struct CPSLOpenAIToolFunction: Codable, Sendable {
     let name: String
     let description: String
     let parameters: CPSLOpenAIToolParameters
 }
 
-nonisolated struct CPSLOpenAIToolParameters: Encodable, Sendable {
+nonisolated struct CPSLOpenAIToolParameters: Codable, Sendable {
     let type: String
     let properties: [String: CPSLOpenAIToolParameter]
     let required: [String]
@@ -222,7 +222,7 @@ nonisolated struct CPSLOpenAIToolParameters: Encodable, Sendable {
     }
 }
 
-nonisolated struct CPSLOpenAIToolParameter: Encodable, Sendable {
+nonisolated struct CPSLOpenAIToolParameter: Codable, Sendable {
     let type: String
     let description: String
 }

--- a/app/apple/herm/Services/Agent/CPSLOpenAIProtocol.swift
+++ b/app/apple/herm/Services/Agent/CPSLOpenAIProtocol.swift
@@ -165,10 +165,14 @@ nonisolated struct CPSLOpenAITool: Encodable, Sendable {
         type: "function",
         function: CPSLOpenAIToolFunction(
             name: "agent",
-            description: "Spawn a focused sub-agent with its own turn budget. Use mode explore for research and reading. Use mode general for CPSL execution cycles or implementation-style work. Sub-agents return a concise result to this conversation and cannot access host shell tools.",
+            description: "Spawn a focused sub-agent with its own turn budget. Include intent: a short user-facing description of the expected work, without mentioning helpers, agents, tools, code, paths, or implementation details. Use mode explore for research and reading. Use mode general for CPSL execution cycles or implementation-style work. Sub-agents return a concise result to this conversation and cannot access host shell tools.",
             parameters: CPSLOpenAIToolParameters(
                 type: "object",
                 properties: [
+                    "intent": CPSLOpenAIToolParameter(
+                        type: "string",
+                        description: "Short user-facing action phrase shown as status, such as Comparing venue options or Verifying document details. Do not mention helpers, agents, tools, code, paths, or implementation details."
+                    ),
                     "task": CPSLOpenAIToolParameter(
                         type: "string",
                         description: "A clear, self-contained task for the sub-agent."
@@ -178,7 +182,7 @@ nonisolated struct CPSLOpenAITool: Encodable, Sendable {
                         description: "Either explore or general. Explore is for research; general is for execution-heavy work."
                     )
                 ],
-                required: ["task", "mode"],
+                required: ["intent", "task", "mode"],
                 additionalProperties: false
             )
         )

--- a/app/apple/herm/Services/CPSLDictationService.swift
+++ b/app/apple/herm/Services/CPSLDictationService.swift
@@ -3,7 +3,7 @@ import Accelerate
 import Foundation
 import Observation
 
-enum CPSLDictationState {
+enum CPSLDictationState: Equatable, Sendable {
     /// No startup or audio-session cleanup remains in flight.
     case idle
     /// Permissions and model checks; capture hasn't started.

--- a/app/apple/herm/Services/CPSLWebBrowserService.swift
+++ b/app/apple/herm/Services/CPSLWebBrowserService.swift
@@ -28,6 +28,7 @@ final class CPSLWebBrowserService: ObservableObject {
     private let defaultWindowSize = CGSize(width: 1200, height: 900)
     private let maxInlineJSONBytes = 16_000
     private let activityDuration: TimeInterval = 1.6
+    private static let maxBackgroundLeanBrowsers = 6
     private static let supportedControlKeys: Set<String> = [
         "Enter", "Escape", "Tab", "Backspace", "Delete",
         "ArrowLeft", "ArrowUp", "ArrowRight", "ArrowDown",
@@ -555,6 +556,9 @@ final class CPSLWebBrowserService: ObservableObject {
         resourceMode: CPSLWebBrowserResourceMode,
         networkPolicy: CPSLWebBrowserNetworkPolicy
     ) async throws -> CPSLWebBrowserSession {
+        if resourceMode == .lean {
+            retireOldestBackgroundLeanBrowserIfNeeded()
+        }
         let id = nextBrowserID()
         let browser = try await makeBrowser(
             id: id,
@@ -566,6 +570,24 @@ final class CPSLWebBrowserService: ObservableObject {
         lastBrowserID = id
         refreshSummaries()
         return browser
+    }
+
+    private func retireOldestBackgroundLeanBrowserIfNeeded() {
+        let backgroundLeanBrowsers = browsers.values.filter {
+            $0.resourceMode == .lean && !$0.isVisible
+        }
+        guard backgroundLeanBrowsers.count >= Self.maxBackgroundLeanBrowsers,
+              let oldest = backgroundLeanBrowsers.min(by: { $0.createdAt < $1.createdAt })
+        else {
+            return
+        }
+
+        oldest.webView.stopLoading()
+        backgroundHost.detach(oldest.webView)
+        browsers.removeValue(forKey: oldest.id)
+        if lastBrowserID == oldest.id {
+            lastBrowserID = browsers.values.max(by: { $0.createdAt < $1.createdAt })?.id
+        }
     }
 
     private func makeBrowser(
@@ -2431,6 +2453,7 @@ private final class CPSLWebBrowserBackgroundHost {
 
 private final class CPSLWebBrowserSession {
     let id: String
+    let createdAt = Date()
     var resourceMode: CPSLWebBrowserResourceMode
     let webView: WKWebView
     var windowSize: CGSize

--- a/app/apple/herm/Skills/webbrowser/SKILL.md
+++ b/app/apple/herm/Skills/webbrowser/SKILL.md
@@ -34,6 +34,7 @@ after one check instead of trying alternate imports.
 ## Sub-Agent First For Research
 
 - For broad web research, multi-page comparison, repeated search result triage, or anything likely to produce a lot of page text, delegate the browsing task to an `agent` sub-agent in explore mode.
+- Delegate broad research once. Give the helper a concrete output shape and ask it to return the best verified findings it has before its final turn; do not redo the same research in the main agent unless the helper reports a specific missing fact.
 - Keep the main conversation context focused on the user's request, the sub-agent task, and the concise result. Do not stream raw search result pages, long page dumps, or every visited URL into the main context unless the user asks for that detail.
 - Use the main agent directly only for small, targeted browsing where one or two page inspections are enough.
 
@@ -59,6 +60,13 @@ after one check instead of trying alternate imports.
 - `webbrowser.type()` uses `{backend="auto"}` by default. Background pages remain attached to an offscreen native host. macOS uses AppKit key events. iOS uses a scene-associated window that cannot become key, temporarily sets `inputmode="none"`, and attempts WebKit's `UIKeyInput` responder without activating the software keyboard. If WebKit cannot expose that responder before committing text, it falls back once to a whole-string DOM edit. Read `result.typing.backendUsed`, `nativeAttempted`, `committedCharacterCount`, `fallbackReason`, `interruptionReason`, and host diagnostics instead of assuming which path ran. Use `{speed=4.0}` if you need to be explicit.
 
 ## Search And Browse
+
+Reuse one browser for a research pass. Navigate that browser to each query or
+result instead of creating a browser per query; create another only when two
+independent login states or simultaneous pages are genuinely required. For a
+normal comparison, gather enough evidence in at most three sandbox invocations,
+then synthesize. More browsing is appropriate only when a named fact is still
+missing or sources conflict.
 
 ```lua
 local opened = webbrowser.open("https://www.google.com/search?q=site%3Aexample.com+query")

--- a/app/apple/herm/Views/Chat/CPSLChatScreen.swift
+++ b/app/apple/herm/Views/Chat/CPSLChatScreen.swift
@@ -368,7 +368,7 @@ private enum CPSLOverlayMotion {
 }
 
 struct CPSLChatScreen: View {
-    @StateObject private var model = CPSLChatModel()
+    @State private var model = CPSLChatModel()
     @State private var promptDismissRequest = 0
     @State private var drawerProgress: CGFloat = 0
     @State private var drawerMotionGeneration = 0
@@ -587,7 +587,7 @@ private struct CPSLDrawerGestureCapture<DrawerGesture: Gesture>: View {
 }
 
 private struct CPSLMainContentStage: View {
-    @ObservedObject var model: CPSLChatModel
+    let model: CPSLChatModel
     @Binding var promptDismissRequest: Int
     let contentTopInset: CGFloat
     let contentBottomInset: CGFloat
@@ -680,7 +680,7 @@ private struct CPSLMainContentStage: View {
 }
 
 private struct CPSLPrimaryContentView: View {
-    @ObservedObject var model: CPSLChatModel
+    let model: CPSLChatModel
     let contentTopInset: CGFloat
     let contentBottomInset: CGFloat
     let isTimelineScrollGeometryPaused: Bool
@@ -716,7 +716,7 @@ private struct CPSLFileBrowserOverlay: View {
 }
 
 private struct CPSLBottomChromeView: View {
-    @ObservedObject var model: CPSLChatModel
+    let model: CPSLChatModel
     @Binding var promptDismissRequest: Int
 
     private var isPromptCompact: Bool {
@@ -815,7 +815,7 @@ private struct CPSLICloudImportStatusView: View {
 }
 
 private struct CPSLHeaderActionsView: View {
-    @ObservedObject var model: CPSLChatModel
+    let model: CPSLChatModel
 #if DEBUG
     @State private var traceShareFile: CPSLJSONTraceShareFile?
     @State private var isPreparingTraceShareFile = false

--- a/app/apple/herm/Views/Chat/CPSLChatScreen.swift
+++ b/app/apple/herm/Views/Chat/CPSLChatScreen.swift
@@ -416,8 +416,6 @@ struct CPSLChatScreen: View {
                 .padding(.leading, CPSLTheme.medium)
                 .padding(.top, CPSLTheme.topChromeSafeAreaGap)
                 .offset(x: drawerToggleOffset(width: proxy.size.width))
-                .opacity(1 - drawerProgress)
-                .allowsHitTesting(!model.isDrawerOpen)
                 .zIndex(3)
             }
             .onAppear {

--- a/app/apple/herm/Views/Chat/CPSLChatTimelineView.swift
+++ b/app/apple/herm/Views/Chat/CPSLChatTimelineView.swift
@@ -24,83 +24,86 @@ struct CPSLChatTimelineView: View {
     }
 
     var body: some View {
-        let foldedThoughtIDs = Self.foldedThoughtIDs(
-            in: model.messages,
-            hasActiveToolStatus: model.activeToolStatusNodeID != nil
-        )
-        ZStack {
-            if !hasTimelineContent {
-                CPSLEmptyChatView()
-            }
-
-            ScrollView {
-                LazyVStack(spacing: CPSLTheme.messageVerticalSpacing) {
-                    ForEach(model.messages) { message in
-                        CPSLChatMessageView(
-                            message: message,
-                            isThoughtFolded: foldedThoughtIDs.contains(message.id),
-                            isStreaming: message.id == model.streamingAssistantMessageID,
-                            openBrowser: { browserID in
-                                model.openWebBrowserFromTimeline(browserID: browserID)
-                            },
-                            openFilePath: { path in
-                                model.openFilePathFromTimeline(path)
-                            },
-                            loadAttachmentThumbnail: { attachment in
-                                await model.attachmentThumbnail(for: attachment)
-                            }
-                        )
-                            .id(message.id)
-                    }
-
-                    if model.isRunning {
-                        CPSLAgentWorkingIndicatorView()
-                            .id("agent-working-indicator")
-                    }
+        GeometryReader { geometry in
+            let foldedThoughtIDs = Self.foldedThoughtIDs(
+                in: model.messages,
+                hasActiveToolStatus: model.activeToolStatusNodeID != nil
+            )
+            ZStack {
+                if !hasTimelineContent {
+                    CPSLEmptyChatView()
                 }
-                .padding(.horizontal, CPSLTheme.contentHorizontalInset)
-                .padding(.top, topInset)
-                .padding(.bottom, bottomInset)
-            }
-            .id(timelineIdentity)
-            .scrollPosition($scrollPosition)
-            .scrollDismissesKeyboard(.interactively)
-            .contentMargins(.top, topInset, for: .scrollIndicators)
-            .contentMargins(.bottom, bottomInset, for: .scrollIndicators)
-            .opacity(hasTimelineContent ? 1 : 0)
-            .onAppear {
-                scrollToBottom(animated: false)
-            }
-            .onChange(of: model.messages.count) { _, _ in
-                scrollToBottom(animated: true)
-            }
-            .onChange(of: model.isRunning) { _, isRunning in
-                if isRunning {
+
+                ScrollView {
+                    LazyVStack(spacing: CPSLTheme.messageVerticalSpacing) {
+                        ForEach(model.messages) { message in
+                            CPSLChatMessageView(
+                                message: message,
+                                isThoughtFolded: foldedThoughtIDs.contains(message.id),
+                                isStreaming: message.id == model.streamingAssistantMessageID,
+                                maxExpandableHeight: geometry.size.height * 0.3,
+                                openBrowser: { browserID in
+                                    model.openWebBrowserFromTimeline(browserID: browserID)
+                                },
+                                openFilePath: { path in
+                                    model.openFilePathFromTimeline(path)
+                                },
+                                loadAttachmentThumbnail: { attachment in
+                                    await model.attachmentThumbnail(for: attachment)
+                                }
+                            )
+                            .id(message.id)
+                        }
+
+                        if model.isRunning {
+                            CPSLAgentWorkingIndicatorView()
+                                .id("agent-working-indicator")
+                        }
+                    }
+                    .padding(.horizontal, CPSLTheme.contentHorizontalInset)
+                    .padding(.top, topInset)
+                    .padding(.bottom, bottomInset)
+                }
+                .id(timelineIdentity)
+                .scrollPosition($scrollPosition)
+                .scrollDismissesKeyboard(.interactively)
+                .contentMargins(.top, topInset, for: .scrollIndicators)
+                .contentMargins(.bottom, bottomInset, for: .scrollIndicators)
+                .opacity(hasTimelineContent ? 1 : 0)
+                .onAppear {
+                    scrollToBottom(animated: false)
+                }
+                .onChange(of: model.messages.count) { _, _ in
                     scrollToBottom(animated: true)
                 }
-            }
-            .onChange(of: model.messages.last?.body) { _, _ in
-                followStreamingBottomIfPinned()
-            }
-            .onChange(of: bottomInset) { _, _ in
-                scrollToBottomIfPinned()
-            }
-            .onChange(of: timelineIdentity) { _, _ in
-                resetScrollState()
-            }
-            .onScrollGeometryChange(
-                for: CPSLTimelineScrollState.self,
-                of: { geometry in
-                    CPSLTimelineScrollState(geometry: geometry)
-                },
-                action: { oldState, newState in
-                    guard !isScrollGeometryPaused else {
-                        return
+                .onChange(of: model.isRunning) { _, isRunning in
+                    if isRunning {
+                        scrollToBottom(animated: true)
                     }
-
-                    handleScrollGeometryChange(oldState: oldState, newState: newState)
                 }
-            )
+                .onChange(of: model.messages.last?.body) { _, _ in
+                    followStreamingBottomIfPinned()
+                }
+                .onChange(of: bottomInset) { _, _ in
+                    scrollToBottomIfPinned()
+                }
+                .onChange(of: timelineIdentity) { _, _ in
+                    resetScrollState()
+                }
+                .onScrollGeometryChange(
+                    for: CPSLTimelineScrollState.self,
+                    of: { geometry in
+                        CPSLTimelineScrollState(geometry: geometry)
+                    },
+                    action: { oldState, newState in
+                        guard !isScrollGeometryPaused else {
+                            return
+                        }
+
+                        handleScrollGeometryChange(oldState: oldState, newState: newState)
+                    }
+                )
+            }
         }
     }
 
@@ -314,6 +317,7 @@ private struct CPSLChatMessageView: View {
     let message: CPSLChatMessage
     let isThoughtFolded: Bool
     let isStreaming: Bool
+    let maxExpandableHeight: CGFloat
     let openBrowser: (String?) -> Void
     let openFilePath: (String) -> Void
     let loadAttachmentThumbnail: (CPSLAttachment) async -> Data?
@@ -352,11 +356,15 @@ private struct CPSLChatMessageView: View {
     }
 
     private var horizontalPadding: CGFloat {
-        message.role == .toolStatus ? CPSLTheme.small : CPSLTheme.medium
+        isExpandableRow ? CPSLTheme.small : CPSLTheme.medium
     }
 
     private var verticalPadding: CGFloat {
-        message.role == .toolStatus ? CPSLTheme.small / 2 : CPSLTheme.medium
+        isExpandableRow ? CPSLTheme.small / 2 : CPSLTheme.medium
+    }
+
+    private var isExpandableRow: Bool {
+        message.role == .thought || message.role == .toolStatus
     }
 
     private var messageStack: some View {
@@ -382,7 +390,11 @@ private struct CPSLChatMessageView: View {
     @ViewBuilder
     private var messageBody: some View {
         if message.role == .thought {
-            CPSLThoughtBody(text: message.body, isFolded: isThoughtFolded)
+            CPSLThoughtBody(
+                text: message.body,
+                isFolded: isThoughtFolded,
+                maxExpandedHeight: maxExpandableHeight
+            )
         } else if message.role == .command {
             CPSLCommandBlockBody(
                 text: message.body,
@@ -391,7 +403,11 @@ private struct CPSLChatMessageView: View {
             )
         } else if message.role == .toolStatus {
             if let payload = CPSLToolStatusPayload.decode(from: message.body) {
-                CPSLToolStatusBody(payload: payload, openBrowser: openBrowser)
+                CPSLToolStatusBody(
+                    payload: payload,
+                    maxExpandedHeight: maxExpandableHeight,
+                    openBrowser: openBrowser
+                )
             } else {
                 Text(message.body)
                     .font(CPSLTheme.supportingFont)
@@ -420,32 +436,88 @@ private struct CPSLChatMessageView: View {
     }
 }
 
+private struct CPSLExpandableMessageRow<Label: View, Content: View>: View {
+    @Binding var isExpanded: Bool
+    let maxExpandedHeight: CGFloat
+    let label: Label
+    let content: Content
+
+    init(
+        isExpanded: Binding<Bool>,
+        maxExpandedHeight: CGFloat,
+        @ViewBuilder label: () -> Label,
+        @ViewBuilder content: () -> Content
+    ) {
+        _isExpanded = isExpanded
+        self.maxExpandedHeight = maxExpandedHeight
+        self.label = label()
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button {
+                withAnimation(.easeOut(duration: 0.2)) {
+                    isExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: CPSLTheme.small) {
+                    label
+
+                    Image(systemName: "chevron.right")
+                        .font(CPSLTheme.iconSmallFont)
+                        .foregroundStyle(CPSLTheme.secondaryText)
+                        .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                        .padding(.trailing, CPSLTheme.medium)
+                        .accessibilityHidden(true)
+                }
+                .frame(minHeight: CPSLTheme.large, alignment: .center)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityValue(isExpanded ? "Expanded" : "Collapsed")
+
+            if isExpanded {
+                ViewThatFits(in: .vertical) {
+                    content
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    ScrollView(.vertical) {
+                        content
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .scrollBounceBehavior(.basedOnSize)
+                }
+                .frame(maxHeight: maxExpandedHeight)
+                .padding(.top, CPSLTheme.small / 2)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
 private struct CPSLThoughtBody: View {
     let text: String
     let isFolded: Bool
+    let maxExpandedHeight: CGFloat
     @State private var isExpanded: Bool
 
-    init(text: String, isFolded: Bool) {
+    init(text: String, isFolded: Bool, maxExpandedHeight: CGFloat) {
         self.text = text
         self.isFolded = isFolded
+        self.maxExpandedHeight = maxExpandedHeight
         _isExpanded = State(initialValue: !isFolded)
     }
 
     var body: some View {
-        DisclosureGroup(isExpanded: $isExpanded) {
-            CPSLSelectableText(
-                text,
-                style: .supporting,
-                foreground: CPSLTheme.secondaryText,
-                fillsAvailableWidth: true,
-                parsesInlineMarkdown: true
-            )
-            .padding(.top, CPSLTheme.small / 2)
-        } label: {
+        CPSLExpandableMessageRow(
+            isExpanded: $isExpanded,
+            maxExpandedHeight: maxExpandedHeight
+        ) {
             HStack(spacing: CPSLTheme.small) {
-                Image(systemName: "sparkles")
-                    .font(CPSLTheme.iconSmallFont)
-                    .foregroundStyle(CPSLTheme.mauve)
+                Text("💭")
+                    .font(CPSLTheme.iconMediumFont)
+                    .frame(width: CPSLTheme.large, height: CPSLTheme.large)
                 Text(isExpanded ? "Thought" : preview)
                     .font(CPSLTheme.supportingMediumFont)
                     .foregroundStyle(CPSLTheme.secondaryText)
@@ -453,11 +525,18 @@ private struct CPSLThoughtBody: View {
                     .truncationMode(.tail)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
+        } content: {
+            CPSLSelectableText(
+                text,
+                style: .supporting,
+                foreground: CPSLTheme.secondaryText,
+                fillsAvailableWidth: true,
+                parsesInlineMarkdown: true
+            )
         }
         .onChange(of: isFolded) { _, folded in
             isExpanded = !folded
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var preview: String {
@@ -490,44 +569,87 @@ private struct CPSLMessageAttachmentList: View {
 
 private struct CPSLToolStatusBody: View {
     let payload: CPSLToolStatusPayload
+    let maxExpandedHeight: CGFloat
     let openBrowser: (String?) -> Void
-
-#if DEBUG
     @State private var isExpanded = false
-#endif
 
     var body: some View {
-#if DEBUG
         VStack(alignment: .leading, spacing: CPSLTheme.small / 2) {
-            DisclosureGroup(isExpanded: $isExpanded) {
-                CPSLToolStatusDebugDetails(invocations: payload.invocations)
-                    .padding(.top, CPSLTheme.small)
-            } label: {
+            CPSLExpandableMessageRow(
+                isExpanded: $isExpanded,
+                maxExpandedHeight: maxExpandedHeight
+            ) {
                 CPSLToolStatusLine(payload: payload)
+            } content: {
+                CPSLToolStatusDetails(invocations: payload.invocations)
             }
-            .disclosureGroupStyle(.automatic)
 
             if !payload.webVisits.isEmpty {
                 CPSLWebSearchStatusLine(visits: payload.webVisits, openBrowser: openBrowser)
             }
         }
-#else
-        CPSLToolStatusStack(payload: payload, openBrowser: openBrowser)
-#endif
     }
 }
 
-private struct CPSLToolStatusStack: View {
-    let payload: CPSLToolStatusPayload
-    let openBrowser: (String?) -> Void
+private struct CPSLToolStatusDetails: View {
+    let invocations: [CPSLToolStatusInvocation]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: CPSLTheme.medium) {
+            if invocations.isEmpty {
+                Text("No completed tool calls yet.")
+                    .font(CPSLTheme.captionFont)
+                    .foregroundStyle(CPSLTheme.secondaryText)
+            } else {
+                ForEach(invocations) { invocation in
+                    CPSLToolStatusInvocationView(invocation: invocation)
+                }
+            }
+        }
+    }
+}
+
+private struct CPSLToolStatusInvocationView: View {
+    let invocation: CPSLToolStatusInvocation
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: CPSLTheme.small) {
+            HStack(spacing: CPSLTheme.small) {
+                Image(systemName: invocation.isError ? "xmark.circle.fill" : "checkmark.circle.fill")
+                    .foregroundStyle(invocation.isError ? CPSLTheme.danger : CPSLTheme.success)
+                Text(invocation.summary)
+                    .font(CPSLTheme.captionMediumFont)
+                    .foregroundStyle(CPSLTheme.text)
+            }
+
+            CPSLToolStatusDetailBlock(title: "Input", text: invocation.input)
+            CPSLToolStatusDetailBlock(title: "Output", text: invocation.output)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct CPSLToolStatusDetailBlock: View {
+    let title: LocalizedStringKey
+    let text: String
 
     var body: some View {
         VStack(alignment: .leading, spacing: CPSLTheme.small / 2) {
-            CPSLToolStatusLine(payload: payload)
-            if !payload.webVisits.isEmpty {
-                CPSLWebSearchStatusLine(visits: payload.webVisits, openBrowser: openBrowser)
-            }
+            Text(title)
+                .font(CPSLTheme.captionMediumFont)
+                .foregroundStyle(CPSLTheme.secondaryText)
+
+            CPSLSelectableText(
+                text.isEmpty ? "(empty)" : text,
+                style: .monospacedBody,
+                foreground: CPSLTheme.text,
+                fillsAvailableWidth: true,
+                lineSpacing: 0
+            )
         }
+        .padding(CPSLTheme.small)
+        .background(CPSLTheme.command)
+        .clipShape(RoundedRectangle(cornerRadius: CPSLTheme.rowRadius, style: .continuous))
     }
 }
 
@@ -545,7 +667,6 @@ private struct CPSLToolStatusLine: View {
                 .truncationMode(.tail)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .frame(minHeight: CPSLTheme.large, alignment: .center)
     }
 }
 
@@ -700,71 +821,6 @@ private struct CPSLToolStatusIcon: View {
         return cycle / 0.9 * 360
     }
 }
-
-#if DEBUG
-private struct CPSLToolStatusDebugDetails: View {
-    let invocations: [CPSLToolStatusInvocation]
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: CPSLTheme.medium) {
-            if invocations.isEmpty {
-                Text("No completed tool calls yet.")
-                    .font(CPSLTheme.captionFont)
-                    .foregroundStyle(CPSLTheme.secondaryText)
-            } else {
-                ForEach(invocations) { invocation in
-                    CPSLToolStatusInvocationDebugView(invocation: invocation)
-                }
-            }
-        }
-    }
-}
-
-private struct CPSLToolStatusInvocationDebugView: View {
-    let invocation: CPSLToolStatusInvocation
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: CPSLTheme.small) {
-            HStack(spacing: CPSLTheme.small) {
-                Image(systemName: invocation.isError ? "xmark.circle.fill" : "checkmark.circle.fill")
-                    .foregroundStyle(invocation.isError ? CPSLTheme.danger : CPSLTheme.success)
-                Text(invocation.isError ? "Failed step" : "Completed step")
-                    .font(CPSLTheme.captionMediumFont)
-                    .foregroundStyle(CPSLTheme.text)
-            }
-
-            CPSLToolDebugBlock(title: "Input", text: invocation.input)
-            CPSLToolDebugBlock(title: "Output", text: invocation.output)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-}
-
-private struct CPSLToolDebugBlock: View {
-    let title: String
-    let text: String
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: CPSLTheme.small / 2) {
-            Text(title)
-                .font(CPSLTheme.captionMediumFont)
-                .foregroundStyle(CPSLTheme.secondaryText)
-
-            CPSLSelectableText(
-                text.isEmpty ? "(empty)" : text,
-                style: .monospacedBody,
-                foreground: CPSLTheme.text,
-                fillsAvailableWidth: true,
-                lineSpacing: 0
-            )
-                .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .padding(CPSLTheme.small)
-        .background(CPSLTheme.command)
-        .clipShape(RoundedRectangle(cornerRadius: CPSLTheme.rowRadius, style: .continuous))
-    }
-}
-#endif
 
 private struct CPSLMarkdownMessageBody: View {
     let text: String
@@ -1412,6 +1468,16 @@ private enum CPSLDiscussionPathLinks {
         }
 
         let text = run.text
+        if run.isCode,
+           let match = exactCodePath(in: text),
+           let url = fileURL(for: match.path) {
+            return [
+                run
+                    .applying(link: true, linkURL: url)
+                    .withText(displayPath(for: match.path) + match.lineSuffix)
+            ]
+        }
+
         var output: [CPSLSelectableTextRun] = []
         var cursor = text.startIndex
 
@@ -1436,6 +1502,15 @@ private enum CPSLDiscussionPathLinks {
             output.append(run.applying().withText(String(text[cursor..<text.endIndex])))
         }
         return output.isEmpty ? [run] : output
+    }
+
+    private static func exactCodePath(in text: String) -> (path: String, lineSuffix: String)? {
+        let candidate = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !candidate.isEmpty else {
+            return nil
+        }
+        let normalized = normalizedPathAndLineSuffix(candidate)
+        return isAllowedPath(normalized.path) ? normalized : nil
     }
 
     private static func nextMatch(

--- a/app/apple/herm/Views/Chat/CPSLChatTimelineView.swift
+++ b/app/apple/herm/Views/Chat/CPSLChatTimelineView.swift
@@ -6,6 +6,137 @@ import AppKit
 import UIKit
 #endif
 
+nonisolated struct CPSLTimelineActivityGroup: Identifiable, Equatable, Sendable {
+    let id: UUID
+    let messages: [CPSLChatMessage]
+}
+
+nonisolated extension CPSLChatMessage {
+    var activityEntryID: UUID {
+        guard role == .toolStatus,
+              let activityID = CPSLToolStatusPayload.decode(from: body)?.activityID
+        else {
+            return id
+        }
+        return activityID
+    }
+}
+
+nonisolated enum CPSLChatTimelineItem: Identifiable, Equatable, Sendable {
+    case message(CPSLChatMessage)
+    case activity(CPSLTimelineActivityGroup)
+
+    var id: UUID {
+        switch self {
+        case .message(let message):
+            message.id
+        case .activity(let group):
+            group.id
+        }
+    }
+
+    static func grouped(from messages: [CPSLChatMessage]) -> [CPSLChatTimelineItem] {
+        var items: [CPSLChatTimelineItem] = []
+        var groupID: UUID?
+        var activityMessages: [CPSLChatMessage] = []
+
+        func appendActivityGroup() {
+            guard let groupID, !activityMessages.isEmpty else {
+                return
+            }
+            items.append(.activity(CPSLTimelineActivityGroup(id: groupID, messages: activityMessages)))
+        }
+
+        for message in messages {
+            guard message.role == .thought || message.role == .toolStatus else {
+                appendActivityGroup()
+                groupID = nil
+                activityMessages.removeAll(keepingCapacity: true)
+                items.append(.message(message))
+                continue
+            }
+
+            if groupID == nil {
+                groupID = message.id
+            }
+            if message.role != .toolStatus
+                || CPSLToolStatusPayload.decode(from: message.body)?.isSuperseded != true {
+                activityMessages.append(message)
+            }
+        }
+
+        appendActivityGroup()
+        return items
+    }
+}
+
+nonisolated struct CPSLActivityExpansionState: Equatable, Sendable {
+    var expandedEntryIDs: Set<UUID> = []
+
+    subscript(entry id: UUID) -> Bool {
+        get { expandedEntryIDs.contains(id) }
+        set {
+            if newValue {
+                expandedEntryIDs.insert(id)
+            } else {
+                expandedEntryIDs.remove(id)
+            }
+        }
+    }
+}
+
+nonisolated enum CPSLActivityDisplayItem: Identifiable, Equatable, Sendable {
+    enum ID: Hashable, Sendable {
+        case message(UUID)
+        case omission(UUID)
+        case collapse(UUID)
+    }
+
+    case message(CPSLChatMessage)
+    case omission(UUID)
+    case collapse(UUID)
+
+    var id: ID {
+        switch self {
+        case .message(let message):
+            .message(message.activityEntryID)
+        case .omission(let id):
+            .omission(id)
+        case .collapse(let id):
+            .collapse(id)
+        }
+    }
+
+    static func items(
+        for group: CPSLTimelineActivityGroup,
+        expandedEntryIDs: Set<UUID>,
+        showsAll: Bool,
+        collapsedLimit: Int = 3
+    ) -> [CPSLActivityDisplayItem] {
+        guard group.messages.count > collapsedLimit else {
+            return group.messages.map(CPSLActivityDisplayItem.message)
+        }
+        if showsAll {
+            return [.collapse(group.id)] + group.messages.map(CPSLActivityDisplayItem.message)
+        }
+
+        let trailingIDs = Set(group.messages.suffix(collapsedLimit).map(\.activityEntryID))
+        let visibleIDs = trailingIDs.union(expandedEntryIDs)
+        var result: [CPSLActivityDisplayItem] = []
+        var isInsideOmission = false
+        for message in group.messages {
+            if visibleIDs.contains(message.activityEntryID) {
+                result.append(.message(message))
+                isInsideOmission = false
+            } else if !isInsideOmission {
+                result.append(.omission(message.id))
+                isInsideOmission = true
+            }
+        }
+        return result
+    }
+}
+
 struct CPSLChatTimelineView: View {
     let model: CPSLChatModel
     let topInset: CGFloat
@@ -25,10 +156,7 @@ struct CPSLChatTimelineView: View {
 
     var body: some View {
         GeometryReader { geometry in
-            let foldedThoughtIDs = Self.foldedThoughtIDs(
-                in: model.messages,
-                hasActiveToolStatus: model.activeToolStatusNodeID != nil
-            )
+            let timelineItems = CPSLChatTimelineItem.grouped(from: model.messages)
             ZStack {
                 if !hasTimelineContent {
                     CPSLEmptyChatView()
@@ -36,11 +164,10 @@ struct CPSLChatTimelineView: View {
 
                 ScrollView {
                     LazyVStack(spacing: CPSLTheme.messageVerticalSpacing) {
-                        ForEach(model.messages) { message in
-                            CPSLChatMessageView(
-                                message: message,
-                                isThoughtFolded: foldedThoughtIDs.contains(message.id),
-                                isStreaming: message.id == model.streamingAssistantMessageID,
+                        ForEach(timelineItems) { item in
+                            CPSLChatTimelineItemView(
+                                item: item,
+                                streamingAssistantMessageID: model.streamingAssistantMessageID,
                                 maxExpandableHeight: geometry.size.height * 0.3,
                                 openBrowser: { browserID in
                                     model.openWebBrowserFromTimeline(browserID: browserID)
@@ -52,7 +179,7 @@ struct CPSLChatTimelineView: View {
                                     await model.attachmentThumbnail(for: attachment)
                                 }
                             )
-                            .id(message.id)
+                            .id(item.id)
                         }
 
                         if model.isRunning {
@@ -105,24 +232,6 @@ struct CPSLChatTimelineView: View {
                 )
             }
         }
-    }
-
-    private static func foldedThoughtIDs(
-        in messages: [CPSLChatMessage],
-        hasActiveToolStatus: Bool
-    ) -> Set<UUID> {
-        var result = Set<UUID>()
-        if messages.count > 1 {
-            for index in messages.indices.dropLast() where messages[index].role == .thought {
-                if messages[messages.index(after: index)].role != .thought {
-                    result.insert(messages[index].id)
-                }
-            }
-        }
-        if hasActiveToolStatus, let last = messages.last, last.role == .thought {
-            result.insert(last.id)
-        }
-        return result
     }
 
     private func scrollToBottom(animated: Bool) {
@@ -313,9 +422,161 @@ private struct CPSLEmptyChatView: View {
     }
 }
 
+private struct CPSLChatTimelineItemView: View {
+    let item: CPSLChatTimelineItem
+    let streamingAssistantMessageID: UUID?
+    let maxExpandableHeight: CGFloat
+    let openBrowser: (String?) -> Void
+    let openFilePath: (String) -> Void
+    let loadAttachmentThumbnail: (CPSLAttachment) async -> Data?
+
+    var body: some View {
+        ZStack {
+            switch item {
+            case .message(let message):
+                CPSLChatMessageView(
+                    message: message,
+                    isStreaming: message.id == streamingAssistantMessageID,
+                    maxExpandableHeight: maxExpandableHeight,
+                    openBrowser: openBrowser,
+                    openFilePath: openFilePath,
+                    loadAttachmentThumbnail: loadAttachmentThumbnail
+                )
+            case .activity(let group):
+                CPSLActivityGroupView(
+                    group: group,
+                    expandedBlockMaxHeight: maxExpandableHeight,
+                    openBrowser: openBrowser
+                )
+            }
+        }
+    }
+}
+
+private struct CPSLActivityGroupView: View {
+    let group: CPSLTimelineActivityGroup
+    let expandedBlockMaxHeight: CGFloat
+    let openBrowser: (String?) -> Void
+    @State private var expansion = CPSLActivityExpansionState()
+    @State private var showsAll = false
+
+    var body: some View {
+        let displayItems = CPSLActivityDisplayItem.items(
+            for: group,
+            expandedEntryIDs: expansion.expandedEntryIDs,
+            showsAll: showsAll
+        )
+        VStack(alignment: .leading, spacing: CPSLTheme.small / 2) {
+            ForEach(displayItems) { item in
+                CPSLActivityDisplayItemView(
+                    item: item,
+                    expansion: $expansion,
+                    expandedBlockMaxHeight: expandedBlockMaxHeight,
+                    openBrowser: openBrowser,
+                    showAll: showAll,
+                    showLess: showLess
+                )
+            }
+        }
+        .padding(.horizontal, CPSLTheme.small)
+        .padding(.vertical, CPSLTheme.small / 2)
+        .background(CPSLTheme.surface)
+        .clipShape(RoundedRectangle(cornerRadius: CPSLTheme.messageRadius, style: .continuous))
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func showAll() {
+        withAnimation(.easeOut(duration: 0.2)) {
+            showsAll = true
+        }
+    }
+
+    private func showLess() {
+        withAnimation(.easeOut(duration: 0.2)) {
+            showsAll = false
+        }
+    }
+}
+
+private struct CPSLActivityDisplayItemView: View {
+    let item: CPSLActivityDisplayItem
+    @Binding var expansion: CPSLActivityExpansionState
+    let expandedBlockMaxHeight: CGFloat
+    let openBrowser: (String?) -> Void
+    let showAll: () -> Void
+    let showLess: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            switch item {
+            case .message(let message):
+                CPSLActivityEntryView(
+                    message: message,
+                    isExpanded: $expansion[entry: message.activityEntryID],
+                    maxExpandedHeight: expandedBlockMaxHeight,
+                    openBrowser: openBrowser
+                )
+            case .omission:
+                CPSLActivityFoldButton(systemName: "ellipsis", action: showAll)
+                    .accessibilityLabel("Show all activity")
+            case .collapse:
+                CPSLActivityFoldButton(systemName: "ellipsis", action: showLess)
+                    .accessibilityLabel("Show less activity")
+            }
+        }
+    }
+}
+
+private struct CPSLActivityFoldButton: View {
+    let systemName: String
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(CPSLTheme.iconSmallFont)
+                .foregroundStyle(CPSLTheme.mutedText)
+                .frame(width: CPSLTheme.large, height: CPSLTheme.large)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct CPSLActivityEntryView: View {
+    let message: CPSLChatMessage
+    @Binding var isExpanded: Bool
+    let maxExpandedHeight: CGFloat
+    let openBrowser: (String?) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if message.role == .thought {
+                CPSLThoughtBody(
+                    text: message.body,
+                    isExpanded: $isExpanded,
+                    maxExpandedHeight: maxExpandedHeight
+                )
+            } else if let payload = CPSLToolStatusPayload.decode(from: message.body) {
+                CPSLToolStatusBody(
+                    payload: payload,
+                    isExpanded: $isExpanded,
+                    maxExpandedHeight: maxExpandedHeight,
+                    openBrowser: openBrowser
+                )
+            } else {
+                Text("Activity unavailable")
+                    .font(CPSLTheme.supportingFont)
+                    .foregroundStyle(CPSLTheme.secondaryText)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+        }
+    }
+}
+
 private struct CPSLChatMessageView: View {
     let message: CPSLChatMessage
-    let isThoughtFolded: Bool
     let isStreaming: Bool
     let maxExpandableHeight: CGFloat
     let openBrowser: (String?) -> Void
@@ -392,7 +653,7 @@ private struct CPSLChatMessageView: View {
         if message.role == .thought {
             CPSLThoughtBody(
                 text: message.body,
-                isFolded: isThoughtFolded,
+                isExpanded: .constant(false),
                 maxExpandedHeight: maxExpandableHeight
             )
         } else if message.role == .command {
@@ -405,13 +666,14 @@ private struct CPSLChatMessageView: View {
             if let payload = CPSLToolStatusPayload.decode(from: message.body) {
                 CPSLToolStatusBody(
                     payload: payload,
+                    isExpanded: .constant(false),
                     maxExpandedHeight: maxExpandableHeight,
                     openBrowser: openBrowser
                 )
             } else {
-                Text(message.body)
+                Text("Activity unavailable")
                     .font(CPSLTheme.supportingFont)
-                    .foregroundStyle(message.role.foreground)
+                    .foregroundStyle(CPSLTheme.secondaryText)
                     .lineLimit(1)
                     .truncationMode(.tail)
             }
@@ -438,18 +700,18 @@ private struct CPSLChatMessageView: View {
 
 private struct CPSLExpandableMessageRow<Label: View, Content: View>: View {
     @Binding var isExpanded: Bool
-    let maxExpandedHeight: CGFloat
+    let canExpand: Bool
     let label: Label
     let content: Content
 
     init(
         isExpanded: Binding<Bool>,
-        maxExpandedHeight: CGFloat,
+        canExpand: Bool = true,
         @ViewBuilder label: () -> Label,
         @ViewBuilder content: () -> Content
     ) {
         _isExpanded = isExpanded
-        self.maxExpandedHeight = maxExpandedHeight
+        self.canExpand = canExpand
         self.label = label()
         self.content = content()
     }
@@ -457,6 +719,9 @@ private struct CPSLExpandableMessageRow<Label: View, Content: View>: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Button {
+                guard canExpand else {
+                    return
+                }
                 withAnimation(.easeOut(duration: 0.2)) {
                     isExpanded.toggle()
                 }
@@ -468,6 +733,7 @@ private struct CPSLExpandableMessageRow<Label: View, Content: View>: View {
                         .font(CPSLTheme.iconSmallFont)
                         .foregroundStyle(CPSLTheme.secondaryText)
                         .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                        .opacity(canExpand ? 1 : 0)
                         .padding(.trailing, CPSLTheme.medium)
                         .accessibilityHidden(true)
                 }
@@ -475,44 +741,50 @@ private struct CPSLExpandableMessageRow<Label: View, Content: View>: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .accessibilityValue(isExpanded ? "Expanded" : "Collapsed")
+            .allowsHitTesting(canExpand)
+            .accessibilityValue(canExpand ? (isExpanded ? "Expanded" : "Collapsed") : "")
 
-            if isExpanded {
-                ViewThatFits(in: .vertical) {
-                    content
-                        .fixedSize(horizontal: false, vertical: true)
-
-                    ScrollView(.vertical) {
-                        content
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    .scrollBounceBehavior(.basedOnSize)
-                }
-                .frame(maxHeight: maxExpandedHeight)
-                .padding(.top, CPSLTheme.small / 2)
+            if canExpand && isExpanded {
+                content
+                    .padding(.top, CPSLTheme.small / 2)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 
-private struct CPSLThoughtBody: View {
-    let text: String
-    let isFolded: Bool
-    let maxExpandedHeight: CGFloat
-    @State private var isExpanded: Bool
+private struct CPSLHeightLimitedExpandedBlock<Content: View>: View {
+    let maxHeight: CGFloat
+    let content: Content
 
-    init(text: String, isFolded: Bool, maxExpandedHeight: CGFloat) {
-        self.text = text
-        self.isFolded = isFolded
-        self.maxExpandedHeight = maxExpandedHeight
-        _isExpanded = State(initialValue: !isFolded)
+    init(maxHeight: CGFloat, @ViewBuilder content: () -> Content) {
+        self.maxHeight = maxHeight
+        self.content = content()
     }
 
     var body: some View {
+        ViewThatFits(in: .vertical) {
+            content
+                .fixedSize(horizontal: false, vertical: true)
+
+            ScrollView(.vertical) {
+                content
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .scrollBounceBehavior(.basedOnSize)
+        }
+        .frame(maxHeight: maxHeight)
+    }
+}
+
+private struct CPSLThoughtBody: View {
+    let text: String
+    @Binding var isExpanded: Bool
+    let maxExpandedHeight: CGFloat
+
+    var body: some View {
         CPSLExpandableMessageRow(
-            isExpanded: $isExpanded,
-            maxExpandedHeight: maxExpandedHeight
+            isExpanded: $isExpanded
         ) {
             HStack(spacing: CPSLTheme.small) {
                 Text("💭")
@@ -526,16 +798,15 @@ private struct CPSLThoughtBody: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
         } content: {
-            CPSLSelectableText(
-                text,
-                style: .supporting,
-                foreground: CPSLTheme.secondaryText,
-                fillsAvailableWidth: true,
-                parsesInlineMarkdown: true
-            )
-        }
-        .onChange(of: isFolded) { _, folded in
-            isExpanded = !folded
+            CPSLHeightLimitedExpandedBlock(maxHeight: maxExpandedHeight) {
+                CPSLSelectableText(
+                    text,
+                    style: .supporting,
+                    foreground: CPSLTheme.secondaryText,
+                    fillsAvailableWidth: true,
+                    parsesInlineMarkdown: true
+                )
+            }
         }
     }
 
@@ -569,19 +840,22 @@ private struct CPSLMessageAttachmentList: View {
 
 private struct CPSLToolStatusBody: View {
     let payload: CPSLToolStatusPayload
+    @Binding var isExpanded: Bool
     let maxExpandedHeight: CGFloat
     let openBrowser: (String?) -> Void
-    @State private var isExpanded = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: CPSLTheme.small / 2) {
             CPSLExpandableMessageRow(
                 isExpanded: $isExpanded,
-                maxExpandedHeight: maxExpandedHeight
+                canExpand: canExpand
             ) {
                 CPSLToolStatusLine(payload: payload)
             } content: {
-                CPSLToolStatusDetails(invocations: payload.invocations)
+                CPSLToolStatusDetails(
+                    invocations: detailInvocations,
+                    maxExpandedBlockHeight: maxExpandedHeight
+                )
             }
 
             if !payload.webVisits.isEmpty {
@@ -589,10 +863,32 @@ private struct CPSLToolStatusBody: View {
             }
         }
     }
+
+    private var canExpand: Bool {
+#if DEBUG
+        !detailInvocations.isEmpty
+#else
+        if payload.state == .failed,
+           detailInvocations.count == 1,
+           detailInvocations[0].summary == payload.summary {
+            return false
+        }
+        return !detailInvocations.isEmpty
+#endif
+    }
+
+    private var detailInvocations: [CPSLToolStatusInvocation] {
+#if DEBUG
+        payload.invocations
+#else
+        payload.invocations.filter(\.isError)
+#endif
+    }
 }
 
 private struct CPSLToolStatusDetails: View {
     let invocations: [CPSLToolStatusInvocation]
+    let maxExpandedBlockHeight: CGFloat
 
     var body: some View {
         VStack(alignment: .leading, spacing: CPSLTheme.medium) {
@@ -602,7 +898,10 @@ private struct CPSLToolStatusDetails: View {
                     .foregroundStyle(CPSLTheme.secondaryText)
             } else {
                 ForEach(invocations) { invocation in
-                    CPSLToolStatusInvocationView(invocation: invocation)
+                    CPSLToolStatusInvocationView(
+                        invocation: invocation,
+                        maxExpandedBlockHeight: maxExpandedBlockHeight
+                    )
                 }
             }
         }
@@ -611,6 +910,7 @@ private struct CPSLToolStatusDetails: View {
 
 private struct CPSLToolStatusInvocationView: View {
     let invocation: CPSLToolStatusInvocation
+    let maxExpandedBlockHeight: CGFloat
 
     var body: some View {
         VStack(alignment: .leading, spacing: CPSLTheme.small) {
@@ -622,36 +922,51 @@ private struct CPSLToolStatusInvocationView: View {
                     .foregroundStyle(CPSLTheme.text)
             }
 
-            CPSLToolStatusDetailBlock(title: "Input", text: invocation.input)
-            CPSLToolStatusDetailBlock(title: "Output", text: invocation.output)
+#if DEBUG
+            CPSLToolStatusDetailBlock(
+                title: "Input",
+                text: invocation.input,
+                maxExpandedHeight: maxExpandedBlockHeight
+            )
+            CPSLToolStatusDetailBlock(
+                title: "Output",
+                text: invocation.output,
+                maxExpandedHeight: maxExpandedBlockHeight
+            )
+#endif
         }
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 
+#if DEBUG
 private struct CPSLToolStatusDetailBlock: View {
     let title: LocalizedStringKey
     let text: String
+    let maxExpandedHeight: CGFloat
 
     var body: some View {
-        VStack(alignment: .leading, spacing: CPSLTheme.small / 2) {
-            Text(title)
-                .font(CPSLTheme.captionMediumFont)
-                .foregroundStyle(CPSLTheme.secondaryText)
+        CPSLHeightLimitedExpandedBlock(maxHeight: maxExpandedHeight) {
+            VStack(alignment: .leading, spacing: CPSLTheme.small / 2) {
+                Text(title)
+                    .font(CPSLTheme.captionMediumFont)
+                    .foregroundStyle(CPSLTheme.secondaryText)
 
-            CPSLSelectableText(
-                text.isEmpty ? "(empty)" : text,
-                style: .monospacedBody,
-                foreground: CPSLTheme.text,
-                fillsAvailableWidth: true,
-                lineSpacing: 0
-            )
+                CPSLSelectableText(
+                    text.isEmpty ? "(empty)" : text,
+                    style: .monospacedBody,
+                    foreground: CPSLTheme.text,
+                    fillsAvailableWidth: true,
+                    lineSpacing: 0
+                )
+            }
+            .padding(CPSLTheme.small)
+            .background(CPSLTheme.command)
+            .clipShape(RoundedRectangle(cornerRadius: CPSLTheme.rowRadius, style: .continuous))
         }
-        .padding(CPSLTheme.small)
-        .background(CPSLTheme.command)
-        .clipShape(RoundedRectangle(cornerRadius: CPSLTheme.rowRadius, style: .continuous))
     }
 }
+#endif
 
 private struct CPSLToolStatusLine: View {
     let payload: CPSLToolStatusPayload
@@ -802,6 +1117,8 @@ private struct CPSLToolStatusIcon: View {
             return "checkmark.circle.fill"
         case .failed:
             return "xmark.circle.fill"
+        case .interrupted:
+            return "exclamationmark.triangle.fill"
         }
     }
 
@@ -813,6 +1130,8 @@ private struct CPSLToolStatusIcon: View {
             return CPSLTheme.success
         case .failed:
             return CPSLTheme.danger
+        case .interrupted:
+            return CPSLTheme.warning
         }
     }
 

--- a/app/apple/herm/Views/Chat/CPSLChatTimelineView.swift
+++ b/app/apple/herm/Views/Chat/CPSLChatTimelineView.swift
@@ -7,7 +7,7 @@ import UIKit
 #endif
 
 struct CPSLChatTimelineView: View {
-    @ObservedObject var model: CPSLChatModel
+    let model: CPSLChatModel
     let topInset: CGFloat
     let bottomInset: CGFloat
     let isScrollGeometryPaused: Bool
@@ -24,6 +24,10 @@ struct CPSLChatTimelineView: View {
     }
 
     var body: some View {
+        let foldedThoughtIDs = Self.foldedThoughtIDs(
+            in: model.messages,
+            hasActiveToolStatus: model.activeToolStatusNodeID != nil
+        )
         ZStack {
             if !hasTimelineContent {
                 CPSLEmptyChatView()
@@ -34,6 +38,8 @@ struct CPSLChatTimelineView: View {
                     ForEach(model.messages) { message in
                         CPSLChatMessageView(
                             message: message,
+                            isThoughtFolded: foldedThoughtIDs.contains(message.id),
+                            isStreaming: message.id == model.streamingAssistantMessageID,
                             openBrowser: { browserID in
                                 model.openWebBrowserFromTimeline(browserID: browserID)
                             },
@@ -96,6 +102,24 @@ struct CPSLChatTimelineView: View {
                 }
             )
         }
+    }
+
+    private static func foldedThoughtIDs(
+        in messages: [CPSLChatMessage],
+        hasActiveToolStatus: Bool
+    ) -> Set<UUID> {
+        var result = Set<UUID>()
+        if messages.count > 1 {
+            for index in messages.indices.dropLast() where messages[index].role == .thought {
+                if messages[messages.index(after: index)].role != .thought {
+                    result.insert(messages[index].id)
+                }
+            }
+        }
+        if hasActiveToolStatus, let last = messages.last, last.role == .thought {
+            result.insert(last.id)
+        }
+        return result
     }
 
     private func scrollToBottom(animated: Bool) {
@@ -288,6 +312,8 @@ private struct CPSLEmptyChatView: View {
 
 private struct CPSLChatMessageView: View {
     let message: CPSLChatMessage
+    let isThoughtFolded: Bool
+    let isStreaming: Bool
     let openBrowser: (String?) -> Void
     let openFilePath: (String) -> Void
     let loadAttachmentThumbnail: (CPSLAttachment) async -> Data?
@@ -355,7 +381,9 @@ private struct CPSLChatMessageView: View {
 
     @ViewBuilder
     private var messageBody: some View {
-        if message.role == .command {
+        if message.role == .thought {
+            CPSLThoughtBody(text: message.body, isFolded: isThoughtFolded)
+        } else if message.role == .command {
             CPSLCommandBlockBody(
                 text: message.body,
                 foreground: message.role.foreground,
@@ -376,6 +404,7 @@ private struct CPSLChatMessageView: View {
                 text: message.body,
                 foreground: message.role.foreground,
                 fillsAvailableWidth: message.role.isFullWidth,
+                isStreaming: isStreaming,
                 openFilePath: openFilePath
             )
         } else {
@@ -388,6 +417,51 @@ private struct CPSLChatMessageView: View {
                 openFilePath: openFilePath
             )
         }
+    }
+}
+
+private struct CPSLThoughtBody: View {
+    let text: String
+    let isFolded: Bool
+    @State private var isExpanded: Bool
+
+    init(text: String, isFolded: Bool) {
+        self.text = text
+        self.isFolded = isFolded
+        _isExpanded = State(initialValue: !isFolded)
+    }
+
+    var body: some View {
+        DisclosureGroup(isExpanded: $isExpanded) {
+            CPSLSelectableText(
+                text,
+                style: .supporting,
+                foreground: CPSLTheme.secondaryText,
+                fillsAvailableWidth: true,
+                parsesInlineMarkdown: true
+            )
+            .padding(.top, CPSLTheme.small / 2)
+        } label: {
+            HStack(spacing: CPSLTheme.small) {
+                Image(systemName: "sparkles")
+                    .font(CPSLTheme.iconSmallFont)
+                    .foregroundStyle(CPSLTheme.mauve)
+                Text(isExpanded ? "Thought" : preview)
+                    .font(CPSLTheme.supportingMediumFont)
+                    .foregroundStyle(CPSLTheme.secondaryText)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .onChange(of: isFolded) { _, folded in
+            isExpanded = !folded
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var preview: String {
+        text.split(whereSeparator: \.isNewline).first.map(String.init) ?? text
     }
 }
 
@@ -696,6 +770,7 @@ private struct CPSLMarkdownMessageBody: View {
     let text: String
     let foreground: Color
     let fillsAvailableWidth: Bool
+    let isStreaming: Bool
     let openFilePath: (String) -> Void
 
     var body: some View {
@@ -708,7 +783,7 @@ private struct CPSLMarkdownMessageBody: View {
                 foreground: foreground,
                 fillsAvailableWidth: fillsAvailableWidth,
                 lineSpacing: CPSLTheme.bodyLineSpacing,
-                parsesBlockMarkdown: true,
+                parsesBlockMarkdown: !isStreaming,
                 openFilePath: openFilePath
             )
         }

--- a/app/apple/herm/Views/Chat/CPSLConversationDrawerView.swift
+++ b/app/apple/herm/Views/Chat/CPSLConversationDrawerView.swift
@@ -10,7 +10,7 @@ enum CPSLConversationDrawerLayout {
 }
 
 struct CPSLConversationDrawerView: View {
-    @ObservedObject var model: CPSLChatModel
+    let model: CPSLChatModel
     let topInset: CGFloat
     let bottomInset: CGFloat
 
@@ -28,7 +28,7 @@ struct CPSLConversationDrawerView: View {
 }
 
 private struct CPSLConversationDrawerContent: View {
-    @ObservedObject var model: CPSLChatModel
+    @Bindable var model: CPSLChatModel
     let width: CGFloat
     let topInset: CGFloat
     let bottomInset: CGFloat
@@ -270,7 +270,7 @@ private struct CPSLDrawerToolbar: View {
 }
 
 private struct CPSLConversationListView: View {
-    @ObservedObject var model: CPSLChatModel
+    let model: CPSLChatModel
     @Binding var tagSheetConversationID: String?
     @Binding var renamingConversation: CPSLConversationSummary?
 

--- a/app/apple/herm/Views/Chat/CPSLConversationDrawerView.swift
+++ b/app/apple/herm/Views/Chat/CPSLConversationDrawerView.swift
@@ -44,10 +44,8 @@ private struct CPSLConversationDrawerContent: View {
         let activeTags = model.allTags.filter { model.activeTagIDs.contains($0.id) }
         VStack(alignment: .leading, spacing: 0) {
             CPSLDrawerToolbar(
-                title: model.showingArchived ? "Archived" : "Conversations",
                 isBusy: model.isBusy,
                 isArchivedScope: model.showingArchived,
-                onBack: { searchFocused = false; model.closeDrawer() },
                 onNewChat: { searchFocused = false; model.startNewConversation() },
                 onToggleArchived: { searchFocused = false; model.setArchivedScope(!model.showingArchived) }
             )
@@ -76,6 +74,11 @@ private struct CPSLConversationDrawerContent: View {
         }
         .contentShape(Rectangle())
         .onTapGesture { searchFocused = false }
+        .onChange(of: model.isDrawerOpen) { _, isOpen in
+            if !isOpen {
+                searchFocused = false
+            }
+        }
         .padding(.top, topInset)
         .padding(.bottom, keyboardOverlap > 0 ? keyboardOverlap + CPSLTheme.small : bottomInset)
         .frame(width: width)
@@ -213,26 +216,19 @@ private struct CPSLConversationSearchBar: View {
 }
 
 private struct CPSLDrawerToolbar: View {
-    let title: String
     let isBusy: Bool
     let isArchivedScope: Bool
-    let onBack: () -> Void
     let onNewChat: () -> Void
     let onToggleArchived: () -> Void
 
     var body: some View {
         HStack(spacing: CPSLTheme.small) {
-            Button(action: onBack) {
-                chip("chevron.left")
+            HStack(spacing: CPSLTheme.small / 2) {
+                Text("Herm")
+                    .cpslAnimatedPastelRainbowForeground()
+                Text(verbatim: "🐚")
             }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Back to chat")
-
-            Text(title)
-                .font(CPSLTheme.userFont(size: CPSLTheme.FontSize.body, weight: .semibold))
-                .foregroundStyle(CPSLTheme.text)
-                .lineLimit(1)
-                .padding(.leading, CPSLTheme.small / 2)
+            .font(CPSLTheme.headerFont)
 
             Spacer(minLength: CPSLTheme.small)
 
@@ -251,6 +247,7 @@ private struct CPSLDrawerToolbar: View {
             .accessibilityLabel("New conversation")
         }
         .frame(height: CPSLTheme.controlSize)
+        .padding(.trailing, CPSLTheme.controlSize + CPSLTheme.small)
     }
 
     private func chip(_ systemName: String, isActive: Bool = false) -> some View {

--- a/app/apple/herm/Views/Chat/CPSLTagAssignmentSheet.swift
+++ b/app/apple/herm/Views/Chat/CPSLTagAssignmentSheet.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct CPSLTagAssignmentSheet: View {
-    @ObservedObject var model: CPSLChatModel
+    let model: CPSLChatModel
     let conversationID: String
     @Environment(\.dismiss) private var dismiss
     @State private var selected: Set<String> = []

--- a/app/apple/herm/Views/Chat/CPSLTagFilterSheet.swift
+++ b/app/apple/herm/Views/Chat/CPSLTagFilterSheet.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct CPSLTagFilterSheet: View {
-    @ObservedObject var model: CPSLChatModel
+    let model: CPSLChatModel
     @Environment(\.dismiss) private var dismiss
     @State private var renaming: CPSLTag?
     @State private var renameText = ""

--- a/app/apple/herm/Views/Composer/CPSLPromptComposerView.swift
+++ b/app/apple/herm/Views/Composer/CPSLPromptComposerView.swift
@@ -162,7 +162,7 @@ private struct CPSLPromptTextView: UIViewRepresentable {
 #endif
 
 struct CPSLPromptComposerView: View {
-    @ObservedObject var model: CPSLChatModel
+    @Bindable var model: CPSLChatModel
     let dismissKeyboardRequest: Int
     let isCompact: Bool
     let dismissKeyboard: () -> Void

--- a/app/apple/herm/Views/Composer/CPSLToolStripView.swift
+++ b/app/apple/herm/Views/Composer/CPSLToolStripView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 #endif
 
 struct CPSLToolStripView: View {
-    @ObservedObject var model: CPSLChatModel
+    let model: CPSLChatModel
     @ObservedObject private var calendar: CPSLCalendarService
     @ObservedObject private var location: CPSLLocationService
 

--- a/app/apple/herm/Views/Files/CPSLFileBrowserView.swift
+++ b/app/apple/herm/Views/Files/CPSLFileBrowserView.swift
@@ -175,7 +175,7 @@ private enum CPSLFileBrowserInteractionMode: Equatable {
 }
 
 struct CPSLFileBrowserView: View {
-    @ObservedObject var model: CPSLChatModel
+    let model: CPSLChatModel
     @State private var isICloudImporterPresented = false
     @State private var isICloudImporterPending = false
     @State private var isICloudAccessModePickerPresented = false
@@ -380,7 +380,7 @@ struct CPSLFileBrowserView: View {
 }
 
 private struct CPSLFileBrowserRouteStack: View {
-    @ObservedObject var model: CPSLChatModel
+    let model: CPSLChatModel
     let actions: CPSLFileBrowserActions
     @State private var pages: [CPSLFileBrowserDisplayPage] = []
     @State private var transitionGeneration = 0
@@ -662,7 +662,7 @@ private struct CPSLFileBrowserActions {
 }
 
 private struct CPSLFileBrowserHeader: View {
-    @ObservedObject var model: CPSLChatModel
+    let model: CPSLChatModel
     let actions: CPSLFileBrowserActions
 
     var body: some View {

--- a/app/apple/herm/Views/Files/CPSLFileOverlayPanel.swift
+++ b/app/apple/herm/Views/Files/CPSLFileOverlayPanel.swift
@@ -85,9 +85,12 @@ struct CPSLFileOverlayPanel<Header: View, Content: View>: View {
             tint: CPSLTheme.command,
             strokeOpacity: 0.07
         )
-        .cpslAnimatedPastelRainbowBorder(
-            in: RoundedRectangle(cornerRadius: CPSLTheme.paneRadius, style: .continuous)
-        )
+        .overlay {
+            // Keep full-size PDF, web, and calendar surfaces out of a 30 fps overlay redraw.
+            RoundedRectangle(cornerRadius: CPSLTheme.paneRadius, style: .continuous)
+                .strokeBorder(CPSLPastelRainbow.gradient(at: .zero), lineWidth: 1)
+                .allowsHitTesting(false)
+        }
     }
 }
 

--- a/app/apple/herm/Views/Files/CPSLFilePreviewOverlay.swift
+++ b/app/apple/herm/Views/Files/CPSLFilePreviewOverlay.swift
@@ -89,6 +89,7 @@ private struct CPSLPDFFilePreview: View {
     var body: some View {
         #if (os(macOS) || canImport(UIKit)) && canImport(PDFKit)
             CPSLPDFKitView(url: url)
+                .equatable()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         #else
             CPSLPDFPreviewUnavailable(message: "PDF preview is not available on this platform.")
@@ -165,7 +166,7 @@ private enum CPSLPDFKitConfiguration {
 }
 
 #if os(macOS)
-private struct CPSLPDFKitView: NSViewRepresentable {
+private struct CPSLPDFKitView: NSViewRepresentable, Equatable {
     let url: URL
 
     func makeCoordinator() -> CPSLPDFKitCoordinator {
@@ -188,7 +189,7 @@ private struct CPSLPDFKitView: NSViewRepresentable {
     }
 }
 #elseif canImport(UIKit)
-private struct CPSLPDFKitView: UIViewRepresentable {
+private struct CPSLPDFKitView: UIViewRepresentable, Equatable {
     let url: URL
 
     func makeCoordinator() -> CPSLPDFKitCoordinator {

--- a/app/apple/herm/Views/Files/CPSLFilePreviewOverlay.swift
+++ b/app/apple/herm/Views/Files/CPSLFilePreviewOverlay.swift
@@ -1,5 +1,7 @@
 import Foundation
-import Combine
+import CoreGraphics
+import ImageIO
+import Observation
 import SwiftUI
 
 #if canImport(AVFoundation)
@@ -8,15 +10,9 @@ import SwiftUI
 #if canImport(AVKit)
 @preconcurrency import AVKit
 #endif
-#if os(macOS) && canImport(AppKit)
-import AppKit
-#elseif canImport(UIKit)
-import UIKit
-#endif
 #if canImport(PDFKit)
-import PDFKit
+@preconcurrency import PDFKit
 #endif
-
 struct CPSLFilePreviewContentView: View {
     let preview: CPSLFilePreview
 
@@ -77,7 +73,13 @@ private struct CPSLHighlightedCodeText: View {
     let language: CPSLCodeLanguage
 
     var body: some View {
-        Text(CPSLCodeHighlighter.highlight(text, language: language))
+        if text.utf8.count <= 32_768 {
+            Text(CPSLCodeHighlighter.highlight(text, language: language))
+        } else {
+            Text(text)
+                .font(CPSLTheme.monospacedBodyFont)
+                .foregroundStyle(CPSLTheme.text)
+        }
     }
 }
 
@@ -85,28 +87,134 @@ private struct CPSLPDFFilePreview: View {
     let url: URL
 
     var body: some View {
-        #if os(macOS) && canImport(PDFKit)
+        #if (os(macOS) || canImport(UIKit)) && canImport(PDFKit)
             CPSLPDFKitView(url: url)
-        #elseif canImport(UIKit) && canImport(PDFKit)
-            CPSLPDFKitView(url: url)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         #else
-            CPSLUnsupportedPDFPreview()
+            CPSLPDFPreviewUnavailable(message: "PDF preview is not available on this platform.")
         #endif
     }
 }
 
-private struct CPSLUnsupportedPDFPreview: View {
+private struct CPSLPDFPreviewUnavailable: View {
+    let message: String
+
     var body: some View {
         VStack(spacing: CPSLTheme.small) {
             Image(systemName: "doc.richtext")
                 .font(CPSLTheme.iconLargeFont)
                 .foregroundStyle(CPSLTheme.secondaryText)
-            Text("PDF preview is not available on this platform.")
+            Text(message)
                 .font(CPSLTheme.supportingFont)
                 .foregroundStyle(CPSLTheme.secondaryText)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
+}
+
+#if canImport(PDFKit)
+private nonisolated struct CPSLSendablePDFDocument: @unchecked Sendable {
+    let value: PDFDocument?
+}
+
+@MainActor
+private final class CPSLPDFKitCoordinator {
+    private var representedURL: URL?
+    private var loadTask: Task<Void, Never>?
+
+    func load(url: URL, into pdfView: PDFView) {
+        guard representedURL != url else {
+            return
+        }
+        representedURL = url
+        loadTask?.cancel()
+        pdfView.document = nil
+        loadTask = Task { @MainActor [weak self, weak pdfView] in
+            let document = await Task.detached(priority: .userInitiated) {
+                CPSLSendablePDFDocument(value: PDFDocument(url: url))
+            }.value
+            guard !Task.isCancelled,
+                  self?.representedURL == url,
+                  let pdfView
+            else {
+                return
+            }
+            pdfView.document = document.value
+            pdfView.autoScales = true
+        }
+    }
+
+    func cancel() {
+        loadTask?.cancel()
+        loadTask = nil
+        representedURL = nil
+    }
+}
+
+@MainActor
+private enum CPSLPDFKitConfiguration {
+    static func makeView() -> PDFView {
+        let pdfView = PDFView()
+        pdfView.autoScales = true
+        pdfView.displayBox = .cropBox
+        pdfView.displayDirection = .vertical
+        pdfView.displayMode = .singlePageContinuous
+        pdfView.displaysPageBreaks = true
+        return pdfView
+    }
+}
+
+#if os(macOS)
+private struct CPSLPDFKitView: NSViewRepresentable {
+    let url: URL
+
+    func makeCoordinator() -> CPSLPDFKitCoordinator {
+        CPSLPDFKitCoordinator()
+    }
+
+    func makeNSView(context: Context) -> PDFView {
+        let pdfView = CPSLPDFKitConfiguration.makeView()
+        context.coordinator.load(url: url, into: pdfView)
+        return pdfView
+    }
+
+    func updateNSView(_ pdfView: PDFView, context: Context) {
+        context.coordinator.load(url: url, into: pdfView)
+    }
+
+    static func dismantleNSView(_ pdfView: PDFView, coordinator: CPSLPDFKitCoordinator) {
+        coordinator.cancel()
+        pdfView.document = nil
+    }
+}
+#elseif canImport(UIKit)
+private struct CPSLPDFKitView: UIViewRepresentable {
+    let url: URL
+
+    func makeCoordinator() -> CPSLPDFKitCoordinator {
+        CPSLPDFKitCoordinator()
+    }
+
+    func makeUIView(context: Context) -> PDFView {
+        let pdfView = CPSLPDFKitConfiguration.makeView()
+        context.coordinator.load(url: url, into: pdfView)
+        return pdfView
+    }
+
+    func updateUIView(_ pdfView: PDFView, context: Context) {
+        context.coordinator.load(url: url, into: pdfView)
+    }
+
+    static func dismantleUIView(_ pdfView: PDFView, coordinator: CPSLPDFKitCoordinator) {
+        coordinator.cancel()
+        pdfView.document = nil
+    }
+}
+#endif
+#endif
+
+private nonisolated struct CPSLSendableCGImage: @unchecked Sendable {
+    let value: CGImage
 }
 
 private struct CPSLImageFilePreview: View {
@@ -316,53 +424,42 @@ private enum CPSLFilePreviewFormatting {
     }
 }
 
-#if os(macOS) && canImport(AppKit)
-private typealias CPSLPlatformPreviewImage = NSImage
-
 private enum CPSLPlatformImageLoader {
-    static func image(for url: URL) -> CPSLPlatformPreviewImage? {
-        NSImage(contentsOf: url)
+    static func image(for url: URL) async -> CPSLSendableCGImage? {
+        await Task.detached(priority: .userInitiated) {
+            guard let source = CGImageSourceCreateWithURL(url as CFURL, nil) else {
+                return nil
+            }
+            let options: [CFString: Any] = [
+                kCGImageSourceCreateThumbnailFromImageAlways: true,
+                kCGImageSourceCreateThumbnailWithTransform: true,
+                kCGImageSourceThumbnailMaxPixelSize: 2_400,
+                kCGImageSourceShouldCacheImmediately: true,
+            ]
+            guard let image = CGImageSourceCreateThumbnailAtIndex(
+                source,
+                0,
+                options as CFDictionary
+            ) else {
+                return nil
+            }
+            return CPSLSendableCGImage(value: image)
+        }.value
     }
 }
 
-private struct CPSLPlatformImageView: View {
-    let image: CPSLPlatformPreviewImage
-
-    var body: some View {
-        Image(nsImage: image)
-            .resizable()
-    }
-}
-#elseif canImport(UIKit)
-private typealias CPSLPlatformPreviewImage = UIImage
-
-private enum CPSLPlatformImageLoader {
-    static func image(for url: URL) -> CPSLPlatformPreviewImage? {
-        UIImage(contentsOfFile: url.path)
-    }
-}
-
-private struct CPSLPlatformImageView: View {
-    let image: CPSLPlatformPreviewImage
-
-    var body: some View {
-        Image(uiImage: image)
-            .resizable()
-    }
-}
-#endif
-
-#if (os(macOS) && canImport(AppKit)) || canImport(UIKit)
 private struct CPSLPlatformImageFilePreview: View {
     let url: URL
     let preview: CPSLFilePreview
-    @State private var image: CPSLPlatformPreviewImage?
+    @Environment(\.displayScale) private var displayScale
+    @State private var image: CGImage?
     @State private var didAttemptLoad = false
 
     var body: some View {
         ZStack {
             if let image {
-                CPSLPlatformImageView(image: image)
+                Image(decorative: image, scale: displayScale, orientation: .up)
+                    .resizable()
                     .scaledToFit()
                     .padding(CPSLTheme.large)
             } else if didAttemptLoad {
@@ -373,7 +470,9 @@ private struct CPSLPlatformImageFilePreview: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .task(id: url) {
-            image = CPSLPlatformImageLoader.image(for: url)
+            image = nil
+            didAttemptLoad = false
+            image = await CPSLPlatformImageLoader.image(for: url)?.value
             didAttemptLoad = true
         }
     }
@@ -398,17 +497,16 @@ private struct CPSLImageLoadFailurePreview: View {
         .scrollBounceBehavior(.basedOnSize)
     }
 }
-#endif
 
 #if canImport(AVFoundation) && canImport(AVKit)
 private struct CPSLAudioPlayerPreview: View {
     let preview: CPSLFilePreview
-    @StateObject private var playback: CPSLMediaPlaybackModel
+    @State private var playback: CPSLMediaPlaybackModel
 
     init(url: URL, preview: CPSLFilePreview) {
         self.preview = preview
-        _playback = StateObject(
-            wrappedValue: CPSLMediaPlaybackModel(
+        _playback = State(
+            initialValue: CPSLMediaPlaybackModel(
                 url: url,
                 duration: preview.metadata.durationSeconds
             )
@@ -430,12 +528,12 @@ private struct CPSLAudioPlayerPreview: View {
 
 private struct CPSLVideoPlayerPreview: View {
     let preview: CPSLFilePreview
-    @StateObject private var playback: CPSLMediaPlaybackModel
+    @State private var playback: CPSLMediaPlaybackModel
 
     init(url: URL, preview: CPSLFilePreview) {
         self.preview = preview
-        _playback = StateObject(
-            wrappedValue: CPSLMediaPlaybackModel(
+        _playback = State(
+            initialValue: CPSLMediaPlaybackModel(
                 url: url,
                 duration: preview.metadata.durationSeconds
             )
@@ -467,7 +565,7 @@ private struct CPSLVideoPlayerPreview: View {
 }
 
 private struct CPSLMediaControlsView: View {
-    @ObservedObject var playback: CPSLMediaPlaybackModel
+    let playback: CPSLMediaPlaybackModel
 
     var body: some View {
         VStack(spacing: CPSLTheme.small) {
@@ -509,14 +607,17 @@ private struct CPSLMediaControlsView: View {
 }
 
 @MainActor
-private final class CPSLMediaPlaybackModel: ObservableObject {
-    @Published private(set) var currentTime: Double = 0
-    @Published private(set) var duration: Double
-    @Published private(set) var isPlaying = false
+@Observable
+private final class CPSLMediaPlaybackModel {
+    private(set) var currentTime: Double = 0
+    private(set) var duration: Double
+    private(set) var isPlaying = false
 
     let player: AVPlayer
 
+    @ObservationIgnored
     private var timeObserver: Any?
+    @ObservationIgnored
     private var endObserver: NSObjectProtocol?
 
     init(url: URL, duration: Double?) {
@@ -603,48 +704,6 @@ private final class CPSLMediaPlaybackModel: ObservableObject {
     private func finishPlayback() {
         isPlaying = false
         currentTime = duration
-    }
-}
-#endif
-
-#if os(macOS) && canImport(PDFKit)
-private struct CPSLPDFKitView: NSViewRepresentable {
-    let url: URL
-
-    func makeNSView(context: Context) -> PDFView {
-        let pdfView = PDFView()
-        configure(pdfView)
-        return pdfView
-    }
-
-    func updateNSView(_ pdfView: PDFView, context: Context) {
-        configure(pdfView)
-    }
-
-    private func configure(_ pdfView: PDFView) {
-        pdfView.autoScales = true
-        pdfView.displayMode = .singlePageContinuous
-        pdfView.document = PDFDocument(url: url)
-    }
-}
-#elseif canImport(UIKit) && canImport(PDFKit)
-private struct CPSLPDFKitView: UIViewRepresentable {
-    let url: URL
-
-    func makeUIView(context: Context) -> PDFView {
-        let pdfView = PDFView()
-        configure(pdfView)
-        return pdfView
-    }
-
-    func updateUIView(_ pdfView: PDFView, context: Context) {
-        configure(pdfView)
-    }
-
-    private func configure(_ pdfView: PDFView) {
-        pdfView.autoScales = true
-        pdfView.displayMode = .singlePageContinuous
-        pdfView.document = PDFDocument(url: url)
     }
 }
 #endif

--- a/app/apple/hermTests/CPSLAgentPresentationTests.swift
+++ b/app/apple/hermTests/CPSLAgentPresentationTests.swift
@@ -66,18 +66,18 @@ struct CPSLAgentPresentationTests {
         #expect(CPSLAgentToolFormatting.summary(for: agentCall) == "Compare the candidate venues")
     }
 
-    @Test func presentationProjectionDoesNotAlterPersistedDiagnostics() {
-        let invocations = (0..<6).map { index in
-            CPSLToolStatusInvocation(
-                id: "invocation-\(index)",
-                name: "tool",
-                summary: "Invocation \(index)",
-                input: "input-\(index)",
-                output: "output-\(index)",
+    @Test func statusPayloadRoundTripsPresentationState() {
+        let invocation = CPSLToolStatusInvocation(
+            traceInvocation: CPSLToolTraceInvocation(
+                id: "call-1",
+                name: "local_sandbox_exec",
+                summary: "Building report",
+                input: "print('hello')",
+                output: "done",
                 isError: false
             )
-        }
-        let visits = (0..<14).map { index in
+        )
+        let visits = (0..<2).map { index in
             CPSLWebSearchVisit(
                 id: "visit-\(index)",
                 browserID: "browser-\(index)",
@@ -90,23 +90,18 @@ struct CPSLAgentPresentationTests {
         let payload = CPSLToolStatusPayload(
             state: .succeeded,
             summary: "Finished",
-            invocations: invocations,
+            invocations: [invocation],
             webVisits: visits
         )
 
-        let persisted = CPSLToolStatusPayload.decode(from: payload.encodedBody())
-        let presentation = CPSLToolStatusPayload.decode(from: payload.presentationEncodedBody())
+        let decoded = CPSLToolStatusPayload.decode(from: payload.encodedBody())
+        #expect(decoded == payload)
+    }
 
-        #expect(persisted?.invocations.count == 6)
-        #expect(persisted?.webVisits.count == 14)
-#if DEBUG
-        #expect(presentation?.invocations.map(\.id) == [
-            "invocation-2", "invocation-3", "invocation-4", "invocation-5",
-        ])
-#else
-        #expect(presentation?.invocations.isEmpty == true)
-#endif
-        #expect(presentation?.webVisits.first?.id == "visit-2")
-        #expect(presentation?.webVisits.count == 12)
+    @Test func statusPayloadWithoutInvocationExcerptsStillDecodes() {
+        let legacyBody = #"{"state":"succeeded","summary":"Finished","webVisits":[]}"#
+
+        let decoded = CPSLToolStatusPayload.decode(from: legacyBody)
+        #expect(decoded?.invocations.isEmpty == true)
     }
 }

--- a/app/apple/hermTests/CPSLAgentPresentationTests.swift
+++ b/app/apple/hermTests/CPSLAgentPresentationTests.swift
@@ -103,5 +103,118 @@ struct CPSLAgentPresentationTests {
 
         let decoded = CPSLToolStatusPayload.decode(from: legacyBody)
         #expect(decoded?.invocations.isEmpty == true)
+        #expect(decoded?.isSuperseded == false)
+    }
+
+    @Test func interruptedStatusRoundTrips() {
+        let activityID = UUID()
+        let payload = CPSLToolStatusPayload(
+            state: .interrupted,
+            summary: "Stopped",
+            activityID: activityID
+        )
+
+        #expect(CPSLToolStatusPayload.decode(from: payload.encodedBody()) == payload)
+    }
+
+    @Test func retryStatusKeepsItsPresentationIdentity() {
+        let activityID = UUID()
+        let failedAttempt = CPSLChatMessage(
+            role: .toolStatus,
+            title: nil,
+            body: CPSLToolStatusPayload(
+                state: .running,
+                summary: "First attempt",
+                isSuperseded: true,
+                activityID: activityID
+            ).encodedBody()
+        )
+        let retry = CPSLChatMessage(
+            role: .toolStatus,
+            title: nil,
+            body: CPSLToolStatusPayload(
+                state: .running,
+                summary: "Retrying",
+                activityID: activityID
+            ).encodedBody()
+        )
+
+        #expect(failedAttempt.activityEntryID == retry.activityEntryID)
+    }
+
+    @Test func timelineGroupsConsecutiveThoughtsAndVisibleToolStatuses() {
+        let user = CPSLChatMessage(role: .user, title: nil, body: "Start")
+        let firstThought = CPSLChatMessage(role: .thought, title: nil, body: "First thought")
+        let supersededStatus = CPSLChatMessage(
+            role: .toolStatus,
+            title: nil,
+            body: CPSLToolStatusPayload(
+                state: .running,
+                summary: "Failed attempt",
+                isSuperseded: true
+            ).encodedBody()
+        )
+        let secondThought = CPSLChatMessage(role: .thought, title: nil, body: "Second thought")
+        let currentStatus = CPSLChatMessage(
+            role: .toolStatus,
+            title: nil,
+            body: CPSLToolStatusPayload.running(summary: "Trying again").encodedBody()
+        )
+        let assistant = CPSLChatMessage(role: .assistant, title: nil, body: "Done")
+
+        let items = CPSLChatTimelineItem.grouped(
+            from: [user, firstThought, supersededStatus, secondThought, currentStatus, assistant]
+        )
+
+        #expect(items.count == 3)
+        guard case .activity(let group) = items[1] else {
+            Issue.record("Expected one activity group between the user and assistant messages")
+            return
+        }
+        #expect(group.id == firstThought.id)
+        #expect(group.messages.map(\.id) == [firstThought.id, secondThought.id, currentStatus.id])
+    }
+
+    @Test func collapsedActivityKeepsAnExpandedOlderEntryVisible() {
+        let messages = (0..<9).map { index in
+            CPSLChatMessage(role: .thought, title: nil, body: "Thought \(index)")
+        }
+        let group = CPSLTimelineActivityGroup(id: messages[0].id, messages: messages)
+
+        let displayItems = CPSLActivityDisplayItem.items(
+            for: group,
+            expandedEntryIDs: [messages[3].id],
+            showsAll: false
+        )
+
+        #expect(displayItems.map(\.id) == [
+            .omission(messages[0].id),
+            .message(messages[3].id),
+            .omission(messages[4].id),
+            .message(messages[6].id),
+            .message(messages[7].id),
+            .message(messages[8].id),
+        ])
+    }
+
+    @Test func expandedActivityOffersOneFoldControlAndEveryEntry() {
+        let messages = (0..<4).map { index in
+            CPSLChatMessage(role: .thought, title: nil, body: "Thought \(index)")
+        }
+        let group = CPSLTimelineActivityGroup(id: messages[0].id, messages: messages)
+
+        let displayItems = CPSLActivityDisplayItem.items(
+            for: group,
+            expandedEntryIDs: [],
+            showsAll: true
+        )
+
+        #expect(displayItems.map(\.id) == [
+            .collapse(group.id),
+            .message(messages[0].id),
+            .message(messages[1].id),
+            .message(messages[2].id),
+            .message(messages[3].id),
+        ])
     }
 }

--- a/app/apple/hermTests/CPSLAgentPresentationTests.swift
+++ b/app/apple/hermTests/CPSLAgentPresentationTests.swift
@@ -1,0 +1,112 @@
+import Testing
+@testable import herm
+
+struct CPSLAgentPresentationTests {
+    private let toolCall = CPSLOpenAIToolCall(
+        id: "call-1",
+        type: "function",
+        function: CPSLOpenAIFunctionCall(
+            name: CPSLAgentToolFormatting.localSandboxExecName,
+            arguments: #"{"intent":"Checking available skills","source":"print(help())"}"#
+        )
+    )
+
+    @Test func redundantToolCommentaryIsNotShownAsThought() {
+        let thought = CPSLAgentToolFormatting.uniqueThought(
+            from: "I'll check the available skills now.",
+            toolCalls: [toolCall]
+        )
+        #expect(thought == nil)
+    }
+
+    @Test func uniqueCommentarySurvivesAlongsideRedundantStatus() {
+        let thought = CPSLAgentToolFormatting.uniqueThought(
+            from: "Checking available skills\nThe document needs current venue hours before it can be finalized.",
+            toolCalls: [toolCall]
+        )
+        #expect(thought == "The document needs current venue hours before it can be finalized.")
+    }
+
+    @Test func providerStatusFallbackIsNotRepeatedAsThought() {
+        let fallbackToolCall = CPSLOpenAIToolCall(
+            id: "call-2",
+            type: "function",
+            function: CPSLOpenAIFunctionCall(name: "unknown", arguments: "{}")
+        )
+        let thought = CPSLAgentToolFormatting.uniqueThought(
+            from: "I’ll inspect the remaining details.",
+            toolCalls: [fallbackToolCall]
+        )
+        #expect(thought == nil)
+    }
+
+    @Test func agentStatusUsesItsSpecificIntent() {
+        let agentCall = CPSLOpenAIToolCall(
+            id: "call-agent",
+            type: "function",
+            function: CPSLOpenAIFunctionCall(
+                name: CPSLAgentToolFormatting.agentName,
+                arguments: #"{"intent":"Comparing venue options","task":"Research the candidate venues.","mode":"explore"}"#
+            )
+        )
+
+        #expect(CPSLAgentToolFormatting.summary(for: agentCall) == "Comparing venue options")
+    }
+
+    @Test func legacyAgentStatusFallsBackToItsTask() {
+        let agentCall = CPSLOpenAIToolCall(
+            id: "call-agent-legacy",
+            type: "function",
+            function: CPSLOpenAIFunctionCall(
+                name: CPSLAgentToolFormatting.agentName,
+                arguments: #"{"task":"Compare the candidate venues","mode":"explore"}"#
+            )
+        )
+
+        #expect(CPSLAgentToolFormatting.summary(for: agentCall) == "Compare the candidate venues")
+    }
+
+    @Test func presentationProjectionDoesNotAlterPersistedDiagnostics() {
+        let invocations = (0..<6).map { index in
+            CPSLToolStatusInvocation(
+                id: "invocation-\(index)",
+                name: "tool",
+                summary: "Invocation \(index)",
+                input: "input-\(index)",
+                output: "output-\(index)",
+                isError: false
+            )
+        }
+        let visits = (0..<14).map { index in
+            CPSLWebSearchVisit(
+                id: "visit-\(index)",
+                browserID: "browser-\(index)",
+                url: "https://example.com/\(index)",
+                title: "Visit \(index)",
+                host: "example.com",
+                faviconURL: nil
+            )
+        }
+        let payload = CPSLToolStatusPayload(
+            state: .succeeded,
+            summary: "Finished",
+            invocations: invocations,
+            webVisits: visits
+        )
+
+        let persisted = CPSLToolStatusPayload.decode(from: payload.encodedBody())
+        let presentation = CPSLToolStatusPayload.decode(from: payload.presentationEncodedBody())
+
+        #expect(persisted?.invocations.count == 6)
+        #expect(persisted?.webVisits.count == 14)
+#if DEBUG
+        #expect(presentation?.invocations.map(\.id) == [
+            "invocation-2", "invocation-3", "invocation-4", "invocation-5",
+        ])
+#else
+        #expect(presentation?.invocations.isEmpty == true)
+#endif
+        #expect(presentation?.webVisits.first?.id == "visit-2")
+        #expect(presentation?.webVisits.count == 12)
+    }
+}

--- a/app/apple/hermTests/CPSLConversationMutationTests.swift
+++ b/app/apple/hermTests/CPSLConversationMutationTests.swift
@@ -5,8 +5,8 @@ import Testing
 struct CPSLConversationMutationTests {
     private func makeStore() throws -> CPSLConversationStore {
         let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("herm-test-\(UUID().uuidString).sqlite")
-        return try CPSLConversationStore(databaseURL: url, usesICloudContainer: false)
+            .appendingPathComponent("herm-test-\(UUID().uuidString).jsonl")
+        return try CPSLConversationStore(logURL: url, usesICloudContainer: false)
     }
 
     @Test func pinToggles() async throws {

--- a/app/apple/hermTests/CPSLConversationStoreMigrationTests.swift
+++ b/app/apple/hermTests/CPSLConversationStoreMigrationTests.swift
@@ -3,11 +3,79 @@ import Testing
 @testable import herm
 
 struct CPSLConversationStoreMigrationTests {
-    @Test func migrationIsIdempotent() throws {
+    @Test func reopeningJSONLStoreIsIdempotent() throws {
         let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("herm-test-\(UUID().uuidString).sqlite")
-        _ = try CPSLConversationStore(databaseURL: url, usesICloudContainer: false)
-        // Reopening the same database replays migrate() without error.
-        _ = try CPSLConversationStore(databaseURL: url, usesICloudContainer: false)
+            .appendingPathComponent("herm-test-\(UUID().uuidString).jsonl")
+        _ = try CPSLConversationStore(logURL: url, usesICloudContainer: false)
+        // Reopening the same append-only log leaves it intact.
+        _ = try CPSLConversationStore(logURL: url, usesICloudContainer: false)
+    }
+
+    @Test func mutationsAppendJSONLinesAndExportStructuredJSON() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("herm-test-\(UUID().uuidString).jsonl")
+        let store = try CPSLConversationStore(logURL: url, usesICloudContainer: false)
+        let created = try await store.createConversation(
+            userText: "hello",
+            model: "test-model",
+            systemPrompt: "test prompt"
+        )
+        let sizeAfterCreate = try Data(contentsOf: url).count
+        try await store.setPinned(conversationID: created.summary.id, pinned: true)
+        let log = try Data(contentsOf: url)
+
+        #expect(log.count > sizeAfterCreate)
+        #expect(log.filter { $0 == 0x0A }.count == 2)
+
+        try await store.recordToolInvocation(
+            conversationID: created.summary.id,
+            nodeID: created.userNode.id,
+            invocation: CPSLToolTraceInvocation(
+                id: "call-1",
+                name: "test",
+                summary: "Testing",
+                input: "input",
+                output: "output",
+                isError: false
+            )
+        )
+        let projectedInvocations = try await store.toolStatusInvocations(
+            conversationID: created.summary.id,
+            nodeIDs: [created.userNode.id]
+        )
+        #expect(projectedInvocations[created.userNode.id]?.map(\.id) == ["call-1"])
+
+#if DEBUG
+        let json = try await store.exportConversationJSON(id: created.summary.id)
+        let object = try #require(
+            JSONSerialization.jsonObject(with: Data(json.utf8)) as? [String: Any]
+        )
+        #expect(object["format"] as? String == "herm.debug-export")
+        #expect((object["conversationEvents"] as? [[String: Any]])?.count == 2)
+        #expect((object["traceEvents"] as? [[String: Any]])?.count == 1)
+#endif
+    }
+
+    @Test func incompleteTailIsDiscardedBeforeNextAppend() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("herm-test-\(UUID().uuidString).jsonl")
+        let store = try CPSLConversationStore(logURL: url, usesICloudContainer: false)
+        let created = try await store.createConversation(
+            userText: "hello",
+            model: nil,
+            systemPrompt: ""
+        )
+        let handle = try FileHandle(forWritingTo: url)
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data(#"{"partial":"#.utf8))
+        try handle.close()
+
+        try await store.setPinned(conversationID: created.summary.id, pinned: true)
+        let reopened = try CPSLConversationStore(logURL: url, usesICloudContainer: false)
+        let summary = try await reopened.fetchConversationSummaries(
+            archiveScope: .active,
+            tagIDs: []
+        ).first
+        #expect(summary?.pinned == true)
     }
 }

--- a/app/apple/hermTests/CPSLFetchSummariesTests.swift
+++ b/app/apple/hermTests/CPSLFetchSummariesTests.swift
@@ -5,8 +5,8 @@ import Testing
 struct CPSLFetchSummariesTests {
     private func makeStore() throws -> CPSLConversationStore {
         let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("herm-test-\(UUID().uuidString).sqlite")
-        return try CPSLConversationStore(databaseURL: url, usesICloudContainer: false)
+            .appendingPathComponent("herm-test-\(UUID().uuidString).jsonl")
+        return try CPSLConversationStore(logURL: url, usesICloudContainer: false)
     }
 
     @Test func activeScopeReturnsCreatedByDefault() async throws {

--- a/app/apple/hermTests/CPSLTagStoreTests.swift
+++ b/app/apple/hermTests/CPSLTagStoreTests.swift
@@ -5,8 +5,8 @@ import Testing
 struct CPSLTagStoreTests {
     private func makeStore() throws -> CPSLConversationStore {
         let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("herm-test-\(UUID().uuidString).sqlite")
-        return try CPSLConversationStore(databaseURL: url, usesICloudContainer: false)
+            .appendingPathComponent("herm-test-\(UUID().uuidString).jsonl")
+        return try CPSLConversationStore(logURL: url, usesICloudContainer: false)
     }
 
     @Test func createAndListTags() async throws {

--- a/docs/apple-agent-config.md
+++ b/docs/apple-agent-config.md
@@ -23,6 +23,12 @@ main agent to spawn one helper level. Set it to `0` to remove the `agent` tool
 from provider requests. `HERM_EXPLORE_SUBAGENT_TURNS` and
 `HERM_GENERAL_SUBAGENT_TURNS` control the turn budget for helper agents.
 
+Round limits are fail-safe ceilings, not targets. Herm starts nudging the main
+agent to synthesize at rounds 8 and 12, reserves the last helper turn for a
+tool-free result, and clears stale tool output when replay reaches four output
+budgets (or 80% of a configured context window, whichever comes first). This
+keeps routine runs short without cutting off an unusually long task.
+
 Local credential files are ignored by git and excluded from the Xcode target:
 
 - `.env`

--- a/docs/apple-agent-storage.md
+++ b/docs/apple-agent-storage.md
@@ -1,26 +1,65 @@
 # Apple Agent Storage
 
-The Swift agent stores conversations in a local SQLite database with node-shaped
-conversation history. At launch, the app first tries the iCloud ubiquity
-container and stores the database under `Documents/Herm/conversations.sqlite`.
-If iCloud is unavailable, it falls back to Application Support.
+The Swift agent stores durable state in two append-only JSONL files:
 
-This is an iCloud file-container prototype, not Apple's standard robust
-structured-data sync design. It can make a SQLite file available through the
-shared iCloud documents container, but SQLite is still a single local database
-file and iCloud file syncing does not provide record-level merge semantics. For
-production-quality multi-device structured data sync, the expected Apple stack is
-CloudKit-backed persistence, such as Core Data or SwiftData with CloudKit.
+- `conversations.jsonl` contains conversation, node, tag, and metadata mutations.
+- `traces.jsonl` contains detailed provider requests/responses, tool calls, web
+  visits, and errors. Trace entries are not loaded to render a conversation.
+
+At launch, the app first tries the iCloud ubiquity container and stores the logs
+under `Documents/Herm`. If iCloud is unavailable, it falls back to Application
+Support. Each write encodes one complete JSON value on one line, appends it, and
+synchronizes the file. Normal writes never load and rewrite the existing log.
+
+The debug export is different by design: it loads the relevant JSONL entries and
+creates a documented, pretty-printed JSON object with the reconstructed
+conversation, chronological source events, chronological trace events, and `jq`
+examples. This keeps the live format cheap to append while making exported data
+easy for humans and analysis tools to inspect partially.
+
+## Log and export shape
+
+Every JSONL entry has `schemaVersion`, `id`, `timestamp`, and `kind`; timestamps
+use ISO-8601 UTC with fractional seconds so rapid mutations remain ordered.
+Conversation entries additionally identify `conversationID` when the event is
+conversation-scoped. Their kinds are `conversation.created`, `nodes.appended`,
+`node.body_updated`, conversation metadata mutations, and tag mutations. The
+event-specific value is stored under the matching field such as `conversation`,
+`nodes`, `body`, `model`, `flag`, `title`, `tag`, or `tagIDs`.
+
+Trace kinds are `provider.request`, `provider.response`, `tool.invocation`,
+`web.visit`, and `error`. Their detailed values are under `providerRequest`,
+`providerResponse`, `toolInvocation`, `webVisit`, or `message`. Provider request
+entries include the exact replay messages and tool schemas; sandbox trace output
+is not shortened for presentation.
+
+An exported JSON object has this stable top-level shape:
+
+```text
+format, schemaVersion, generatedAt, documentation,
+conversation, tags, conversationEvents, traceEvents
+```
+
+Useful partial reads include:
+
+```sh
+jq '.conversation.summary' export.json
+jq '.conversation.nodes[] | {sequence, role, title, body}' export.json
+jq '.traceEvents[] | select(.kind == "tool.invocation") | .toolInvocation' export.json
+```
+
+This is an iCloud file-container prototype, not a multi-writer sync system.
+Concurrent appends from multiple devices and log compaction remain future work.
 
 Practical implications for this prototype:
 
-- Keep SQLite in rollback-journal mode, not WAL, so the database is not split
-  across multiple live files.
-- Use short transactions and `BEGIN IMMEDIATE` so local writes are serialized.
-- Treat concurrent edits from multiple devices as a future CloudKit migration
-  problem, not something this file-sync prototype fully solves.
-- Keep the node schema independent of SQLite details so the persistence layer can
-  move to CloudKit-backed storage later without changing the agent loop.
+- Keep every JSONL entry independently decodable and versioned.
+- Ignore and discard only an incomplete final line, which can be left by process
+  termination; corruption in a completed line is an error.
+- Treat concurrent edits from multiple devices as a future storage problem, not
+  something this prototype fully solves.
+- Keep the node model independent of the log replay details so persistence can
+  change later without changing the agent loop.
 
 ## Agent files
 

--- a/scripts/vet-apple-agent-integration.sh
+++ b/scripts/vet-apple-agent-integration.sh
@@ -122,7 +122,8 @@ require_match 'OPENAI_API_KEY' docs/apple-agent-config.md
 require_match 'OPENAI_MODEL' docs/apple-agent-config.md
 require_match 'HERM_MAX_AGENT_DEPTH' docs/apple-agent-config.md
 require_match 'main agent may summon sub-agents' docs/apple-agent-config.md
-require_match 'invalidValue\("OPENAI_BASE_URL"\)' app/apple/herm/Services/Agent/CPSLAgentConfig.swift
+require_match 'validatedBaseURL\(baseURLValue, key: "OPENAI_BASE_URL"\)' app/apple/herm/Services/Agent/CPSLAgentConfig.swift
+require_match 'throw CPSLAgentConfigError\.invalidValue\(key\)' app/apple/herm/Services/Agent/CPSLAgentConfig.swift
 require_match 'make\(' app/apple/herm/Services/Agent/CPSLAgentConfig.swift
 require_match 'parseEnv' scripts/generate-apple-env-constants.swift
 require_match '\["http", "https"\]\.contains\(scheme\)' app/apple/herm/Services/Agent/CPSLAgentConfig.swift
@@ -143,7 +144,7 @@ require_match 'CODE_SIGN_ENTITLEMENTS = herm/herm.entitlements;' app/apple/herm.
 require_match 'CODE_SIGN_ENTITLEMENTS\[sdk=macosx\*\].*herm-macOS.entitlements' app/apple/herm.xcodeproj/project.pbxproj
 require_match 'ENABLE_USER_SELECTED_FILES = readwrite;' app/apple/herm.xcodeproj/project.pbxproj
 reject_match 'ENABLE_USER_SELECTED_FILES = readonly;' app/apple/herm.xcodeproj/project.pbxproj
-require_match 'libsqlite3.tbd' app/apple/herm.xcodeproj/project.pbxproj
+reject_match 'libsqlite3.tbd' app/apple/herm.xcodeproj/project.pbxproj
 require_match 'PBXFileSystemSynchronizedBuildFileExceptionSet' app/apple/herm.xcodeproj/project.pbxproj
 require_match '^[[:space:]]*\.env,' app/apple/herm.xcodeproj/project.pbxproj
 require_match '^[[:space:]]*\.env\.local,' app/apple/herm.xcodeproj/project.pbxproj
@@ -161,20 +162,17 @@ require_match 'allow_webview_pdf_rendering\(webview_pdf_rendering_allowed\(confi
 require_match 'restricted_network_policy_returns_structured_webview_pdf_denials' external/cpsl/ffi/src/lib.rs
 require_match 'webview_pdf_rendering_requires_unrestricted_webbrowser_policy' external/cpsl/ffi/src/lib.rs
 require_match 'iCloud file-container prototype' docs/apple-agent-storage.md
-require_match 'not Apple.s standard robust' docs/apple-agent-storage.md
-require_match 'CloudKit-backed persistence' docs/apple-agent-storage.md
+require_match 'append-only JSONL files' docs/apple-agent-storage.md
+require_match 'debug export' docs/apple-agent-storage.md
 
 require_match 'url\(forUbiquityContainerIdentifier: nil\)' app/apple/herm/Services/Agent/CPSLConversationStore.swift
-require_match 'PRAGMA journal_mode=DELETE' app/apple/herm/Services/Agent/CPSLConversationStore.swift
-require_match 'PRAGMA synchronous=FULL' app/apple/herm/Services/Agent/CPSLConversationStore.swift
-require_match 'BEGIN IMMEDIATE TRANSACTION' app/apple/herm/Services/Agent/CPSLConversationStore.swift
-require_match 'sqlite3_busy_timeout' app/apple/herm/Services/Agent/CPSLConversationStore.swift
-require_match 'init\(databaseURL: URL, usesICloudContainer: Bool\)' app/apple/herm/Services/Agent/CPSLConversationStore.swift
-require_match 'addColumnIfMissing' app/apple/herm/Services/Agent/CPSLConversationStore.swift
-require_match 'PRAGMA table_info' app/apple/herm/Services/Agent/CPSLConversationStore.swift
-require_match 'ALTER TABLE' app/apple/herm/Services/Agent/CPSLConversationStore.swift
-require_match 'backfillLegacyConversationPointers' app/apple/herm/Services/Agent/CPSLConversationStore.swift
-require_match 'legacy conversation pointers did not backfill' scripts/vet-apple-conversation-store.swift
+require_match 'conversations\.jsonl' app/apple/herm/Services/Agent/CPSLConversationStore.swift
+require_match 'traces\.jsonl' app/apple/herm/Services/Agent/CPSLConversationStore.swift
+require_match 'appendJSONLine' app/apple/herm/Services/Agent/CPSLConversationStore.swift
+require_match 'handle\.seekToEnd\(\)' app/apple/herm/Services/Agent/CPSLConversationStore.swift
+require_match 'handle\.synchronize\(\)' app/apple/herm/Services/Agent/CPSLConversationStore.swift
+require_match 'partial tail' app/apple/herm/Services/Agent/CPSLConversationStore.swift
+require_match 'init\(logURL: URL, usesICloudContainer: Bool\)' app/apple/herm/Services/Agent/CPSLConversationStore.swift
 require_match 'model: String\?' app/apple/herm/Services/Agent/CPSLConversationStore.swift
 require_match 'updateConversationModelIfMissing' app/apple/herm/Services/Agent/CPSLConversationStore.swift
 require_match 'updateConversationModelIfMissing' app/apple/herm/Models/CPSLChatModel.swift
@@ -186,14 +184,14 @@ require_match 'private func loadStore\(\) async throws -> CPSLConversationStore'
 require_match 'let store = try await loadStore\(\)' app/apple/herm/Models/CPSLChatModel.swift
 require_match 'store = try await loadStore\(\)' app/apple/herm/Models/CPSLChatModel.swift
 reject_match 'guard let store else' app/apple/herm/Models/CPSLChatModel.swift
-require_match 'conversations = try await store\.loadSummaries\(\)' app/apple/herm/Models/CPSLChatModel.swift
-require_match 'sequence = try nextSequence' app/apple/herm/Services/Agent/CPSLConversationStore.swift
+require_match 'conversations = try await store\.fetchConversationSummaries' app/apple/herm/Models/CPSLChatModel.swift
+require_match 'nextSequence' app/apple/herm/Services/Agent/CPSLConversationStore.swift
 require_match 'parentRequired' app/apple/herm/Services/Agent/CPSLConversationStore.swift
 require_match 'parentRequired' scripts/vet-apple-conversation-store.swift
-require_match 'assertParentBelongsToConversation' app/apple/herm/Services/Agent/CPSLConversationStore.swift
+require_match 'conversation\.nodes\.contains' app/apple/herm/Services/Agent/CPSLConversationStore.swift
 require_match 'parentConversationMismatch' scripts/vet-apple-conversation-store.swift
-require_match 'CREATE UNIQUE INDEX IF NOT EXISTS idx_nodes_conversation_sequence_unique' app/apple/herm/Services/Agent/CPSLConversationStore.swift
-require_match 'CREATE INDEX IF NOT EXISTS idx_nodes_parent' app/apple/herm/Services/Agent/CPSLConversationStore.swift
+require_match 'recordProviderRequest' app/apple/herm/Services/Agent/CPSLConversationStore.swift
+require_match 'recordToolInvocation' app/apple/herm/Services/Agent/CPSLConversationStore.swift
 
 require_match 'maxToolRounds: positiveIntValue' app/apple/herm/Services/Agent/CPSLAgentConfig.swift
 require_match 'defaultMaxToolRounds = 200' app/apple/herm/Services/Agent/CPSLAgentConfig.swift
@@ -214,7 +212,7 @@ require_match 'fs\.help\(\)' app/apple/herm/Services/Agent/CPSLOpenAIProtocol.sw
 require_match 'Declare variables with local' app/apple/herm/Services/Agent/CPSLOpenAIProtocol.swift
 require_match 'external lua/luau interpreters' app/apple/herm/Services/Agent/CPSLOpenAIProtocol.swift
 require_match 'Bash, Python, shell commands' app/apple/herm/Services/Agent/CPSLOpenAIProtocol.swift
-require_match 'fs\.help\(\)' app/apple/herm/Models/CPSLChatModel.swift
+require_match 'module\.help\(\)' app/apple/herm/Models/CPSLChatModel.swift
 require_match 'CPSL is your execution environment: a Unix-like local environment' app/apple/herm/Models/CPSLChatModel.swift
 require_match 'Luau is the interface instead of Bash' app/apple/herm/Models/CPSLChatModel.swift
 require_match 'Luau essentials' app/apple/herm/Models/CPSLChatModel.swift
@@ -292,8 +290,6 @@ require_match '"skills"' app/apple/herm/Services/CPSLDebugService.swift
 require_match '"virtual": mount.virtualPath' app/apple/herm/Services/CPSLDebugService.swift
 require_match '"mode": "ro"' app/apple/herm/Services/CPSLDebugService.swift
 require_match 'Copy Bundled Skills' app/apple/herm.xcodeproj/project.pbxproj
-reject_match 'alwaysOutOfDate = 1;' app/apple/herm.xcodeproj/project.pbxproj
-require_match 'Skills,' app/apple/herm.xcodeproj/project.pbxproj
 require_match 'SRCROOT.*/herm/Skills' app/apple/herm.xcodeproj/project.pbxproj
 require_match 'UNLOCALIZED_RESOURCES_FOLDER_PATH.*/Skills' app/apple/herm.xcodeproj/project.pbxproj
 require_match 'cp -R.*src.*dst' app/apple/herm.xcodeproj/project.pbxproj
@@ -305,7 +301,7 @@ require_match 'let callbackBox = CPSLWebBrowserCallbackBox\(service: webBrowser\
   app/apple/herm/Services/CPSLDebugService.swift
 require_match 'let allowedDomains = \["\*"\]' app/apple/herm/Services/CPSLDebugService.swift
 require_match 'do not use require to load them' app/apple/herm/Models/CPSLChatModel.swift
-require_match 'help\(\) is the authoritative module list' app/apple/herm/Skills/webbrowser/SKILL.md
+require_match 'help\(\).*authoritative module list' app/apple/herm/Skills/webbrowser/SKILL.md
 require_match 'Treat CPSL as its own Luau ecosystem' app/apple/herm/Models/CPSLChatModel.swift
 require_match 'APIs from other Lua/Luau environments' app/apple/herm/Models/CPSLChatModel.swift
 require_match 'do not assign help output to a variable' app/apple/herm/Models/CPSLChatModel.swift
@@ -414,7 +410,7 @@ require_match 'title: "Temporary"' app/apple/herm/Views/Files/CPSLFileBrowserVie
 require_match 'title: "iCloud"' app/apple/herm/Views/Files/CPSLFileBrowserView.swift
 require_match 'systemName: "icloud\.fill"' app/apple/herm/Views/Files/CPSLFileBrowserView.swift
 require_match 'title: "Cloud Drives"' app/apple/herm/Views/Files/CPSLFileBrowserView.swift
-require_match 'Button\("Connect"' app/apple/herm/Views/Files/CPSLFileBrowserView.swift
+require_match 'actionTitle: "Connect"' app/apple/herm/Views/Files/CPSLFileBrowserView.swift
 require_match 'model\.dictation\.finish\(\)' app/apple/herm/Views/Files/CPSLFileBrowserView.swift
 require_match 'guard isICloudImporterPending, !model\.dictation\.isActive else' app/apple/herm/Views/Files/CPSLFileBrowserView.swift
 require_match 'Button\("Read Only"\)' app/apple/herm/Views/Files/CPSLFileBrowserView.swift
@@ -550,9 +546,9 @@ if command -v swiftc >/dev/null 2>&1; then
     swiftc \
       app/apple/herm/Services/Agent/CPSLOpenAIProtocol.swift \
       app/apple/herm/Models/CPSLTypes.swift \
+      app/apple/herm/Services/Agent/CPSLAgentToolFormatting.swift \
       app/apple/herm/Services/Agent/CPSLConversationStore.swift \
       scripts/vet-apple-conversation-store.swift \
-      -lsqlite3 \
       -o /tmp/herm-vet-conversation-store
     /tmp/herm-vet-conversation-store
   fi

--- a/scripts/vet-apple-agent-integration.sh
+++ b/scripts/vet-apple-agent-integration.sh
@@ -347,9 +347,10 @@ require_match 'Provider returned an empty response' app/apple/herm/Models/CPSLCh
 require_match 'Reached maximum tool rounds' app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
 require_match 'synthesizeAfterToolLimit' app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
 require_match 'role: \.toolStatus' app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
-require_match 'hasUnresolvedToolFailure' app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
-require_match 'toolStatus\.state = hasUnresolvedToolFailure \? \.running : \.succeeded' app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
-reject_match 'toolStatusHasFailure' app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
+require_match 'pendingFailures' app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
+require_match 'supersedeActiveToolStatus' app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
+require_match 'finishActiveToolStatus\(as: \.failed\)' app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
+require_match 'as: \.interrupted' app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
 require_match 'role: \.hidden' app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
 require_match 'runSubAgent' app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
 require_match 'makeConversationJSONTraceShareFile' app/apple/herm/Models/CPSLChatModel.swift
@@ -371,6 +372,12 @@ require_match 'CPSLAgentWorkingIndicatorView' app/apple/herm/Views/Chat/CPSLChat
 require_match 'CPSLAgentWorkingIndicatorView\(\)' app/apple/herm/Views/Chat/CPSLChatTimelineView.swift
 require_match 'Text\(payload\.summary\)' app/apple/herm/Views/Chat/CPSLChatTimelineView.swift
 require_match 'TimelineView\(\.animation\)' app/apple/herm/Views/Chat/CPSLChatTimelineView.swift
+require_match 'CPSLActivityDisplayItem\.items' app/apple/herm/Views/Chat/CPSLChatTimelineView.swift
+require_match 'expandedEntryIDs: expansion\.expandedEntryIDs' app/apple/herm/Views/Chat/CPSLChatTimelineView.swift
+require_match '#if DEBUG' app/apple/herm/Views/Chat/CPSLChatTimelineView.swift
+require_match '\.allowsHitTesting\(canExpand\)' app/apple/herm/Views/Chat/CPSLChatTimelineView.swift
+require_match 'CPSLHeightLimitedExpandedBlock' app/apple/herm/Views/Chat/CPSLChatTimelineView.swift
+reject_match '\.disabled\(!canExpand\)' app/apple/herm/Views/Chat/CPSLChatTimelineView.swift
 require_match 'cycleDuration: TimeInterval = 0\.84' app/apple/herm/Views/Chat/CPSLChatTimelineView.swift
 require_match 'dotBounceOffset' app/apple/herm/Views/Chat/CPSLChatTimelineView.swift
 reject_match 'return trimmed\.isEmpty \? "Thinking" : trimmed' app/apple/herm/Views/Chat/CPSLChatTimelineView.swift

--- a/scripts/vet-apple-conversation-store.swift
+++ b/scripts/vet-apple-conversation-store.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SQLite3
 
 @main
 private struct CPSLConversationStoreChecks {
@@ -8,242 +7,111 @@ private struct CPSLConversationStoreChecks {
         let directory = fileManager.temporaryDirectory
             .appendingPathComponent("herm-store-vet-\(UUID().uuidString)", isDirectory: true)
         try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
-        defer {
-            try? fileManager.removeItem(at: directory)
-        }
+        defer { try? fileManager.removeItem(at: directory) }
 
-        let store = try CPSLConversationStore(
-            databaseURL: directory.appendingPathComponent("conversations.sqlite"),
-            usesICloudContainer: false
-        )
-
+        let logURL = directory.appendingPathComponent("conversations.jsonl")
+        let store = try CPSLConversationStore(logURL: logURL, usesICloudContainer: false)
         let created = try await store.createConversation(
             userText: "Run a sandbox check",
             model: "test-model",
             systemPrompt: "test system prompt"
         )
+        let sizeAfterCreate = try Data(contentsOf: logURL).count
 
-        let toolCall = CPSLOpenAIToolCall(
-            id: "call_1",
-            type: "function",
-            function: CPSLOpenAIFunctionCall(
-                name: "local_sandbox_exec",
-                arguments: #"{"source":"print(\"ok\")"}"#
-            )
-        )
-        let assistantToolMessage = CPSLOpenAIMessage.assistant(
-            content: nil,
-            toolCalls: [toolCall]
-        )
-        let commandNode = try await store.appendNode(
+        let assistantNode = try await store.appendNode(
             conversationID: created.summary.id,
             parentID: created.userNode.id,
-            role: .command,
-            title: "local_sandbox_exec",
-            body: "local_sandbox_exec\n\nprint(\"ok\")",
-            model: "test-model",
-            providerMessage: assistantToolMessage
+            draft: CPSLNodeAppendDraft(
+                role: .assistant,
+                title: nil,
+                body: "ok",
+                model: "test-model",
+                providerMessage: .assistant("ok")
+            )
         )
+        guard try Data(contentsOf: logURL).count > sizeAfterCreate else {
+            throw CheckFailure("conversation mutation did not append to JSONL")
+        }
 
-        let toolMessage = CPSLOpenAIMessage.tool(
-            id: toolCall.id,
-            content: #"{"ok":true,"stdout":"ok\n","stderr":""}"#
-        )
-        let outputNode = try await store.appendNode(
-            conversationID: created.summary.id,
-            parentID: commandNode.id,
-            role: .output,
-            title: "local_sandbox_exec",
-            body: "ok",
-            model: "test-model",
-            providerMessage: toolMessage
-        )
-
-        let summaries = try await store.loadSummaries()
+        let summaries = try await store.fetchConversationSummaries(archiveScope: .active, tagIDs: [])
         guard summaries.count == 1,
-              summaries[0].id == created.summary.id,
-              summaries[0].currentNodeID == outputNode.id,
+              summaries[0].currentNodeID == assistantNode.id,
               summaries[0].model == "test-model"
         else {
-            throw CheckFailure("conversation summary did not track the current node")
+            throw CheckFailure("conversation summary did not replay the current node")
         }
 
-        guard let loaded = try await store.loadConversation(id: created.summary.id) else {
-            throw CheckFailure("created conversation could not be loaded")
-        }
-        guard loaded.systemPrompt == "test system prompt" else {
-            throw CheckFailure("stored system prompt did not round-trip")
-        }
-        guard loaded.nodes.map(\.sequence) == [0, 1, 2],
-              loaded.nodes.map(\.id) == [created.userNode.id, commandNode.id, outputNode.id],
-              loaded.nodes[1].parentID == created.userNode.id,
-              loaded.nodes[2].parentID == commandNode.id
+        guard let loaded = try await store.loadConversation(id: created.summary.id),
+              loaded.systemPrompt == "test system prompt",
+              loaded.nodes.map(\.sequence) == [0, 1],
+              loaded.nodes[1].parentID == created.userNode.id
         else {
-            throw CheckFailure("node order or parent chain was not preserved")
+            throw CheckFailure("conversation JSONL did not replay")
         }
 
         let providerMessages = try await store.providerMessages(conversationID: created.summary.id)
         guard providerMessages == [
             CPSLOpenAIMessage.user("Run a sandbox check"),
-            assistantToolMessage,
-            toolMessage
+            CPSLOpenAIMessage.assistant("ok"),
         ] else {
-            throw CheckFailure("provider message replay did not round-trip")
+            throw CheckFailure("provider messages did not round-trip")
         }
 
-        let second = try await store.createConversation(
-            userText: "Independent chain",
-            model: nil,
-            systemPrompt: "test system prompt"
+        try await store.recordToolInvocation(
+            conversationID: created.summary.id,
+            nodeID: assistantNode.id,
+            invocation: CPSLToolTraceInvocation(
+                id: "call-1",
+                name: "test",
+                summary: "Testing",
+                input: "input",
+                output: "output",
+                isError: false
+            )
         )
-        guard second.userNode.model == nil else {
-            throw CheckFailure("pre-config user node should allow missing provider model")
-        }
-        try await store.updateConversationModelIfMissing(
-            conversationID: second.summary.id,
-            model: "test-model"
-        )
-        let secondSummaries = try await store.loadSummaries()
-        guard secondSummaries.first(where: { $0.id == second.summary.id })?.model == "test-model" else {
-            throw CheckFailure("conversation model was not backfilled after config load")
-        }
-        let secondNode = try await store.appendNode(
-            conversationID: second.summary.id,
-            parentID: second.userNode.id,
-            role: .assistant,
-            title: nil,
-            body: "ok",
-            model: "test-model",
-            providerMessage: .assistant("ok")
-        )
-        guard secondNode.sequence == 1 else {
-            throw CheckFailure("node sequence should be scoped to each conversation")
+        let traceLogURL = await store.traceLogURL
+        guard try Data(contentsOf: traceLogURL).contains(0x0A) else {
+            throw CheckFailure("trace did not append to JSONL")
         }
 
         do {
             _ = try await store.appendNode(
-                conversationID: second.summary.id,
+                conversationID: created.summary.id,
                 parentID: nil,
-                role: .assistant,
-                title: nil,
-                body: "orphan",
-                model: "test-model",
-                providerMessage: .assistant("orphan")
+                draft: CPSLNodeAppendDraft(
+                    role: .assistant,
+                    title: nil,
+                    body: "orphan",
+                    model: "test-model",
+                    providerMessage: .assistant("orphan")
+                )
             )
             throw CheckFailure("nil-parent append node was accepted")
         } catch CPSLConversationStoreError.parentRequired {
         }
 
+        let other = try await store.createConversation(
+            userText: "Other",
+            model: nil,
+            systemPrompt: ""
+        )
         do {
             _ = try await store.appendNode(
-                conversationID: second.summary.id,
-                parentID: commandNode.id,
-                role: .assistant,
-                title: nil,
-                body: "cross-chain parent",
-                model: "test-model",
-                providerMessage: .assistant("cross-chain parent")
+                conversationID: other.summary.id,
+                parentID: assistantNode.id,
+                draft: CPSLNodeAppendDraft(
+                    role: .assistant,
+                    title: nil,
+                    body: "cross-chain",
+                    model: nil,
+                    providerMessage: .assistant("cross-chain")
+                )
             )
             throw CheckFailure("cross-conversation parent node was accepted")
         } catch CPSLConversationStoreError.parentConversationMismatch {
         }
 
-        try await assertLegacySchemaMigrates(in: directory)
-    }
-
-    private static func assertLegacySchemaMigrates(in directory: URL) async throws {
-        let databaseURL = directory.appendingPathComponent("legacy.sqlite")
-        var database: OpaquePointer?
-        guard sqlite3_open(databaseURL.path, &database) == SQLITE_OK else {
-            throw CheckFailure("could not create legacy database")
-        }
-        for sql in [
-            """
-            CREATE TABLE conversations (
-                id TEXT PRIMARY KEY,
-                title TEXT NOT NULL,
-                created_at REAL NOT NULL,
-                updated_at REAL NOT NULL
-            )
-            """,
-            """
-            CREATE TABLE nodes (
-                id TEXT PRIMARY KEY,
-                conversation_id TEXT NOT NULL,
-                parent_id TEXT,
-                role TEXT NOT NULL,
-                body TEXT NOT NULL,
-                sequence INTEGER NOT NULL,
-                created_at REAL NOT NULL
-            )
-            """,
-            """
-            INSERT INTO conversations (id, title, created_at, updated_at)
-            VALUES ('legacy-conversation', 'Legacy conversation', 100.0, 102.0)
-            """,
-            """
-            INSERT INTO nodes (id, conversation_id, parent_id, role, body, sequence, created_at)
-            VALUES ('legacy-root', 'legacy-conversation', NULL, 'user', 'old user text', 0, 100.0)
-            """,
-            """
-            INSERT INTO nodes (id, conversation_id, parent_id, role, body, sequence, created_at)
-            VALUES ('legacy-current', 'legacy-conversation', 'legacy-root', 'assistant', 'old assistant text', 1, 101.0)
-            """
-        ] {
-            guard sqlite3_exec(database, sql, nil, nil, nil) == SQLITE_OK else {
-                sqlite3_close(database)
-                throw CheckFailure("could not create legacy schema")
-            }
-        }
-        sqlite3_close(database)
-
-        let store = try CPSLConversationStore(databaseURL: databaseURL, usesICloudContainer: false)
-        guard let loaded = try await store.loadConversation(id: "legacy-conversation"),
-              loaded.summary.currentNodeID == "legacy-current",
-              loaded.systemPrompt == "",
-              loaded.nodes.map(\.id) == ["legacy-root", "legacy-current"],
-              loaded.nodes[1].parentID == "legacy-root"
-        else {
-            throw CheckFailure("legacy conversation pointers did not backfill")
-        }
-
-        let columns = try sqliteColumns(databaseURL: databaseURL)
-        guard columns["conversations"]?.contains("model") == true,
-              columns["conversations"]?.contains("system_prompt") == true,
-              columns["nodes"]?.contains("provider_message_json") == true,
-              columns["nodes"]?.contains("title") == true
-        else {
-            throw CheckFailure("legacy schema did not migrate expected columns")
-        }
-    }
-
-    private static func sqliteColumns(databaseURL: URL) throws -> [String: Set<String>] {
-        var database: OpaquePointer?
-        guard sqlite3_open(databaseURL.path, &database) == SQLITE_OK else {
-            throw CheckFailure("could not reopen migrated database")
-        }
-        defer {
-            sqlite3_close(database)
-        }
-
-        var result: [String: Set<String>] = [:]
-        for table in ["conversations", "nodes"] {
-            var statement: OpaquePointer?
-            guard sqlite3_prepare_v2(database, "PRAGMA table_info(\"\(table)\")", -1, &statement, nil) == SQLITE_OK else {
-                throw CheckFailure("could not inspect migrated table")
-            }
-            defer {
-                sqlite3_finalize(statement)
-            }
-            var columns = Set<String>()
-            while sqlite3_step(statement) == SQLITE_ROW {
-                if let name = sqlite3_column_text(statement, 1) {
-                    columns.insert(String(cString: name))
-                }
-            }
-            result[table] = columns
-        }
-        return result
+        _ = try CPSLConversationStore(logURL: logURL, usesICloudContainer: false)
     }
 }
 


### PR DESCRIPTION
## Summary
- improve agent pacing, context replay, browser reuse, and bounded live diagnostics while preserving complete exported traces
- group agent activity into full-width, foldable timeline rows and use task-specific intent for delegated work
- move expensive preview and diagnostic work off the main actor, narrow SwiftUI observation invalidation, and resolve concurrency warnings
- use native PDFKit views for correctly oriented, full-size PDF display on iOS and macOS
- bound hidden WebKit sessions associated with research runs
- restore the conversation drawer's morphing menu/back control and animated Herm title, with archive and new-conversation actions beside the back control

## Verification
- `git diff --check`
- `swiftc -frontend -parse` was run for the earlier Swift changes and new tests
- source audit confirmed the custom PDF bitmap transform and generic delegated-work strings were removed
- device/simulator verification was unavailable because DeviceInteraction tools were not exposed
- no Xcode build or test run was performed by Codex
