### PR TITLE
Polish Apple app: Stop control, Files info nav, media silent mode, overlay latency

### DIFF
--- a/app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
+++ b/app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
@@ -483,7 +483,12 @@ extension CPSLChatModel {
         let estimatedBytesPerTokenValue = estimatedBytesPerToken
         let toolResultClearThresholdValue = toolResultClearThreshold
         let recentToolResultsToKeepValue = recentToolResultsToKeep
-        return await Task.detached(priority: .userInitiated) {
+        // Detached work does not inherit cancellation; check before and after so Stop
+        // still aborts between provider turns promptly.
+        guard !Task.isCancelled else {
+            return []
+        }
+        let messages = await Task.detached(priority: .userInitiated) {
             CPSLAgentRequestPreparationBuilder.preparedRequestMessages(
                 preparation,
                 estimatedBytesPerToken: estimatedBytesPerTokenValue,
@@ -491,6 +496,7 @@ extension CPSLChatModel {
                 recentToolResultsToKeep: recentToolResultsToKeepValue
             )
         }.value
+        return Task.isCancelled ? [] : messages
     }
 
     private func appendProviderLoopError(
@@ -680,7 +686,7 @@ extension CPSLChatModel {
         messages[index] = persistedMessage
     }
 
-    private func discardStreamingAssistantIfNeeded() {
+    func discardStreamingAssistantIfNeeded() {
         guard let id = streamingAssistantMessageID else {
             return
         }
@@ -695,6 +701,9 @@ extension CPSLChatModel {
         _ toolCall: CPSLOpenAIToolCall,
         context: CPSLToolExecutionContext
     ) async -> CPSLToolExecutionResult {
+        if Task.isCancelled {
+            return cancelledToolExecutionResult(for: toolCall)
+        }
         if let requestDirectory = context.requestDirectory,
             let restoreError = await restoreCurrentDirectory(requestDirectory, for: toolCall) {
             return restoreError
@@ -720,6 +729,18 @@ extension CPSLChatModel {
                 )
             )
         }
+    }
+
+    private func cancelledToolExecutionResult(
+        for toolCall: CPSLOpenAIToolCall
+    ) -> CPSLToolExecutionResult {
+        let message = "Stopped."
+        return CPSLToolExecutionResult(
+            providerContent: providerToolContent(ok: false, output: nil, error: message),
+            displayBody: message,
+            isError: true,
+            traceInvocation: traceInvocation(for: toolCall, displayBody: message, isError: true)
+        )
     }
 
     private func restoreCurrentDirectory(
@@ -752,7 +773,13 @@ extension CPSLChatModel {
             )
         }
 
+        if Task.isCancelled {
+            return cancelledToolExecutionResult(for: toolCall)
+        }
         let result = await service.evaluateLuau(source)
+        if Task.isCancelled || result.errorCode == "cancelled" {
+            return cancelledToolExecutionResult(for: toolCall)
+        }
         let output = CPSLAgentToolOutput(
             stdout: result.stdout,
             stderr: result.stderr,
@@ -842,9 +869,11 @@ extension CPSLChatModel {
 
         do {
             for turn in 0..<maxTurns {
+                try Task.checkCancellation()
                 turnsUsed = turn + 1
                 let isFinalTurn = turn == maxTurns - 1
                 let sandboxDirectory = await service.currentDirectory()
+                try Task.checkCancellation()
                 let turnGuidance: String
                 if isFinalTurn {
                     turnGuidance = "Budget: turn \(turn + 1)/\(maxTurns). FINAL: return the best usable result now; no tools."
@@ -884,6 +913,7 @@ extension CPSLChatModel {
                     )
                 }
                 let completion = try await context.client.streamChat(request) { _ in }
+                try Task.checkCancellation()
                 if let traceStore = context.traceStore,
                    let conversationID = context.conversationID {
                     try await traceStore.recordProviderResponse(
@@ -932,6 +962,7 @@ extension CPSLChatModel {
                     )
                 )
                 for toolCall in completion.toolCalls {
+                    try Task.checkCancellation()
                     let toolResult = await executeToolCall(
                         toolCall,
                         context: CPSLToolExecutionContext(
@@ -943,6 +974,7 @@ extension CPSLChatModel {
                             conversationID: context.conversationID
                         )
                     )
+                    try Task.checkCancellation()
                     if let traceStore = context.traceStore,
                        let conversationID = context.conversationID {
                         try await traceStore.recordToolInvocation(
@@ -967,6 +999,18 @@ extension CPSLChatModel {
                     )
                 ),
                 false
+            )
+        } catch is CancellationError {
+            return (
+                subAgentOutput(
+                    CPSLSubAgentOutputDraft(
+                        mode: input.mode,
+                        turnsUsed: turnsUsed,
+                        maxTurns: maxTurns,
+                        textParts: textParts + ["Stopped."]
+                    )
+                ),
+                true
             )
         } catch {
             if let traceStore = context.traceStore,

--- a/app/apple/herm/Models/CPSLChatModel.swift
+++ b/app/apple/herm/Models/CPSLChatModel.swift
@@ -30,14 +30,19 @@ final class CPSLChatModel {
     private(set) var filePreview: CPSLFilePreview? {
         didSet {
             if filePreview == nil {
+                isFileInfoOpen = false
                 activeFileNavigationRequestID = nil
                 activeFilePreviewRequestID = nil
                 filePreviewLoadTask?.cancel()
                 filePreviewLoadTask = nil
                 retireFilePreviewLifetimeToken()
+            } else if oldValue?.path != filePreview?.path {
+                isFileInfoOpen = false
             }
         }
     }
+    /// File metadata pushed one level deeper in the Files route stack (not a popover/drawer).
+    private(set) var isFileInfoOpen = false
     private(set) var isWebBrowserOpen = false
     private(set) var isFileActivityActive = false
     private(set) var isCalendarOpen = false
@@ -442,11 +447,14 @@ final class CPSLChatModel {
         guard isRunning else {
             return
         }
+        // Cancel the run task first so nested awaits (provider streams, sub-agents,
+        // eval race) observe cooperative cancellation immediately.
         activeRunTask?.cancel()
         isSuppressingAssistantStream = true
         typewriterTask?.cancel()
         typewriterTask = nil
         typewriterBuffer = ""
+        discardStreamingAssistantIfNeeded()
     }
 
     func addAttachment(from url: URL) {
@@ -549,6 +557,7 @@ final class CPSLChatModel {
             isCalendarOpen = false
             isLocationOpen = false
             filePreview = nil
+            // Directory listing runs async on the debug-service actor; keep open snappy.
             loadBrowserPath(browserPath)
         } else {
             filePreview = nil
@@ -655,7 +664,7 @@ final class CPSLChatModel {
         isLocationOpen = false
         closeWebBrowser()
         isCalendarOpen = true
-        Task {
+        Task(priority: .userInitiated) {
             let access = await calendar.loadUpcomingEvents()
             if access == .denied {
                 comingSoonMessage = "Calendar access is denied. Enable Calendar access for Herm in iOS Settings or macOS System Settings."
@@ -678,8 +687,9 @@ final class CPSLChatModel {
         filePreview = nil
         isCalendarOpen = false
         closeWebBrowser()
+        // Open chrome immediately; location fetch/MapKit work must not gate presentation.
         isLocationOpen = true
-        Task {
+        Task(priority: .userInitiated) {
             let access = await location.loadCurrentLocation()
             if access == .denied {
                 comingSoonMessage = location.locationError
@@ -762,7 +772,19 @@ final class CPSLChatModel {
     }
 
     func closeFilePreview() {
+        isFileInfoOpen = false
         filePreview = nil
+    }
+
+    func openFileInfo() {
+        guard filePreview != nil else {
+            return
+        }
+        isFileInfoOpen = true
+    }
+
+    func closeFileInfo() {
+        isFileInfoOpen = false
     }
 
     func isFileReadOnly(_ path: String) -> Bool {

--- a/app/apple/herm/Services/Agent/CPSLOpenAIClient.swift
+++ b/app/apple/herm/Services/Agent/CPSLOpenAIClient.swift
@@ -32,16 +32,20 @@ actor CPSLOpenAIClient {
         request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
         request.setValue("Bearer \(config.token)", forHTTPHeaderField: "Authorization")
 
+        try Task.checkCancellation()
         let (bytes, response) = try await session.bytes(for: request)
+        try Task.checkCancellation()
         try await validate(response: response, bytes: bytes)
 
         let accumulator = CPSLOpenAIStreamAccumulator(model: config.model)
         for try await line in bytes.lines {
+            try Task.checkCancellation()
             guard let event = try accumulator.consume(line: line) else {
                 continue
             }
             await onEvent(event)
         }
+        try Task.checkCancellation()
         return try accumulator.validatedCompletion()
     }
 

--- a/app/apple/herm/Services/CPSLCalendarService.swift
+++ b/app/apple/herm/Services/CPSLCalendarService.swift
@@ -112,22 +112,13 @@ final class CPSLCalendarService: ObservableObject {
             isLoadingEvents = false
         }
 
-        let now = Date()
-        let endDate = Foundation.Calendar.current.date(byAdding: .day, value: 14, to: now)
-            ?? now.addingTimeInterval(14 * 24 * 60 * 60)
-        let predicate = eventStore.predicateForEvents(
-            withStart: now,
-            end: endDate,
-            calendars: nil
-        )
-        let events = eventStore.events(matching: predicate)
-            .sorted { lhs, rhs in
-                lhs.startDate < rhs.startDate
-            }
-            .prefix(12)
-            .map(Self.event(from:))
-        upcomingEvents = Self.eventsWithUniqueIDs(events)
-        upcomingEventDays = Self.groupedByDay(upcomingEvents)
+        // EventKit reads are thread-safe; keep the MainActor free while matching/sorting.
+        let store = CPSLSendableEventStore(eventStore)
+        let fetched = await Task.detached(priority: .userInitiated) {
+            Self.fetchUpcomingEvents(from: store.value)
+        }.value
+        upcomingEvents = fetched.events
+        upcomingEventDays = fetched.days
 #else
         upcomingEvents = []
         upcomingEventDays = []
@@ -137,7 +128,34 @@ final class CPSLCalendarService: ObservableObject {
     }
 
 #if canImport(EventKit)
-    private static func event(from event: EKEvent) -> CPSLCalendarEvent {
+    /// EventKit allows reading from background threads; box for Task.detached Sendable capture.
+    private nonisolated struct CPSLSendableEventStore: @unchecked Sendable {
+        let value: EKEventStore
+        init(_ value: EKEventStore) { self.value = value }
+    }
+
+    private nonisolated static func fetchUpcomingEvents(
+        from store: EKEventStore
+    ) -> (events: [CPSLCalendarEvent], days: [CPSLCalendarDay]) {
+        let now = Date()
+        let endDate = Foundation.Calendar.current.date(byAdding: .day, value: 14, to: now)
+            ?? now.addingTimeInterval(14 * 24 * 60 * 60)
+        let predicate = store.predicateForEvents(
+            withStart: now,
+            end: endDate,
+            calendars: nil
+        )
+        let events = store.events(matching: predicate)
+            .sorted { lhs, rhs in
+                lhs.startDate < rhs.startDate
+            }
+            .prefix(12)
+            .map(Self.event(from:))
+        let unique = Self.eventsWithUniqueIDs(Array(events))
+        return (unique, Self.groupedByDay(unique))
+    }
+
+    private nonisolated static func event(from event: EKEvent) -> CPSLCalendarEvent {
         let id = [
             event.eventIdentifier,
             event.calendarItemIdentifier,
@@ -162,8 +180,10 @@ final class CPSLCalendarService: ObservableObject {
             attachments: Self.attachments(from: event.notes)
         )
     }
+#endif
 
-    private static func eventsWithUniqueIDs(_ events: [CPSLCalendarEvent]) -> [CPSLCalendarEvent] {
+#if canImport(EventKit)
+    private nonisolated static func eventsWithUniqueIDs(_ events: [CPSLCalendarEvent]) -> [CPSLCalendarEvent] {
         var countsByID: [String: Int] = [:]
         return events.map { event in
             let count = countsByID[event.id, default: 0]
@@ -187,7 +207,7 @@ final class CPSLCalendarService: ObservableObject {
         }
     }
 
-    private static func groupedByDay(_ events: [CPSLCalendarEvent]) -> [CPSLCalendarDay] {
+    private nonisolated static func groupedByDay(_ events: [CPSLCalendarEvent]) -> [CPSLCalendarDay] {
         let calendar = Foundation.Calendar.autoupdatingCurrent
         var groups: [CPSLCalendarDay] = []
         for event in events {
@@ -202,7 +222,7 @@ final class CPSLCalendarService: ObservableObject {
         return groups
     }
 
-    private static func calendarColor(from calendar: EKCalendar?) -> CPSLCalendarColor? {
+    private nonisolated static func calendarColor(from calendar: EKCalendar?) -> CPSLCalendarColor? {
 #if canImport(CoreGraphics)
         guard let sourceColor = calendar?.cgColor,
               let colorSpace = CGColorSpace(name: CGColorSpace.sRGB),
@@ -228,7 +248,7 @@ final class CPSLCalendarService: ObservableObject {
 #endif
     }
 
-    private static func visibleNotes(from notes: String?) -> String? {
+    private nonisolated static func visibleNotes(from notes: String?) -> String? {
         guard var notes else {
             return nil
         }
@@ -242,7 +262,7 @@ final class CPSLCalendarService: ObservableObject {
         return notes.trimmingCharacters(in: .whitespacesAndNewlines).cpslNilIfEmpty
     }
 
-    private static func attachments(from notes: String?) -> [CPSLCalendarAttachment] {
+    private nonisolated static func attachments(from notes: String?) -> [CPSLCalendarAttachment] {
         let attachmentRoot = "/home/herm/calendar-attachments/"
         guard let notes,
               let startRange = notes.range(of: "[Herm attachments]"),

--- a/app/apple/herm/Services/CPSLDebugService.swift
+++ b/app/apple/herm/Services/CPSLDebugService.swift
@@ -1257,6 +1257,9 @@ actor CPSLDebugService {
     }
 
     private func evaluate(_ input: String, language: String) async -> CPSLEvalServiceResult {
+        if Task.isCancelled {
+            return Self.cancellationFailure()
+        }
         let mountUseLease: CPSLICloudMountUseLease
         do {
             let manager = try ensureICloudMountManager()
@@ -1265,6 +1268,8 @@ actor CPSLDebugService {
             }
             mountUseLease = lease
             try await manager.materializeMountsForAccess()
+        } catch is CancellationError {
+            return Self.cancellationFailure()
         } catch {
             return Self.ffiFailure("Workspace setup failed: \(error.localizedDescription)")
         }
@@ -1276,8 +1281,13 @@ actor CPSLDebugService {
             sandboxURLs = try ensureSandboxURLs()
             self.sandboxURLs = sandboxURLs
             await webBrowser.setSandboxRoot(sandboxURLs.root)
+        } catch is CancellationError {
+            return Self.cancellationFailure()
         } catch {
             return Self.ffiFailure("Workspace setup failed: \(error.localizedDescription)")
+        }
+        if Task.isCancelled {
+            return Self.cancellationFailure()
         }
 
         if let sessionError = await initializeSessionIfNeeded(

--- a/app/apple/herm/Services/CPSLLocationService.swift
+++ b/app/apple/herm/Services/CPSLLocationService.swift
@@ -77,6 +77,13 @@ final class CPSLLocationService: NSObject, ObservableObject {
     }
 
     func loadCurrentLocation() async -> CPSLFeatureAccessState {
+        // Keep UI responsive: show loading first, then hop for any blocking CoreLocation checks.
+        isLoadingCurrentLocation = true
+        locationError = nil
+        defer {
+            isLoadingCurrentLocation = false
+        }
+
         let requestedAccess = await requestAccess()
         guard requestedAccess == .granted else {
             currentLocation = nil
@@ -85,12 +92,6 @@ final class CPSLLocationService: NSObject, ObservableObject {
         }
 
 #if canImport(CoreLocation)
-        isLoadingCurrentLocation = true
-        locationError = nil
-        defer {
-            isLoadingCurrentLocation = false
-        }
-
         guard await Self.locationServicesEnabled() else {
             currentLocation = nil
             locationError = "Location Services are disabled; enable them in iOS Settings or macOS System Settings."
@@ -98,6 +99,8 @@ final class CPSLLocationService: NSObject, ObservableObject {
         }
 
         startUpdatingIfAllowed()
+        // Yield so the location overlay can paint its chrome before we wait on a fix.
+        await Task.yield()
         let location = await freshestLocation()
         guard let location else {
             locationError = "Current location is not available yet."

--- a/app/apple/herm/Views/Composer/CPSLPromptComposerView.swift
+++ b/app/apple/herm/Views/Composer/CPSLPromptComposerView.swift
@@ -459,11 +459,12 @@ struct CPSLPromptComposerView: View {
                     .contentShape(RoundedRectangle(cornerRadius: CPSLTheme.controlRadius, style: .continuous))
             }
             .buttonStyle(.plain)
-            .foregroundStyle(CPSLTheme.background)
-            .background(CPSLTheme.error)
+            .foregroundStyle(CPSLTheme.text)
+            .background(CPSLTheme.danger)
             .clipShape(RoundedRectangle(cornerRadius: CPSLTheme.controlRadius, style: .continuous))
             .contentShape(RoundedRectangle(cornerRadius: CPSLTheme.controlRadius, style: .continuous))
             .accessibilityLabel("Stop")
+            .accessibilityAddTraits(.isButton)
         } else if canSubmit {
             Button {
                 dismissKeyboard()

--- a/app/apple/herm/Views/Files/CPSLFileBrowserView.swift
+++ b/app/apple/herm/Views/Files/CPSLFileBrowserView.swift
@@ -114,6 +114,7 @@ private enum CPSLFileBrowserRow: Identifiable, Equatable {
 private enum CPSLFileBrowserRoute: Identifiable, Equatable {
     case folder(CPSLFileBrowserFolderSnapshot)
     case preview(CPSLFilePreview)
+    case fileInfo(CPSLFilePreview)
 
     var id: String {
         switch self {
@@ -121,6 +122,8 @@ private enum CPSLFileBrowserRoute: Identifiable, Equatable {
             return "folder:\(snapshot.path)"
         case .preview(let preview):
             return "preview:\(preview.id)"
+        case .fileInfo(let preview):
+            return "fileinfo:\(preview.id)"
         }
     }
 
@@ -131,11 +134,11 @@ private enum CPSLFileBrowserRoute: Identifiable, Equatable {
         switch (source, target) {
         case (.folder(let source), .folder(let target)):
             return folderDirection(from: source.path, to: target.path)
-        case (.folder, .preview):
+        case (.folder, .preview), (.folder, .fileInfo), (.preview, .fileInfo):
             return .forward
-        case (.preview, .folder):
+        case (.preview, .folder), (.fileInfo, .folder), (.fileInfo, .preview):
             return .backward
-        case (.preview, .preview):
+        case (.preview, .preview), (.fileInfo, .fileInfo):
             return .forward
         }
     }
@@ -387,6 +390,9 @@ private struct CPSLFileBrowserRouteStack: View {
 
     private var currentRoute: CPSLFileBrowserRoute {
         if let preview = model.filePreview {
+            if model.isFileInfoOpen {
+                return .fileInfo(preview)
+            }
             return .preview(preview)
         }
         return .folder(CPSLFileBrowserFolderSnapshot(model: model))
@@ -543,6 +549,8 @@ private struct CPSLFileBrowserRouteContent: View {
             CPSLFileBrowserPane(snapshot: snapshot, actions: actions)
         case .preview(let preview):
             CPSLFilePreviewContentView(preview: preview)
+        case .fileInfo(let preview):
+            CPSLFileInfoPageView(preview: preview)
         }
     }
 }
@@ -668,16 +676,22 @@ private struct CPSLFileBrowserHeader: View {
     var body: some View {
         HStack(spacing: CPSLTheme.medium) {
             CPSLFileBrowserBackButton(
-                isAvailable: model.filePreview != nil || model.canNavigateToParentDirectory
+                isAvailable: model.isFileInfoOpen
+                    || model.filePreview != nil
+                    || model.canNavigateToParentDirectory
             ) {
-                if model.filePreview != nil {
+                if model.isFileInfoOpen {
+                    model.closeFileInfo()
+                } else if model.filePreview != nil {
                     model.closeFilePreview()
                 } else {
                     model.navigateToParentDirectory()
                 }
             }
 
-            if let preview = model.filePreview {
+            if model.isFileInfoOpen, let preview = model.filePreview {
+                CPSLFileInfoHeaderTitle(preview: preview)
+            } else if let preview = model.filePreview {
                 CPSLFilePreviewHeaderTitle(
                     preview: preview,
                     accessMode: model.iCloudMount(containing: preview.path)?.accessMode
@@ -692,9 +706,13 @@ private struct CPSLFileBrowserHeader: View {
 
             switch actions.mode {
             case .browsing:
-                if let preview = model.filePreview, preview.showsHeaderInfoButton {
-                    CPSLFilePreviewInfoButton(preview: preview)
-                } else if actions.canEnterSelection {
+                if let preview = model.filePreview,
+                   preview.showsHeaderInfoButton,
+                   !model.isFileInfoOpen {
+                    CPSLFilePreviewInfoButton {
+                        model.openFileInfo()
+                    }
+                } else if model.filePreview == nil, actions.canEnterSelection {
                     Button("Select", action: actions.beginSelection)
                         .font(CPSLTheme.controlFont)
                         .buttonStyle(.plain)
@@ -743,23 +761,19 @@ private struct CPSLFileBrowserBackButton: View {
 }
 
 private struct CPSLFilePreviewInfoButton: View {
-    let preview: CPSLFilePreview
-    @State private var isShowingInfo = false
+    let action: () -> Void
 
     var body: some View {
         CPSLFileOverlayIconButton(
             systemName: "info.circle",
-            accessibilityLabel: "File Info"
-        ) {
-            isShowingInfo = true
-        }
-        .popover(isPresented: $isShowingInfo) {
-            CPSLFilePreviewInfoPopover(preview: preview)
-        }
+            accessibilityLabel: "File Info",
+            action: action
+        )
     }
 }
 
-private struct CPSLFilePreviewInfoPopover: View {
+/// Full-pane file metadata, pushed one level deeper in the Files stack (not a popover).
+struct CPSLFileInfoPageView: View {
     let preview: CPSLFilePreview
 
     var body: some View {
@@ -772,7 +786,7 @@ private struct CPSLFilePreviewInfoPopover: View {
             .padding(CPSLTheme.large)
         }
         .scrollBounceBehavior(.basedOnSize)
-        .frame(minWidth: 280, idealWidth: 320, maxWidth: 380, maxHeight: 360)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 }
 
@@ -797,6 +811,32 @@ private struct CPSLFilePreviewInfoHeader: View {
                     .foregroundStyle(CPSLTheme.secondaryText)
             }
         }
+    }
+}
+
+private struct CPSLFileInfoHeaderTitle: View {
+    let preview: CPSLFilePreview
+
+    var body: some View {
+        HStack(spacing: CPSLTheme.medium) {
+            CPSLFileIcon(
+                systemName: "info.circle.fill",
+                color: CPSLTheme.IconPalette.secondary
+            )
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Info")
+                    .font(CPSLTheme.supportingMediumFont)
+                    .foregroundStyle(CPSLTheme.text)
+                    .lineLimit(1)
+
+                Text(preview.name)
+                    .font(CPSLTheme.captionFont)
+                    .foregroundStyle(CPSLTheme.secondaryText)
+                    .lineLimit(1)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 
@@ -1084,7 +1124,7 @@ private struct CPSLAddICloudFolderRow: View {
             actionTitle: "Add",
             systemName: "icloud.fill",
             color: CPSLTheme.IconPalette.cloud,
-            accessory: .singleIcon
+            accessory: .none
         ) {
             actions.connectICloud()
         }
@@ -1143,7 +1183,7 @@ private struct CPSLFileLocationsView: View {
                         actionTitle: "Add",
                         systemName: "icloud.fill",
                         color: CPSLTheme.IconPalette.cloud,
-                        accessory: .singleIcon
+                        accessory: .none
                     ) {
                         actions.connectICloud()
                     }
@@ -1181,29 +1221,32 @@ private struct CPSLFileLocationRow: View {
                     Text(title)
                         .font(CPSLTheme.rowTitleFont)
                         .foregroundStyle(CPSLTheme.text)
+                        .lineLimit(1)
                     Text(detail)
                         .font(CPSLTheme.captionFont)
                         .foregroundStyle(CPSLTheme.secondaryText)
                         .lineLimit(1)
                 }
 
-                Spacer()
+                Spacer(minLength: 0)
 
                 Image(systemName: "chevron.right")
                     .font(CPSLTheme.iconSmallFont)
                     .foregroundStyle(CPSLTheme.mutedText)
+                    .frame(width: CPSLFileRowMetrics.trailingControlWidth, alignment: .trailing)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .frame(maxWidth: .infinity, minHeight: CPSLFileRowMetrics.height, alignment: .leading)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .padding(.horizontal, CPSLTheme.medium)
+        .padding(.leading, CPSLFileRowMetrics.leading)
+        .padding(.trailing, CPSLFileRowMetrics.trailing)
         .padding(.vertical, CPSLTheme.small)
     }
 }
 
 private enum CPSLCloudAccessory {
-    case singleIcon
+    case none
     case providerIcons
 }
 
@@ -1219,14 +1262,16 @@ private struct CPSLCloudConnectionRow: View {
         HStack(spacing: CPSLTheme.medium) {
             CPSLFileIcon(systemName: systemName, color: color)
 
-            VStack(alignment: .leading, spacing: 2) {
-                Text(title)
-                    .font(CPSLTheme.rowTitleFont)
-                    .foregroundStyle(CPSLTheme.text)
-                cloudAccessory
+            Text(title)
+                .font(CPSLTheme.rowTitleFont)
+                .foregroundStyle(CPSLTheme.text)
+                .lineLimit(1)
+
+            if case .providerIcons = accessory {
+                cloudProviderMarks
             }
 
-            Spacer()
+            Spacer(minLength: 0)
 
             Button(actionTitle, action: action)
                 .font(CPSLTheme.controlFont)
@@ -1241,27 +1286,23 @@ private struct CPSLCloudConnectionRow: View {
                 )
                 .contentShape(RoundedRectangle(cornerRadius: CPSLTheme.rowRadius, style: .continuous))
         }
-        .padding(.horizontal, CPSLTheme.medium)
+        .frame(minHeight: CPSLFileRowMetrics.height)
+        .padding(.leading, CPSLFileRowMetrics.leading)
+        .padding(.trailing, CPSLFileRowMetrics.trailing)
         .padding(.vertical, CPSLTheme.small)
     }
 
-    @ViewBuilder
-    private var cloudAccessory: some View {
-        switch accessory {
-        case .singleIcon:
-            Image(systemName: "icloud")
+    private var cloudProviderMarks: some View {
+        HStack(spacing: 4) {
+            CPSLCloudProviderMark(provider: .googleDrive)
+            CPSLCloudProviderMark(provider: .dropbox)
+            CPSLCloudProviderMark(provider: .oneDrive)
+            Image(systemName: "ellipsis")
                 .font(CPSLTheme.captionFont)
                 .foregroundStyle(CPSLTheme.secondaryText)
-        case .providerIcons:
-            HStack(spacing: 4) {
-                CPSLCloudProviderMark(provider: .googleDrive)
-                CPSLCloudProviderMark(provider: .dropbox)
-                CPSLCloudProviderMark(provider: .oneDrive)
-                Image(systemName: "ellipsis")
-                    .font(CPSLTheme.captionFont)
-                    .foregroundStyle(CPSLTheme.secondaryText)
-            }
         }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Google Drive, Dropbox, OneDrive, and more")
     }
 }
 
@@ -1321,6 +1362,8 @@ private enum CPSLFileRowMetrics {
     static let indent: CGFloat = 24
     static let disclosureWidth: CGFloat = 24
     static let iconWidth: CGFloat = 20
+    /// Shared trailing control column so chevrons/actions line up across row types.
+    static let trailingControlWidth: CGFloat = CPSLTheme.controlSize
 
     static func leadingPadding(depth: Int, isDirectory: Bool) -> CGFloat {
         let base = leading + CGFloat(depth) * indent

--- a/app/apple/herm/Views/Files/CPSLFilePreviewOverlay.swift
+++ b/app/apple/herm/Views/Files/CPSLFilePreviewOverlay.swift
@@ -672,8 +672,22 @@ private final class CPSLMediaPlaybackModel {
         if duration > 0 && currentTime >= duration - 0.25 {
             seek(to: 0)
         }
+        // Match Music: .playback ignores the hardware silent switch so media is audible.
+        Self.activatePlaybackAudioSession()
         player.play()
         isPlaying = true
+    }
+
+    private static func activatePlaybackAudioSession() {
+        #if os(iOS) || os(tvOS) || os(visionOS)
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(.playback, mode: .default, options: [])
+            try session.setActive(true, options: [])
+        } catch {
+            // Playback still attempts; silent-switch behavior depends on session success.
+        }
+        #endif
     }
 
     func seek(to seconds: Double) {

--- a/app/apple/herm/Views/Location/CPSLLocationMapView.swift
+++ b/app/apple/herm/Views/Location/CPSLLocationMapView.swift
@@ -10,19 +10,34 @@ struct CPSLLocationMapView: View {
     let location: CLLocation
     var markerSize: CGFloat = 11
     var span: CLLocationDegrees = 0.01
+    /// Defer MKMapView construction until after the first frame so opening Location
+    /// does not hitch the main thread on MapKit setup.
+    @State private var isMapReady = false
 
     var body: some View {
-        mapContent
-            .overlay {
-                Circle()
-                    .fill(.blue)
-                    .frame(width: markerSize, height: markerSize)
-                    .overlay(
-                        Circle()
-                            .stroke(.white, lineWidth: max(2, markerSize * 0.18))
-                    )
-                    .shadow(color: .black.opacity(0.24), radius: 2, y: 1)
+        Group {
+            if isMapReady {
+                mapContent
+            } else {
+                CPSLTheme.elevated
             }
+        }
+        .overlay {
+            Circle()
+                .fill(.blue)
+                .frame(width: markerSize, height: markerSize)
+                .overlay(
+                    Circle()
+                        .stroke(.white, lineWidth: max(2, markerSize * 0.18))
+                )
+                .shadow(color: .black.opacity(0.24), radius: 2, y: 1)
+        }
+        .task {
+            // Yield twice so the overlay panel can finish its open animation first.
+            await Task.yield()
+            await Task.yield()
+            isMapReady = true
+        }
     }
 
     @ViewBuilder

--- a/scripts/vet-apple-agent-concurrency-ui.swift
+++ b/scripts/vet-apple-agent-concurrency-ui.swift
@@ -24,7 +24,7 @@ private struct CPSLAgentConcurrencyUIChecks {
                     "sub-agent execution should enforce the configured depth limit")
         try require(runtime.contains("allowsSubagents: context.agentDepth < context.config.maxAgentDepth"),
                     "nested sub-agent tool exposure should stop at the depth limit")
-        try require(runtime.contains("tools: isFinalTurn ? [] : CPSLOpenAITool.availableTools"),
+        try require(runtime.contains("let tools = isFinalTurn ? [] : CPSLOpenAITool.availableTools("),
                     "sub-agents should have no tools on their final synthesis turn")
     }
 
@@ -50,16 +50,23 @@ private struct CPSLAgentConcurrencyUIChecks {
     }
 
     private static func assertRunningLifecycleIsBalanced(chatModel: String) throws {
-        try require(chatModel.contains("@Published private(set) var isRunning = false"),
-                    "chat model should publish running state")
+        // Observable macro (not Combine @Published) owns isRunning for SwiftUI.
+        try require(chatModel.contains("private(set) var isRunning = false"),
+                    "chat model should expose running state")
+        try require(chatModel.contains("@Observable"),
+                    "chat model should publish running state via Observation")
         try require(chatModel.contains("private func runAgent(prompt: CPSLAttachmentPrompt) async {\n        defer {\n            isRunning = false\n            activeRunTask = nil\n        }"),
                     "agent run should clear running state through a defer")
         try require(chatModel.contains("Task { @MainActor in\n            defer {\n                isRunning = false\n                activeRunTask = nil\n            }"),
                     "direct command runs should clear running state through a MainActor defer")
+        try require(chatModel.contains("func stopAgent()"),
+                    "chat model should expose stopAgent for the composer Stop control")
+        try require(chatModel.contains("activeRunTask?.cancel()"),
+                    "stopAgent should cancel the active run task so nested work observes cancellation")
     }
 
     private static func assertWorkingIndicatorContract(timeline: String) throws {
-        try require(timeline.contains("if model.isRunning {\n                        CPSLAgentWorkingIndicatorView()"),
+        try require(timeline.contains("if model.isRunning {\n                            CPSLAgentWorkingIndicatorView()"),
                     "timeline should show a dots-only working indicator whenever the model is running")
         try require(timeline.contains("private struct CPSLAgentWorkingIndicatorView"),
                     "working indicator should be a distinct SwiftUI view")

--- a/scripts/vet-apple-agent-integration.sh
+++ b/scripts/vet-apple-agent-integration.sh
@@ -542,6 +542,15 @@ if command -v swiftc >/dev/null 2>&1; then
     -o /tmp/herm-vet-eval-race
   /tmp/herm-vet-eval-race
   swiftc \
+    app/apple/herm/Models/CPSLEvalTypes.swift \
+    scripts/vet-apple-stop-control.swift \
+    -o /tmp/herm-vet-stop-control
+  /tmp/herm-vet-stop-control
+  swiftc -parse-as-library \
+    scripts/vet-apple-file-info-media-mainthread.swift \
+    -o /tmp/herm-vet-file-info-media
+  /tmp/herm-vet-file-info-media
+  swiftc \
     app/apple/herm/Models/CPSLICloudMount.swift \
     app/apple/herm/Services/CPSLICloudBookmarkAccess.swift \
     app/apple/herm/Services/CPSLICloudFileMaterializer.swift \

--- a/scripts/vet-apple-file-info-media-mainthread.swift
+++ b/scripts/vet-apple-file-info-media-mainthread.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+/// Structural gates for:
+/// - file info as Files stack route (not popover)
+/// - media playback audio session (.playback for silent switch)
+/// - location/calendar open paths that keep heavy work off the main thread
+@main
+private struct CPSLFileInfoMediaMainThreadChecks {
+    static func main() throws {
+        let browser = try source("app/apple/herm/Views/Files/CPSLFileBrowserView.swift")
+        let chatModel = try source("app/apple/herm/Models/CPSLChatModel.swift")
+        let preview = try source("app/apple/herm/Views/Files/CPSLFilePreviewOverlay.swift")
+        let locationService = try source("app/apple/herm/Services/CPSLLocationService.swift")
+        let locationMap = try source("app/apple/herm/Views/Location/CPSLLocationMapView.swift")
+        let calendar = try source("app/apple/herm/Services/CPSLCalendarService.swift")
+
+        try assertFileInfoIsStackRoute(browser: browser, chatModel: chatModel)
+        try assertMediaPlaysInSilentMode(preview: preview)
+        try assertMainThreadFriendlyWidgets(
+            chatModel: chatModel,
+            locationService: locationService,
+            locationMap: locationMap,
+            calendar: calendar
+        )
+        print("vet-apple-file-info-media-mainthread: all checks passed")
+    }
+
+    private static func assertFileInfoIsStackRoute(browser: String, chatModel: String) throws {
+        try require(
+            browser.contains("case fileInfo(CPSLFilePreview)"),
+            "Files route stack must include a fileInfo case"
+        )
+        try require(
+            browser.contains("case .fileInfo(let preview):\n            CPSLFileInfoPageView(preview: preview)"),
+            "fileInfo route must render the in-pane info page"
+        )
+        try require(
+            browser.contains("struct CPSLFileInfoPageView"),
+            "file info content must be a full page view"
+        )
+        try require(
+            !browser.contains(".popover(isPresented: $isShowingInfo)"),
+            "file info must not present as a popover drawer"
+        )
+        try require(
+            !browser.contains("CPSLFilePreviewInfoPopover"),
+            "popover-based file info type must be removed"
+        )
+        try require(
+            chatModel.contains("private(set) var isFileInfoOpen = false"),
+            "chat model must own isFileInfoOpen for stack depth"
+        )
+        try require(
+            chatModel.contains("func openFileInfo()") && chatModel.contains("func closeFileInfo()"),
+            "chat model must open/close file info like folder navigation"
+        )
+        try require(
+            browser.contains("model.closeFileInfo()") && browser.contains("model.openFileInfo()"),
+            "header back/info must drive model file-info navigation"
+        )
+        try require(
+            browser.contains("(.preview, .fileInfo)") && browser.contains("(.fileInfo, .preview)"),
+            "route direction must treat info as one level deeper than preview"
+        )
+    }
+
+    private static func assertMediaPlaysInSilentMode(preview: String) throws {
+        try require(
+            preview.contains("activatePlaybackAudioSession()"),
+            "media play must configure the playback audio session"
+        )
+        try require(
+            preview.contains("setCategory(.playback"),
+            "audio session category must be .playback (ignores silent switch like Music)"
+        )
+        try require(
+            preview.contains("player.play()") &&
+                preview.range(of: "activatePlaybackAudioSession()") != nil,
+            "session activation must happen on the play path"
+        )
+    }
+
+    private static func assertMainThreadFriendlyWidgets(
+        chatModel: String,
+        locationService: String,
+        locationMap: String,
+        calendar: String
+    ) throws {
+        try require(
+            chatModel.contains("isLocationOpen = true") &&
+                chatModel.contains("Task(priority: .userInitiated)") &&
+                chatModel.contains("await location.loadCurrentLocation()"),
+            "location overlay must open before awaiting location load"
+        )
+        try require(
+            locationService.contains("await Self.locationServicesEnabled()") &&
+                locationService.contains("Task.detached(priority: .utility)"),
+            "locationServicesEnabled must stay off the main thread"
+        )
+        try require(
+            locationService.contains("await Task.yield()"),
+            "location load must yield so overlay chrome can paint first"
+        )
+        try require(
+            locationMap.contains("@State private var isMapReady = false") &&
+                locationMap.contains("isMapReady = true"),
+            "MKMapView construction must be deferred until after first frames"
+        )
+        try require(
+            calendar.contains("Task.detached(priority: .userInitiated)") &&
+                calendar.contains("fetchUpcomingEvents(from:"),
+            "calendar event matching must run off the MainActor"
+        )
+        try require(
+            chatModel.contains("await service.listDirectory(path)") ||
+                chatModel.contains("await service.listDirectory"),
+            "directory listing must be awaited on the service actor (not sync on UI)"
+        )
+    }
+
+    private static func source(_ relativePath: String) throws -> String {
+        let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent(relativePath)
+        do {
+            return try String(contentsOf: url, encoding: .utf8)
+        } catch {
+            throw CheckFailure("could not read \(relativePath): \(error.localizedDescription)")
+        }
+    }
+
+    private static func require(_ condition: Bool, _ message: String) throws {
+        guard condition else {
+            throw CheckFailure(message)
+        }
+    }
+}
+
+private struct CheckFailure: Error, CustomStringConvertible {
+    let description: String
+    init(_ description: String) { self.description = description }
+}

--- a/scripts/vet-apple-stop-control.swift
+++ b/scripts/vet-apple-stop-control.swift
@@ -1,0 +1,307 @@
+import Foundation
+
+/// Structural + pure-logic gates for Stop control appearance, cooperative cancel
+/// paths, and file-explorer iCloud row layout. Compiles against shipped sources
+/// where possible; otherwise asserts required contracts in source.
+@main
+private struct CPSLStopControlChecks {
+    static func main() async throws {
+        let composer = try source("app/apple/herm/Views/Composer/CPSLPromptComposerView.swift")
+        let chatModel = try source("app/apple/herm/Models/CPSLChatModel.swift")
+        let runtime = try source("app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift")
+        let openAI = try source("app/apple/herm/Services/Agent/CPSLOpenAIClient.swift")
+        let debugService = try source("app/apple/herm/Services/CPSLDebugService.swift")
+        let fileBrowser = try source("app/apple/herm/Views/Files/CPSLFileBrowserView.swift")
+        let theme = try source("app/apple/herm/Design/CPSLTheme.swift")
+
+        try assertStopControlAppearance(composer: composer, theme: theme)
+        try assertStopCancelsRun(chatModel: chatModel, runtime: runtime)
+        try assertNestedPathsObserveCancel(
+            runtime: runtime,
+            openAI: openAI,
+            debugService: debugService
+        )
+        try assertFileExplorerICloudRow(fileBrowser: fileBrowser)
+        try await assertEvalRaceCancelBehavior()
+
+        print("vet-apple-stop-control: all checks passed")
+    }
+
+    private static func assertStopControlAppearance(composer: String, theme: String) throws {
+        try require(
+            theme.contains("static let danger = Color(red: 0.86, green: 0.28, blue: 0.32)"),
+            "theme must define a vivid danger color for active stop styling"
+        )
+        try require(
+            theme.contains("static let error = Color(red: 0.36, green: 0.16, blue: 0.20)"),
+            "theme error surface must remain the muted background token"
+        )
+
+        let stopSlice = try requireSlice(
+            in: composer,
+            startingWith: "if model.isRunning {",
+            endingWith: "} else if canSubmit {"
+        )
+        try require(stopSlice.contains("model.stopAgent()"), "running composer must call stopAgent on tap")
+        try require(stopSlice.contains("stop.fill"), "stop control must use the stop glyph")
+        try require(stopSlice.contains(".background(CPSLTheme.danger)"), "stop fill must use vivid danger, not muted error")
+        try require(!stopSlice.contains("CPSLTheme.error"), "stop must not use muted error surface (reads disabled)")
+        try require(stopSlice.contains(".foregroundStyle(CPSLTheme.text)"), "stop glyph must be high-contrast on danger")
+        try require(!stopSlice.contains(".disabled("), "stop must stay enabled while isRunning")
+        try require(!stopSlice.contains(".opacity("), "stop must not dim via opacity while running")
+        try require(stopSlice.contains("accessibilityLabel(\"Stop\")"), "stop must expose accessibility label")
+    }
+
+    private static func assertStopCancelsRun(chatModel: String, runtime: String) throws {
+        let stopSlice = try requireSlice(
+            in: chatModel,
+            startingWith: "func stopAgent() {",
+            endingWith: "func addAttachment(from url: URL)"
+        )
+        try require(stopSlice.contains("activeRunTask?.cancel()"), "stopAgent must cancel the active run task")
+        try require(stopSlice.contains("isSuppressingAssistantStream = true"), "stop must suppress further stream deltas")
+        try require(stopSlice.contains("typewriterTask?.cancel()"), "stop must cancel typewriter animation")
+        try require(stopSlice.contains("discardStreamingAssistantIfNeeded()"), "stop must drop partial streaming UI")
+
+        try require(
+            chatModel.contains("if Task.isCancelled {\n                await markActiveToolStatusStopped()"),
+            "cancelled agent run must mark active tool status stopped/interrupted"
+        )
+        try require(
+            runtime.contains("as: .interrupted") && runtime.contains("String(localized: \"Stopped\")"),
+            "tool status finish path for stop must use interrupted/Stopped"
+        )
+        try require(
+            chatModel.contains("defer {\n            isRunning = false\n            activeRunTask = nil\n        }"),
+            "agent run must clear isRunning when the cancelled task unwinds"
+        )
+    }
+
+    private static func assertNestedPathsObserveCancel(
+        runtime: String,
+        openAI: String,
+        debugService: String
+    ) throws {
+        try require(
+            runtime.contains("try Task.checkCancellation()") &&
+                runtime.occurrences(of: "try Task.checkCancellation()") >= 8,
+            "provider + sub-agent loops must check cancellation at multiple points"
+        )
+        try require(
+            runtime.contains("if Task.isCancelled {\n            return cancelledToolExecutionResult(for: toolCall)"),
+            "tool execution must short-circuit when already cancelled"
+        )
+        try require(
+            runtime.contains("if Task.isCancelled || result.errorCode == \"cancelled\""),
+            "sandbox/code-exec path must treat cancelled eval as stop"
+        )
+        try require(
+            runtime.contains("} catch is CancellationError {\n            return (") &&
+                runtime.contains("textParts: textParts + [\"Stopped.\"]"),
+            "sub-agent cancellation must surface Stopped rather than a generic failure"
+        )
+
+        let streamSlice = try requireSlice(
+            in: openAI,
+            startingWith: "func streamChat(",
+            endingWith: "private func validate(response:"
+        )
+        try require(
+            streamSlice.occurrences(of: "try Task.checkCancellation()") >= 3,
+            "provider stream must observe cancellation before/during/after SSE reads"
+        )
+
+        try require(
+            debugService.contains("withTaskCancellationHandler"),
+            "eval must race cancellation against native cpsl_eval"
+        )
+        try require(
+            debugService.contains("race.resume(.cancelled)"),
+            "eval race must resume cancelled for Stop"
+        )
+        try require(
+            debugService.contains("errorCode: \"cancelled\""),
+            "cancelled eval must return a cancelled outcome to the agent loop"
+        )
+        try require(
+            debugService.contains("catch is CancellationError {\n            return Self.cancellationFailure()"),
+            "eval setup cancellation must not be converted into a generic ffi failure"
+        )
+    }
+
+    private static func assertFileExplorerICloudRow(fileBrowser: String) throws {
+        try require(
+            fileBrowser.contains("title: \"Add iCloud Folder\""),
+            "Add iCloud Folder row must remain available"
+        )
+        try require(
+            fileBrowser.contains("accessory: .none"),
+            "iCloud connect rows must use single-line .none accessory"
+        )
+        try require(
+            !fileBrowser.contains("case singleIcon") && !fileBrowser.contains(".singleIcon"),
+            "outline singleIcon accessory under the title must be removed"
+        )
+        try require(
+            fileBrowser.contains("case none") && fileBrowser.contains("case providerIcons"),
+            "cloud accessory must only be none or inline provider icons"
+        )
+
+        let cloudRow = try requireSlice(
+            in: fileBrowser,
+            startingWith: "private struct CPSLCloudConnectionRow: View {",
+            endingWith: "private enum CPSLCloudProvider {"
+        )
+        try require(
+            !cloudRow.contains("Image(systemName: \"icloud\")"),
+            "cloud connection row must not render a secondary outline icloud under the title"
+        )
+        try require(
+            cloudRow.contains("Text(title)") && cloudRow.contains("Button(actionTitle, action: action)"),
+            "title and action must share one horizontal cloud connection row"
+        )
+        try require(
+            cloudRow.contains("padding(.leading, CPSLFileRowMetrics.leading)") &&
+                cloudRow.contains("padding(.trailing, CPSLFileRowMetrics.trailing)"),
+            "cloud rows must share file-row leading/trailing metrics"
+        )
+
+        let locationRow = try requireSlice(
+            in: fileBrowser,
+            startingWith: "private struct CPSLFileLocationRow: View {",
+            endingWith: "private enum CPSLCloudAccessory {"
+        )
+        try require(
+            locationRow.contains("padding(.leading, CPSLFileRowMetrics.leading)") &&
+                locationRow.contains("padding(.trailing, CPSLFileRowMetrics.trailing)"),
+            "location rows must share file-row leading/trailing metrics"
+        )
+        try require(
+            fileBrowser.contains("static let leading: CGFloat = CPSLTheme.medium") &&
+                fileBrowser.contains("static let iconWidth: CGFloat = 20"),
+            "shared CPSLFileRowMetrics must define icon column and leading padding"
+        )
+    }
+
+    private static func assertEvalRaceCancelBehavior() async throws {
+        // Drive the real shipped CPSLEvalRaceBox (compiled in via integration, or
+        // duplicated runtime path when this script is compiled with EvalTypes).
+        // When run alone as source-only structural checks, still validate race box
+        // if the type is present in-process; otherwise re-run pure logic below.
+
+        let startState = CPSLEvalRaceBox()
+        try require(!startState.didStartEvaluation, "new evaluation was marked as started")
+        try require(startState.startEvaluationIfPending(), "evaluation did not start")
+        try require(startState.didStartEvaluation, "evaluation start was not recorded")
+        try require(!startState.startEvaluationIfPending(), "evaluation started twice")
+
+        let cancelledBeforeStart = CPSLEvalRaceBox()
+        let cancellationResult = await withCheckedContinuation { continuation in
+            cancelledBeforeStart.resume(.cancelled, continuation: continuation)
+        }
+        guard case .cancelled = cancellationResult else {
+            throw CheckFailure("pre-start cancellation did not win the race")
+        }
+        try require(
+            !cancelledBeforeStart.startEvaluationIfPending(),
+            "evaluation started after cancellation"
+        )
+        try require(
+            !cancelledBeforeStart.didStartEvaluation,
+            "cancelled evaluation was marked as started"
+        )
+        try require(
+            !cancelledBeforeStart.isDetachedEvaluationRunning,
+            "pre-start cancellation left detached work"
+        )
+
+        let cancelledAfterStart = CPSLEvalRaceBox()
+        try require(cancelledAfterStart.startEvaluationIfPending(), "evaluation did not start")
+        let cancelledResult = await withCheckedContinuation { continuation in
+            cancelledAfterStart.resume(.cancelled, continuation: continuation)
+        }
+        guard case .cancelled = cancelledResult else {
+            throw CheckFailure("started evaluation was not cancelled")
+        }
+        try require(
+            cancelledAfterStart.isDetachedEvaluationRunning,
+            "cancelled native evaluation was not retained as running"
+        )
+        try require(
+            !cancelledAfterStart.resume(.completed(successResult)),
+            "late cancelled completion resumed the continuation twice"
+        )
+        cancelledAfterStart.finishDetachedEvaluation()
+        try require(
+            !cancelledAfterStart.isDetachedEvaluationRunning,
+            "finished cancelled evaluation remained busy"
+        )
+    }
+
+    private static let successResult: CPSLEvalServiceResult = (
+        rawJSON: nil,
+        stdout: "",
+        stderr: "",
+        exitCode: 0,
+        ok: true,
+        cwd: "/home/herm",
+        errorCode: nil,
+        errorMessage: nil,
+        warnings: [],
+        ffiError: nil
+    )
+
+    private static func source(_ relativePath: String) throws -> String {
+        let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent(relativePath)
+        do {
+            return try String(contentsOf: url, encoding: .utf8)
+        } catch {
+            throw CheckFailure("could not read \(relativePath): \(error.localizedDescription)")
+        }
+    }
+
+    private static func requireSlice(
+        in source: String,
+        startingWith start: String,
+        endingWith end: String
+    ) throws -> String {
+        guard let startRange = source.range(of: start) else {
+            throw CheckFailure("missing slice start: \(start)")
+        }
+        let fromStart = source[startRange.lowerBound...]
+        guard let endRange = fromStart.range(of: end) else {
+            throw CheckFailure("missing slice end after \(start): \(end)")
+        }
+        return String(fromStart[..<endRange.lowerBound])
+    }
+
+    private static func require(_ condition: Bool, _ message: String) throws {
+        guard condition else {
+            throw CheckFailure(message)
+        }
+    }
+}
+
+private extension String {
+    func occurrences(of needle: String) -> Int {
+        guard !needle.isEmpty else {
+            return 0
+        }
+        var count = 0
+        var searchRange = startIndex..<endIndex
+        while let range = range(of: needle, range: searchRange) {
+            count += 1
+            searchRange = range.upperBound..<endIndex
+        }
+        return count
+    }
+}
+
+private struct CheckFailure: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = description
+    }
+}


### PR DESCRIPTION
## Summary

Apple app UI/runtime polish across composer, Files, media, and overlays:

### Stop control
- **Appearance:** Stop uses vivid `CPSLTheme.danger` + high-contrast glyph (was muted `error`, which looked disabled/unclickable).
- **Behavior:** `stopAgent()` cancels the active run task immediately, suppresses streaming, cancels typewriter, and drops partial assistant stream UI.
- **Nested cancel:** Cooperative cancellation in the main provider loop, **sub-agent turns/tools**, sandbox/code-exec (`cancelled` eval → short-circuit), provider SSE streams, and eval setup (CancellationError → cancel failure, not FFI error).
- Cancelled runs still mark active tool status as **interrupted / “Stopped”** and clear `isRunning` via the existing defer path.

### Files explorer
- **“Add iCloud Folder”** (and empty-state iCloud connect): single horizontal row — leading icon + label + action — **no** secondary outline cloud under the title.
- **Alignment:** location / cloud connection / file rows share `CPSLFileRowMetrics` leading/trailing/height.
- **File info:** tapping **i** pushes full-pane **Info** one level deeper in the **same Files route stack** (folder → preview → info), not a popover/drawer. **Back** returns to the file preview.

### Media
- Audio/video playback activates `AVAudioSession` category **`.playback`** so media is audible with the hardware silent switch on (Music-app behavior).

### Overlay / main-thread responsiveness
- **Location:** opens immediately; `locationServicesEnabled` stays off-main; `MKMapView` construction deferred until after first frames to avoid open hitch.
- **Calendar:** EventKit match/sort/map runs in `Task.detached`, not on the MainActor.
- **Files listing:** remains on the debug-service actor (async). Browser open path already async.

### Tests / vets
- `scripts/vet-apple-stop-control.swift` — Stop styling + cancel contracts + eval race.
- `scripts/vet-apple-file-info-media-mainthread.swift` — file-info stack, silent-mode session, off-main location/calendar gates.
- Wired into `scripts/vet-apple-agent-integration.sh`; concurrency UI vet strings updated for `@Observable` / current sources.

## Test plan
- [ ] Start an agent run → Stop looks clearly clickable (bright red, not dim) and is tappable
- [ ] Stop mid tool / sub-agent / stream / code-exec → UI leaves running state; tool status shows Stopped/interrupted; no stuck “running”
- [ ] Files root: “Add iCloud Folder” is one line, no outline cloud under the label; location/cloud rows look aligned
- [ ] Open a file → tap **i** → full-pane info in Files chrome → **Back** returns to the file (not a floating drawer)
- [ ] Play an audio file with silent switch **on** → sound plays
- [ ] Open Location / Calendar / Files → chrome appears promptly without UI freeze