### PR TITLE
Fix Apple actor warnings and harden CPSL build lock

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,5 +1,5 @@
 {
-  "lockFileVersion": 26,
+  "lockFileVersion": 28,
   "registryFileHashes": {
     "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
     "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
@@ -220,7 +220,7 @@
   "moduleExtensions": {
     "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "b+RP7Sgl8KN0VHamrgTqzGLuYPcQ/Mo4ptNkkHUIIlA=",
+        "bzlTransitiveDigest": "NRXra7941UfmNUyIxnLt82V5hULluVGL2nBsijTl4j4=",
         "usagesDigest": "D1r3lfzMuUBFxgG8V6o0bQTLMk3GkaGOaPzw53wrwyw=",
         "recordedInputs": [
           "REPO_MAPPING:pybind11_bazel+,bazel_tools bazel_tools",
@@ -242,7 +242,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "Ga4z8lQy1YQ5rAMy+dOl0dqcCEBnYNCXku8x3YQmDZI=",
+        "bzlTransitiveDigest": "+Kp6j204mBZ3mxlIDDR0gBoP45BZ4jYRhRAcB8sU0qc=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedInputs": [
           "REPO_MAPPING:rules_kotlin+,bazel_tools bazel_tools"
@@ -299,7 +299,7 @@
     },
     "@@rules_python+//python/extensions:config.bzl%config": {
       "general": {
-        "bzlTransitiveDigest": "iibnRYgg8LpcfmH7EAnVwYePC3jsVaJ6Id8XxUjSZps=",
+        "bzlTransitiveDigest": "dzD8Q2YmrP3fz8saWLHPmlwPLO91ImtTmP/c9JKTStM=",
         "usagesDigest": "ZVSXMAGpD+xzVNPuvF1IoLBkty7TROO0+akMapt1pAg=",
         "recordedInputs": [
           "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",
@@ -497,7 +497,7 @@
     },
     "@@rules_rust+//crate_universe:extensions.bzl%crate": {
       "general": {
-        "bzlTransitiveDigest": "b4+RYpkdcNTH+KdD9JtSZbAiz3JrqHUili7nrw3BL10=",
+        "bzlTransitiveDigest": "4e0uNkFgykXeLgcLZkqWKJbzzSSYqEPlPhfMFR3V4Mw=",
         "usagesDigest": "uUJ6JCurEVGCqQlvBaKy4CPyh8eYHklmkPPtkoBqo7w=",
         "recordedInputs": [
           "ENV:CARGO_BAZEL_DEBUG \\0",
@@ -8333,7 +8333,7 @@
     },
     "@@rules_rust+//crate_universe/private:internal_extensions.bzl%cu_nr": {
       "general": {
-        "bzlTransitiveDigest": "N5252EBbxPruGUNdjDIzrwyJOwTCjPLemyYCFUqkBls=",
+        "bzlTransitiveDigest": "ZLrOFxQ1TjxuMwCWZ7fYB8ufl3TF6YUTiA7tuMIOmXA=",
         "usagesDigest": "cXwM8V1dYpvU0qY6LVYuUUf4Ql389ZhymEzwJhYVr2o=",
         "recordedInputs": [
           "REPO_MAPPING:apple_support+,bazel_skylib bazel_skylib+",
@@ -8759,5 +8759,6 @@
         ]
       }
     }
-  }
+  },
+  "factsVersions": {}
 }

--- a/app/apple/herm/Models/CPSLTypes.swift
+++ b/app/apple/herm/Models/CPSLTypes.swift
@@ -203,12 +203,18 @@ nonisolated final class CPSLFileActivityNotifier: @unchecked Sendable {
     }
 }
 
-struct CPSLFileEntry: Identifiable, Equatable, Sendable {
+nonisolated struct CPSLFileEntry: Identifiable, Equatable, Sendable {
     var id: String { path }
 
     let name: String
     let path: String
     let isDirectory: Bool
+
+    nonisolated init(name: String, path: String, isDirectory: Bool) {
+        self.name = name
+        self.path = path
+        self.isDirectory = isDirectory
+    }
 }
 
 struct CPSLDirectoryListing: Sendable {

--- a/app/apple/herm/Services/CPSLCalendarService.swift
+++ b/app/apple/herm/Services/CPSLCalendarService.swift
@@ -328,7 +328,7 @@ final class CPSLCalendarService: ObservableObject {
 }
 
 private extension String {
-    var cpslNilIfEmpty: String? {
+    nonisolated var cpslNilIfEmpty: String? {
         isEmpty ? nil : self
     }
 }

--- a/scripts/ensure-cpsl-apple-xcframework.sh
+++ b/scripts/ensure-cpsl-apple-xcframework.sh
@@ -20,6 +20,8 @@ Options:
 
 Environment:
   HERM_CPSL_REBUILD=1  Force a CPSL XCFramework rebuild.
+  CPSL_XCFRAMEWORK_LOCK_MAX_AGE_SECONDS
+                         Max lock hold time before auto-expiry (default: 3600).
   CPSL_ROOT, CPSL_WORK_DIR, OUT_DIR, APPLE_PLATFORMS,
   IOS_DEVICE_TARGETS, IOS_SIMULATOR_TARGETS, MACOS_TARGETS, CONFIGURATION
                          Passed through to build-cpsl-apple-xcframework.sh.
@@ -42,6 +44,62 @@ cpsl_ensure_is_visionos_build() {
 	return 1
 }
 
+# Default max hold: 1 hour. Cold Bazel CPSL builds can take a long time; a hard
+# ceiling still prevents a dead/stuck holder from blocking Xcode forever.
+cpsl_ensure_lock_max_age_seconds() {
+	max_age=${CPSL_XCFRAMEWORK_LOCK_MAX_AGE_SECONDS:-3600}
+	case "$max_age" in
+	'' | *[!0-9]*)
+		max_age=3600
+		;;
+	esac
+	if [ "$max_age" -lt 60 ]; then
+		max_age=60
+	fi
+	printf '%s\n' "$max_age"
+}
+
+cpsl_ensure_lock_poll_seconds() {
+	printf '%s\n' 5
+}
+
+cpsl_ensure_lock_log_interval_seconds() {
+	# Avoid spamming Xcode's build log on every poll.
+	printf '%s\n' 30
+}
+
+cpsl_ensure_format_unix_time() {
+	unix_time=$1
+
+	if formatted=$(date -r "$unix_time" '+%Y-%m-%d %H:%M:%S %Z' 2>/dev/null); then
+		printf '%s\n' "$formatted"
+		return 0
+	fi
+	if formatted=$(date -d "@$unix_time" '+%Y-%m-%d %H:%M:%S %Z' 2>/dev/null); then
+		printf '%s\n' "$formatted"
+		return 0
+	fi
+	printf 'unix:%s\n' "$unix_time"
+}
+
+cpsl_ensure_format_duration() {
+	total_seconds=$1
+
+	if [ "$total_seconds" -lt 0 ]; then
+		total_seconds=0
+	fi
+	hours=$((total_seconds / 3600))
+	minutes=$(((total_seconds % 3600) / 60))
+	seconds=$((total_seconds % 60))
+	if [ "$hours" -gt 0 ]; then
+		printf '%dh%02dm%02ds\n' "$hours" "$minutes" "$seconds"
+	elif [ "$minutes" -gt 0 ]; then
+		printf '%dm%02ds\n' "$minutes" "$seconds"
+	else
+		printf '%ds\n' "$seconds"
+	fi
+}
+
 cpsl_ensure_lock_mtime() {
 	path=$1
 
@@ -53,50 +111,203 @@ cpsl_ensure_lock_mtime() {
 	stat -c %Y "$path"
 }
 
+cpsl_ensure_read_first_numeric_file() {
+	# Reads the first line of the first existing candidate that is all digits.
+	for candidate in "$@"; do
+		[ -f "$candidate" ] || continue
+		value=$(cat "$candidate" 2>/dev/null || printf '')
+		case "$value" in
+		'' | *[!0-9]*)
+			continue
+			;;
+		*)
+			printf '%s\n' "$value"
+			return 0
+			;;
+		esac
+	done
+	return 1
+}
+
+cpsl_ensure_read_lock_pid() {
+	lock_path=$1
+
+	# Prefer the canonical pid file, then tolerate cloud/Finder renames such as
+	# "pid 2" that leave a non-empty lock directory and break rmdir reclaim.
+	if [ -d "$lock_path" ]; then
+		cpsl_ensure_read_first_numeric_file \
+			"$lock_path/pid" \
+			"$lock_path"/pid\ * || true
+		return 0
+	fi
+	if [ -f "$lock_path" ]; then
+		cpsl_ensure_read_first_numeric_file "$lock_path" || true
+	fi
+}
+
+cpsl_ensure_read_lock_started_at() {
+	lock_path=$1
+
+	if [ -d "$lock_path" ]; then
+		if started=$(cpsl_ensure_read_first_numeric_file \
+			"$lock_path/started_at" \
+			"$lock_path"/started_at\ *); then
+			printf '%s\n' "$started"
+			return 0
+		fi
+	fi
+
+	cpsl_ensure_lock_mtime "$lock_path" 2>/dev/null
+}
+
+cpsl_ensure_read_lock_expires_at() {
+	lock_path=$1
+	max_age=$2
+
+	if [ -d "$lock_path" ]; then
+		if expires=$(cpsl_ensure_read_first_numeric_file \
+			"$lock_path/expires_at" \
+			"$lock_path"/expires_at\ *); then
+			printf '%s\n' "$expires"
+			return 0
+		fi
+	fi
+
+	started=$(cpsl_ensure_read_lock_started_at "$lock_path") || return 1
+	printf '%s\n' "$((started + max_age))"
+}
+
+cpsl_ensure_remove_stale_lock() {
+	lock_path=$1
+	reason=${2:-stale}
+
+	# Force-remove the whole lock tree. A plain rmdir fails when iCloud/Finder
+	# renames pid -> "pid 2" (or leaves other stray files), which previously
+	# spun forever in the acquire loop.
+	if [ -d "$lock_path" ] || [ -e "$lock_path" ] || [ -L "$lock_path" ]; then
+		printf 'Removing CPSL XCFramework build lock (%s):\n  path: %s\n' \
+			"$reason" "$lock_path"
+		rm -rf "$lock_path"
+	fi
+}
+
+cpsl_ensure_log_lock_status() {
+	lock_path=$1
+	lock_pid=$2
+	holder_state=$3
+	expires_at=$4
+	now=$5
+	reason=$6
+
+	if [ "$expires_at" -gt "$now" ]; then
+		remaining=$((expires_at - now))
+		expiry_clause=$(printf 'expires at %s (in %s)' \
+			"$(cpsl_ensure_format_unix_time "$expires_at")" \
+			"$(cpsl_ensure_format_duration "$remaining")")
+	else
+		expiry_clause=$(printf 'expired at %s (%s ago)' \
+			"$(cpsl_ensure_format_unix_time "$expires_at")" \
+			"$(cpsl_ensure_format_duration $((now - expires_at)))")
+	fi
+
+	printf 'CPSL XCFramework build lock is held (%s).\n' "$reason"
+	printf '  path:        %s\n' "$lock_path"
+	if [ -n "$lock_pid" ]; then
+		printf '  holder_pid:  %s (%s)\n' "$lock_pid" "$holder_state"
+	else
+		printf '  holder_pid:  unknown\n'
+	fi
+	printf '  status:      %s\n' "$expiry_clause"
+	printf '  auto-expire: locks are reclaimed after expiry or when the holder exits\n'
+	printf '  force unlock: rm -rf %s\n' "$lock_path"
+}
+
 cpsl_ensure_acquire_lock() {
 	lock_path=$1
+	max_age=$(cpsl_ensure_lock_max_age_seconds)
+	poll_seconds=$(cpsl_ensure_lock_poll_seconds)
+	log_interval=$(cpsl_ensure_lock_log_interval_seconds)
+	last_wait_log_at=0
 
 	mkdir -p "$(dirname "$lock_path")"
 
 	while ! mkdir "$lock_path" 2>/dev/null; do
-		lock_pid=
-		if [ -f "$lock_path/pid" ]; then
-			lock_pid=$(cat "$lock_path/pid" 2>/dev/null || printf '')
-		elif [ -f "$lock_path" ]; then
-			lock_pid=$(cat "$lock_path" 2>/dev/null || printf '')
+		now=$(date +%s)
+		lock_pid=$(cpsl_ensure_read_lock_pid "$lock_path" || true)
+		holder_alive=0
+		holder_state=unknown
+		if [ -n "$lock_pid" ]; then
+			if kill -0 "$lock_pid" 2>/dev/null; then
+				holder_alive=1
+				holder_state=alive
+			else
+				holder_state=dead
+			fi
 		fi
-		case "$lock_pid" in
-		'' | *[!0-9]*) lock_pid= ;;
-		esac
-		if [ -n "$lock_pid" ] && kill -0 "$lock_pid" 2>/dev/null; then
-			printf 'Waiting for CPSL XCFramework build lock held by PID %s: %s\n' "$lock_pid" "$lock_path"
-			sleep 5
+
+		expires_at=$(cpsl_ensure_read_lock_expires_at "$lock_path" "$max_age" 2>/dev/null) || expires_at=
+		if [ -z "$expires_at" ]; then
+			cpsl_ensure_remove_stale_lock "$lock_path" "unreadable metadata"
 			continue
 		fi
 
-		lock_mtime=$(cpsl_ensure_lock_mtime "$lock_path" 2>/dev/null) || continue
-		lock_age=$(($(date +%s) - lock_mtime))
-		if [ -n "$lock_pid" ] || [ "$lock_age" -ge 10 ]; then
-			if [ -d "$lock_path" ]; then
-				rm -f "$lock_path/pid"
-				rmdir "$lock_path" 2>/dev/null || true
+		# Dead / missing holder: reclaim immediately (no need to wait for expiry).
+		if [ "$holder_alive" -eq 0 ]; then
+			if [ -n "$lock_pid" ]; then
+				reason="holder pid $lock_pid is not running"
 			else
-				rm -f "$lock_path"
+				reason="no live holder pid"
 			fi
+			cpsl_ensure_log_lock_status \
+				"$lock_path" "$lock_pid" "$holder_state" "$expires_at" "$now" "$reason"
+			cpsl_ensure_remove_stale_lock "$lock_path" "$reason"
 			continue
 		fi
-		printf 'Waiting for CPSL XCFramework build lock: %s\n' "$lock_path"
-		sleep 5
+
+		# Live holder past the hard ceiling: steal so Xcode cannot hang forever.
+		if [ "$now" -ge "$expires_at" ]; then
+			reason="expired while held by live pid $lock_pid"
+			cpsl_ensure_log_lock_status \
+				"$lock_path" "$lock_pid" "$holder_state" "$expires_at" "$now" "$reason"
+			cpsl_ensure_remove_stale_lock "$lock_path" "$reason"
+			continue
+		fi
+
+		# Live holder still within the lease: wait, and re-log periodically.
+		if [ $((now - last_wait_log_at)) -ge "$log_interval" ] || [ "$last_wait_log_at" -eq 0 ]; then
+			cpsl_ensure_log_lock_status \
+				"$lock_path" \
+				"$lock_pid" \
+				"$holder_state" \
+				"$expires_at" \
+				"$now" \
+				"another CPSL build is in progress"
+			last_wait_log_at=$now
+		fi
+		sleep "$poll_seconds"
 	done
 
+	now=$(date +%s)
+	expires_at=$((now + max_age))
 	printf '%s\n' "$$" >"$lock_path/pid"
+	printf '%s\n' "$now" >"$lock_path/started_at"
+	printf '%s\n' "$expires_at" >"$lock_path/expires_at"
+	printf 'Acquired CPSL XCFramework build lock.\n'
+	printf '  path:        %s\n' "$lock_path"
+	printf '  holder_pid:  %s\n' "$$"
+	printf '  expires at:  %s (in %s)\n' \
+		"$(cpsl_ensure_format_unix_time "$expires_at")" \
+		"$(cpsl_ensure_format_duration "$max_age")"
+	printf '  force unlock: rm -rf %s\n' "$lock_path"
 	lock_owned=1
 }
 
 cpsl_ensure_release_lock() {
 	[ "${lock_owned:-0}" -eq 1 ] || return 0
-	rm -f "$lock_file/pid"
-	rmdir "$lock_file" 2>/dev/null || true
+	if [ -n "${lock_file:-}" ]; then
+		printf 'Released CPSL XCFramework build lock: %s\n' "$lock_file"
+		rm -rf "$lock_file"
+	fi
 	lock_owned=0
 }
 


### PR DESCRIPTION
## Summary
- Mark `CPSLFileEntry` and related helpers as `nonisolated` so Apple actor isolation warnings are resolved without changing runtime behavior.
- Harden the CPSL XCFramework build lock: explicit lease metadata (`started_at` / `expires_at`), reclaim dead holders and expired locks with `rm -rf`, tolerate iCloud/Finder renames of lock files, and reduce Xcode log spam while waiting.
- Refresh `MODULE.bazel.lock` to lockFileVersion 28.

## Test plan
- [ ] Build the Apple app and confirm main-actor / isolation warnings for `CPSLFileEntry` / calendar helpers are gone
- [ ] Run a CPSL XCFramework ensure/build and verify lock acquire/release logs and successful completion
- [ ] Simulate a stale lock (dead pid or leftover lock dir) and confirm the next build reclaims it instead of hanging
- [ ] Optionally set a short `CPSL_XCFRAMEWORK_LOCK_MAX_AGE_SECONDS` and confirm expired locks are reclaimed