### PR TITLE
Fix stale website version after release tags

### DIFF
--- a/.github/scripts/deploy-pages.cjs
+++ b/.github/scripts/deploy-pages.cjs
@@ -1,0 +1,71 @@
+const failureStatuses = new Set([
+  'deployment_failed',
+  'deployment_perms_error',
+  'deployment_content_failed',
+  'deployment_cancelled',
+  'deployment_lost',
+])
+
+function pagesBuildVersion(context) {
+  // Main and tag pushes can share a commit but produce different artifacts.
+  // Pages requires a unique build version to deploy the second artifact.
+  return `${context.sha}-${context.runId}-${context.runAttempt}`
+}
+
+async function deployPages({ github, context, core }, options = {}) {
+  const artifactId = options.artifactId
+  if (!Number.isSafeInteger(artifactId) || artifactId <= 0) {
+    throw new Error(`Invalid github-pages artifact ID: ${artifactId}`)
+  }
+  const sleep = options.sleep || (ms => new Promise(resolve => setTimeout(resolve, ms)))
+  const pollInterval = options.pollInterval || 5000
+  const timeout = options.timeout || 10 * 60 * 1000
+  const { owner, repo } = context.repo
+  const buildVersion = pagesBuildVersion(context)
+
+  const deployment = await github.request(
+    'POST /repos/{owner}/{repo}/pages/deployments',
+    {
+      owner,
+      repo,
+      artifact_id: artifactId,
+      pages_build_version: buildVersion,
+      oidc_token: await core.getIDToken(),
+    },
+  )
+  core.setOutput('page_url', deployment.data.page_url)
+
+  const deploymentId = deployment.data.id || buildVersion
+  const deadline = Date.now() + timeout
+  let apiErrors = 0
+  while (Date.now() < deadline) {
+    await sleep(pollInterval)
+    let statusResponse
+    try {
+      statusResponse = await github.request(
+        'GET /repos/{owner}/{repo}/pages/deployments/{deploymentId}',
+        { owner, repo, deploymentId },
+      )
+      apiErrors = 0
+    } catch (error) {
+      apiErrors += 1
+      if (apiErrors >= 10) throw error
+      core.warning(`Unable to read Pages deployment status: ${error.message}`)
+      continue
+    }
+
+    const status = statusResponse.data.status
+    if (status === 'succeed') {
+      core.info(`Pages deployment ${buildVersion} succeeded`)
+      return
+    }
+    if (failureStatuses.has(status)) {
+      throw new Error(`Pages deployment failed with status: ${status}`)
+    }
+    core.info(`Pages deployment status: ${status}`)
+  }
+  throw new Error(`Pages deployment ${buildVersion} timed out`)
+}
+
+module.exports = deployPages
+module.exports.pagesBuildVersion = pagesBuildVersion

--- a/.github/scripts/deploy-pages.test.cjs
+++ b/.github/scripts/deploy-pages.test.cjs
@@ -1,0 +1,58 @@
+const assert = require('node:assert/strict')
+const test = require('node:test')
+const deployPages = require('./deploy-pages.cjs')
+
+function harness(contextOverrides = {}) {
+  const requests = []
+  const outputs = []
+  const context = {
+    repo: { owner: 'aduermael', repo: 'herm' },
+    sha: '8e94d354e1ecccbf297753b1fa5babc787aeb637',
+    runId: 100,
+    runAttempt: 1,
+    ...contextOverrides,
+  }
+  return {
+    context,
+    requests,
+    outputs,
+    github: {
+      request: async (route, parameters) => {
+        requests.push({ route, parameters })
+        if (route.startsWith('POST')) {
+          return { data: { id: parameters.pages_build_version, page_url: 'https://example.test' } }
+        }
+        return { data: { status: 'succeed' } }
+      },
+    },
+    core: {
+      getIDToken: async () => 'oidc-token',
+      setOutput: (name, value) => outputs.push({ name, value }),
+      info: () => {},
+      warning: () => {},
+    },
+  }
+}
+
+test('build version differs for main and tag runs of the same commit', () => {
+  const main = harness({ runId: 100 }).context
+  const tag = harness({ runId: 101 }).context
+
+  assert.notEqual(
+    deployPages.pagesBuildVersion(main),
+    deployPages.pagesBuildVersion(tag),
+  )
+})
+
+test('deploys the current run artifact with its unique build version', async () => {
+  const run = harness()
+
+  await deployPages(run, { artifactId: 42, sleep: async () => {} })
+
+  assert.equal(run.requests[0].parameters.artifact_id, 42)
+  assert.equal(
+    run.requests[0].parameters.pages_build_version,
+    '8e94d354e1ecccbf297753b1fa5babc787aeb637-100-1',
+  )
+  assert.deepEqual(run.outputs, [{ name: 'page_url', value: 'https://example.test' }])
+})

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -46,6 +46,15 @@ jobs:
       - run: cd tools/ci-check && go build -o "$RUNNER_TEMP/ci-check" .
       - run: '"$RUNNER_TEMP/ci-check" positional-params .'
 
+  pages-deployment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+      - run: node --test .github/scripts/deploy-pages.test.cjs
+
   cpsl-xcframework-placeholder:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -58,10 +58,18 @@ jobs:
           enablement: true
 
       - name: Upload artifact
+        id: upload
         uses: actions/upload-pages-artifact@v4
         with:
           path: docs
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/github-script@v9
+        env:
+          PAGES_ARTIFACT_ID: ${{ steps.upload.outputs.artifact_id }}
+        with:
+          script: |
+            const deployPages = require('./.github/scripts/deploy-pages.cjs')
+            const artifactId = Number(process.env.PAGES_ARTIFACT_ID)
+            await deployPages({ github, context, core }, { artifactId })


### PR DESCRIPTION
## Summary
- deploy the exact uploaded Pages artifact with a build version unique to each workflow run
- preserve status polling and failure reporting from the standard Pages deployment action
- add regression coverage for main and tag runs that point to the same commit
- run the Pages deployment tests in CI

## Root cause
This looked like a cache problem, but the old HTML was actually still deployed:

1. The main branch was pushed before the v0.8.7 tag existed, so the website workflow deployed v0.8.6.
2. The v0.8.7 tag was then created on the same commit.
3. The tag workflow correctly built a website artifact containing v0.8.7.
4. GitHub Pages identified both deployments using the same commit SHA, treated the tag deployment as already completed, and kept serving the first artifact.

This was therefore a deployment-ID collision, not a browser, Cloudflare, or normal CDN-cache issue. This PR gives every workflow run a unique deployment ID so the tag artifact is deployed even when it references the same commit as the preceding main push.

## Testing
- node --test .github/scripts/deploy-pages.test.cjs
- actionlint .github/workflows/pages.yml .github/workflows/ci-checks.yml
- git diff --check

The repository pre-commit hook also ran. Its Go test and prompt-length checks passed; the repository-wide Go and Swift vet checks failed on pre-existing violations in files untouched by this PR.