### PR TITLE
Fix iCloud on-demand mounts, Bazel CPSL features, actor warnings, and build lock

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -176,8 +176,21 @@ rust_shared_library(
     name = "cpsl",
     srcs = glob(["external/cpsl/ffi/src/**/*.rs"]),
     compile_data = ["external/cpsl/runtime/shrt.luau"],
+    # rules_rust does not expand Cargo feature dependencies. List every
+    # cfg(feature = "...") the ffi crate checks — matching the Cargo
+    # `embedded-agent` expansion in external/cpsl/ffi/Cargo.toml. Without
+    # webbrowser/location/calendar/doc/pdfium-render here, host gateways never
+    # compile in and those Luau modules stay unregistered.
     crate_features = select({
-        ":cpsl_apple_app_profile": ["embedded-agent"],
+        ":cpsl_apple_app_profile": [
+            "embedded-agent",
+            "ffi-minimal",
+            "calendar",
+            "doc",
+            "location",
+            "pdfium-render",
+            "webbrowser",
+        ],
         "//conditions:default": ["ffi-minimal"],
     }),
     crate_name = "cpsl",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1,5 +1,5 @@
 {
-  "lockFileVersion": 26,
+  "lockFileVersion": 28,
   "registryFileHashes": {
     "https://bcr.bazel.build/bazel_registry.json": "8a28e4aff06ee60aed2a8c281907fb8bcbf3b753c91fb5a5c57da3215d5b3497",
     "https://bcr.bazel.build/modules/abseil-cpp/20210324.2/MODULE.bazel": "7cd0312e064fde87c8d1cd79ba06c876bd23630c83466e9500321be55c96ace2",
@@ -220,7 +220,7 @@
   "moduleExtensions": {
     "@@pybind11_bazel+//:internal_configure.bzl%internal_configure_extension": {
       "general": {
-        "bzlTransitiveDigest": "b+RP7Sgl8KN0VHamrgTqzGLuYPcQ/Mo4ptNkkHUIIlA=",
+        "bzlTransitiveDigest": "NRXra7941UfmNUyIxnLt82V5hULluVGL2nBsijTl4j4=",
         "usagesDigest": "D1r3lfzMuUBFxgG8V6o0bQTLMk3GkaGOaPzw53wrwyw=",
         "recordedInputs": [
           "REPO_MAPPING:pybind11_bazel+,bazel_tools bazel_tools",
@@ -242,7 +242,7 @@
     },
     "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
       "general": {
-        "bzlTransitiveDigest": "Ga4z8lQy1YQ5rAMy+dOl0dqcCEBnYNCXku8x3YQmDZI=",
+        "bzlTransitiveDigest": "+Kp6j204mBZ3mxlIDDR0gBoP45BZ4jYRhRAcB8sU0qc=",
         "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
         "recordedInputs": [
           "REPO_MAPPING:rules_kotlin+,bazel_tools bazel_tools"
@@ -299,7 +299,7 @@
     },
     "@@rules_python+//python/extensions:config.bzl%config": {
       "general": {
-        "bzlTransitiveDigest": "iibnRYgg8LpcfmH7EAnVwYePC3jsVaJ6Id8XxUjSZps=",
+        "bzlTransitiveDigest": "dzD8Q2YmrP3fz8saWLHPmlwPLO91ImtTmP/c9JKTStM=",
         "usagesDigest": "ZVSXMAGpD+xzVNPuvF1IoLBkty7TROO0+akMapt1pAg=",
         "recordedInputs": [
           "REPO_MAPPING:rules_python+,bazel_tools bazel_tools",
@@ -497,7 +497,7 @@
     },
     "@@rules_rust+//crate_universe:extensions.bzl%crate": {
       "general": {
-        "bzlTransitiveDigest": "b4+RYpkdcNTH+KdD9JtSZbAiz3JrqHUili7nrw3BL10=",
+        "bzlTransitiveDigest": "4e0uNkFgykXeLgcLZkqWKJbzzSSYqEPlPhfMFR3V4Mw=",
         "usagesDigest": "uUJ6JCurEVGCqQlvBaKy4CPyh8eYHklmkPPtkoBqo7w=",
         "recordedInputs": [
           "ENV:CARGO_BAZEL_DEBUG \\0",
@@ -8333,7 +8333,7 @@
     },
     "@@rules_rust+//crate_universe/private:internal_extensions.bzl%cu_nr": {
       "general": {
-        "bzlTransitiveDigest": "N5252EBbxPruGUNdjDIzrwyJOwTCjPLemyYCFUqkBls=",
+        "bzlTransitiveDigest": "ZLrOFxQ1TjxuMwCWZ7fYB8ufl3TF6YUTiA7tuMIOmXA=",
         "usagesDigest": "cXwM8V1dYpvU0qY6LVYuUUf4Ql389ZhymEzwJhYVr2o=",
         "recordedInputs": [
           "REPO_MAPPING:apple_support+,bazel_skylib bazel_skylib+",
@@ -8759,5 +8759,6 @@
         ]
       }
     }
-  }
+  },
+  "factsVersions": {}
 }

--- a/app/apple/herm/Models/CPSLChatModel.swift
+++ b/app/apple/herm/Models/CPSLChatModel.swift
@@ -50,7 +50,10 @@ final class CPSLChatModel {
     private(set) var isLocationOpen = false
     private(set) var isLocationActivityActive = false
     private(set) var iCloudMounts: [CPSLICloudMount] = []
-    private(set) var isUpdatingICloudMounts = true
+    /// True only while the user is actively connecting/removing a mount — not during launch prepare.
+    private(set) var isUpdatingICloudMounts = false
+    /// True until the first conversation store load attempt finishes (success or failure).
+    private(set) var isLoadingConversations = true
     private(set) var iCloudImportProgress: CPSLICloudImportProgress?
     private(set) var allTags: [CPSLTag] = []
     var searchText: String = ""
@@ -58,7 +61,20 @@ final class CPSLChatModel {
     private(set) var showingArchived = false
 
     var isBusy: Bool {
+        // Launch mount prepare does not lock chat; only active mutations do.
         isRunning || isUpdatingICloudMounts || isManagingFiles
+    }
+
+    var conversationListPresentation: CPSLConversationListPresentation {
+        let isSearching = !searchText.trimmingCharacters(in: .whitespaces).isEmpty
+            || !activeTagIDs.isEmpty
+        // Use filtered section emptiness so text search with zero hits shows "No matches".
+        return .resolve(
+            isLoading: isLoadingConversations,
+            isSearching: isSearching,
+            showingArchived: showingArchived,
+            hasVisibleConversations: !sectionGroups.isEmpty
+        )
     }
 
     let service: CPSLDebugService
@@ -953,7 +969,7 @@ final class CPSLChatModel {
 
     func importICloudDirectory(
         _ url: URL,
-        accessMode: CPSLICloudMountAccessMode
+        accessMode: CPSLICloudMountAccessMode = .readWrite
     ) {
         guard !isBusy else {
             fileBrowserError = "Wait for the current operation to finish before adding an iCloud folder."
@@ -990,6 +1006,50 @@ final class CPSLChatModel {
                 return
             } catch {
                 self?.fileBrowserError = "iCloud: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    func setICloudMountAccessMode(
+        _ accessMode: CPSLICloudMountAccessMode,
+        at path: String
+    ) {
+        guard !isBusy else {
+            fileBrowserError = "Wait for the current operation to finish before changing access."
+            return
+        }
+        fileBrowserError = nil
+        isUpdatingICloudMounts = true
+        Task {
+            defer { isUpdatingICloudMounts = false }
+            do {
+                try await service.setICloudMountAccessMode(accessMode, at: path)
+                iCloudMounts = await service.activeICloudMounts()
+                if isFileBrowserOpen {
+                    loadBrowserPath(browserPath)
+                }
+            } catch {
+                fileBrowserError = "iCloud: \(error.localizedDescription)"
+            }
+        }
+    }
+
+    func setKeepDownloaded(_ keep: Bool, at path: String) {
+        guard !isBusy else {
+            fileBrowserError = "Wait for the current operation to finish before changing download state."
+            return
+        }
+        fileBrowserError = nil
+        isUpdatingICloudMounts = true
+        Task {
+            defer { isUpdatingICloudMounts = false }
+            do {
+                try await service.setKeepDownloaded(keep, at: path)
+                if isFileBrowserOpen {
+                    loadBrowserPath(browserPath)
+                }
+            } catch {
+                fileBrowserError = "iCloud: \(error.localizedDescription)"
             }
         }
     }
@@ -1157,6 +1217,16 @@ final class CPSLChatModel {
     }
 
     private func bootstrap() async {
+        // Conversations and mounts load in parallel — neither waits on the other.
+        async let mountsReady: Void = prepareMountsAndSandbox()
+        async let conversationsReady: Void = loadConversationsAtLaunch()
+        _ = await (mountsReady, conversationsReady)
+        if selectedConversationID == nil, messages.isEmpty, let first = conversations.first {
+            await loadConversation(id: first.id)
+        }
+    }
+
+    private func prepareMountsAndSandbox() async {
         do {
             iCloudMounts = try await service.prepareICloudMounts()
         } catch {
@@ -1169,11 +1239,11 @@ final class CPSLChatModel {
         } catch {
             appendErrorMessage(title: "Files", body: error.localizedDescription)
         }
-        isUpdatingICloudMounts = false
+    }
+
+    private func loadConversationsAtLaunch() async {
+        defer { isLoadingConversations = false }
         await reloadConversations()
-        if selectedConversationID == nil, messages.isEmpty, let first = conversations.first {
-            await loadConversation(id: first.id)
-        }
     }
 
     private func loadStore() async throws -> CPSLConversationStore {

--- a/app/apple/herm/Models/CPSLConversationListPresentation.swift
+++ b/app/apple/herm/Models/CPSLConversationListPresentation.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Pure drawer presentation for conversation list readiness vs true-empty states.
+nonisolated enum CPSLConversationListPresentation: Equatable, Sendable {
+    case loading
+    case emptySearch
+    case emptyArchived
+    case emptyFresh
+    case populated
+
+    /// - Parameter hasVisibleConversations: Whether the *filtered* list (search/tags)
+    ///   has rows to show — not the raw store count. Empty search hits must report false.
+    static func resolve(
+        isLoading: Bool,
+        isSearching: Bool,
+        showingArchived: Bool,
+        hasVisibleConversations: Bool
+    ) -> CPSLConversationListPresentation {
+        if hasVisibleConversations {
+            return .populated
+        }
+        if isLoading {
+            return .loading
+        }
+        if isSearching {
+            return .emptySearch
+        }
+        if showingArchived {
+            return .emptyArchived
+        }
+        return .emptyFresh
+    }
+
+    /// Title shown for empty/loading panes. Nil when the list is populated.
+    var title: String? {
+        switch self {
+        case .loading:
+            return "Loading conversations"
+        case .emptySearch:
+            return "No matches"
+        case .emptyArchived:
+            return "Nothing archived"
+        case .emptyFresh:
+            return "No conversations yet"
+        case .populated:
+            return nil
+        }
+    }
+}

--- a/app/apple/herm/Models/CPSLTypes.swift
+++ b/app/apple/herm/Models/CPSLTypes.swift
@@ -209,6 +209,20 @@ struct CPSLFileEntry: Identifiable, Equatable, Sendable {
     let name: String
     let path: String
     let isDirectory: Bool
+    /// Set for entries under iCloud mounts when sync metadata is available.
+    let syncState: CPSLFileSyncState?
+
+    init(
+        name: String,
+        path: String,
+        isDirectory: Bool,
+        syncState: CPSLFileSyncState? = nil
+    ) {
+        self.name = name
+        self.path = path
+        self.isDirectory = isDirectory
+        self.syncState = syncState
+    }
 }
 
 struct CPSLDirectoryListing: Sendable {

--- a/app/apple/herm/Models/CPSLTypes.swift
+++ b/app/apple/herm/Models/CPSLTypes.swift
@@ -203,7 +203,7 @@ nonisolated final class CPSLFileActivityNotifier: @unchecked Sendable {
     }
 }
 
-struct CPSLFileEntry: Identifiable, Equatable, Sendable {
+nonisolated struct CPSLFileEntry: Identifiable, Equatable, Sendable {
     var id: String { path }
 
     let name: String
@@ -212,7 +212,7 @@ struct CPSLFileEntry: Identifiable, Equatable, Sendable {
     /// Set for entries under iCloud mounts when sync metadata is available.
     let syncState: CPSLFileSyncState?
 
-    init(
+    nonisolated init(
         name: String,
         path: String,
         isDirectory: Bool,

--- a/app/apple/herm/Services/CPSLCalendarService.swift
+++ b/app/apple/herm/Services/CPSLCalendarService.swift
@@ -328,7 +328,7 @@ final class CPSLCalendarService: ObservableObject {
 }
 
 private extension String {
-    var cpslNilIfEmpty: String? {
+    nonisolated var cpslNilIfEmpty: String? {
         isEmpty ? nil : self
     }
 }

--- a/app/apple/herm/Services/CPSLDebugService.swift
+++ b/app/apple/herm/Services/CPSLDebugService.swift
@@ -714,8 +714,16 @@ actor CPSLDebugService {
             self.sandboxURLs = sandboxURLs
             let normalizedPath = Self.normalizedVirtualPath(virtualPath)
             if normalizedPath == CPSLVirtualPath.iCloudRoot {
-                let entries = try ensureICloudMountManager().mounts.map {
-                    CPSLFileEntry(name: $0.label, path: $0.virtualPath, isDirectory: true)
+                let manager = try ensureICloudMountManager()
+                let entries = manager.mounts.map {
+                    CPSLFileEntry(
+                        name: $0.label,
+                        path: $0.virtualPath,
+                        isDirectory: true,
+                        syncState: manager.isKeepDownloaded($0.virtualPath)
+                            ? .keepDownloaded
+                            : nil
+                    )
                 }
                 return CPSLDirectoryListing(entries: entries, error: nil)
             }
@@ -727,17 +735,35 @@ actor CPSLDebugService {
             }
 
             let fileManager = FileManager.default
+            var resourceKeys: [URLResourceKey] = [.isDirectoryKey, .fileSizeKey]
+#if canImport(Darwin)
+            resourceKeys.append(contentsOf: [
+                .isUbiquitousItemKey,
+                .ubiquitousItemDownloadingStatusKey,
+            ])
+#endif
             let urls = try fileManager.contentsOfDirectory(
                 at: hostURL,
-                includingPropertiesForKeys: [.isDirectoryKey],
+                includingPropertiesForKeys: resourceKeys,
                 options: []
             )
+            let manager = try? ensureICloudMountManager()
             let entries = try urls.map { url in
-                let values = try url.resourceValues(forKeys: [.isDirectoryKey])
+                let values = try url.resourceValues(forKeys: Set(resourceKeys))
+                let childPath = Self.virtualChildPath(
+                    parent: normalizedPath,
+                    child: url.lastPathComponent
+                )
+                let syncState = Self.syncState(
+                    for: values,
+                    virtualPath: childPath,
+                    manager: manager
+                )
                 return CPSLFileEntry(
                     name: url.lastPathComponent,
-                    path: Self.virtualChildPath(parent: normalizedPath, child: url.lastPathComponent),
-                    isDirectory: values.isDirectory == true
+                    path: childPath,
+                    isDirectory: values.isDirectory == true,
+                    syncState: syncState
                 )
             }
             .sorted { lhs, rhs in
@@ -745,6 +771,19 @@ actor CPSLDebugService {
                     return lhs.isDirectory
                 }
                 return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+            // Metadata listing only — never block navigation on downloads.
+            // Bounded small-file prefetch runs after the listing is returned.
+            if mountUseLease != nil, let manager {
+                let prefetchPath = normalizedPath
+                let prefetchURLs = urls
+                Task {
+                    guard let lease = try? manager.beginReadUse(for: prefetchPath) else {
+                        return
+                    }
+                    defer { lease.release() }
+                    try? manager.prefetchSmallCloudFiles(at: prefetchURLs)
+                }
             }
             fileActivityNotifier.notify(
                 CPSLFileActivity(path: normalizedPath, operation: "read")
@@ -769,15 +808,28 @@ actor CPSLDebugService {
             guard FileManager.default.fileExists(atPath: hostURL.path) else {
                 return CPSLFileEntryLookup(entry: nil, error: "File does not exist.")
             }
-            let values = try hostURL.resourceValues(forKeys: [.isDirectoryKey])
+            var resourceKeys: Set<URLResourceKey> = [.isDirectoryKey]
+#if canImport(Darwin)
+            resourceKeys.formUnion([
+                .isUbiquitousItemKey,
+                .ubiquitousItemDownloadingStatusKey,
+            ])
+#endif
+            let values = try hostURL.resourceValues(forKeys: resourceKeys)
             let name = normalizedPath == CPSLVirtualPath.root
                 ? CPSLVirtualPath.root
                 : hostURL.lastPathComponent
+            let manager = try? ensureICloudMountManager()
             return CPSLFileEntryLookup(
                 entry: CPSLFileEntry(
                     name: name,
                     path: normalizedPath,
-                    isDirectory: values.isDirectory == true
+                    isDirectory: values.isDirectory == true,
+                    syncState: Self.syncState(
+                        for: values,
+                        virtualPath: normalizedPath,
+                        manager: manager
+                    )
                 ),
                 error: nil
             )
@@ -1231,6 +1283,53 @@ actor CPSLDebugService {
         resetSessionIfMountRevisionChanged(to: iCloudMountManager.currentRevision)
     }
 
+    func setICloudMountAccessMode(
+        _ accessMode: CPSLICloudMountAccessMode,
+        at virtualPath: String
+    ) throws {
+        guard !isSessionBusy else {
+            throw CPSLICloudMountError.sessionBusy
+        }
+        let manager = try ensureICloudMountManager()
+        try manager.setAccessMode(
+            accessMode,
+            at: Self.normalizedVirtualPath(virtualPath)
+        )
+        resetSessionIfMountRevisionChanged(to: manager.currentRevision)
+    }
+
+    func setKeepDownloaded(
+        _ keep: Bool,
+        at virtualPath: String
+    ) async throws {
+        guard !isSessionBusy else {
+            throw CPSLICloudMountError.sessionBusy
+        }
+        try await ensureICloudMountManager().setKeepDownloaded(
+            keep,
+            at: Self.normalizedVirtualPath(virtualPath)
+        )
+    }
+
+    private nonisolated static func syncState(
+        for values: URLResourceValues,
+        virtualPath: String,
+        manager: CPSLICloudMountManager?
+    ) -> CPSLFileSyncState? {
+        let isPinned = manager?.isKeepDownloaded(virtualPath) == true
+#if canImport(Darwin)
+        let status = CPSLICloudSyncPolicy.downloadStatus(from: values)
+        return CPSLICloudSyncPolicy.syncState(
+            isUbiquitous: values.isUbiquitousItem,
+            downloadStatus: status,
+            isPinned: isPinned
+        )
+#else
+        _ = values
+        return isPinned ? .keepDownloaded : nil
+#endif
+    }
+
     func availableSkills() -> [CPSLAgentSkill] {
         let userRootURL: URL?
         do {
@@ -1267,7 +1366,8 @@ actor CPSLDebugService {
                 return Self.ffiFailure("An iCloud folder is already in use")
             }
             mountUseLease = lease
-            try await manager.materializeMountsForAccess()
+            // Pins only — never whole-tree hydrate every mount for an eval.
+            try await manager.materializePinnedContent()
         } catch is CancellationError {
             return Self.cancellationFailure()
         } catch {

--- a/app/apple/herm/Services/CPSLICloudFileMaterializer.swift
+++ b/app/apple/herm/Services/CPSLICloudFileMaterializer.swift
@@ -39,10 +39,119 @@ nonisolated struct CPSLICloudImportProgress: Equatable, Sendable {
     }
 }
 
+/// Ubiquitous item sync state shown in the file browser for iCloud mount entries.
+nonisolated enum CPSLFileSyncState: String, Equatable, Sendable {
+    /// Present in iCloud but not downloaded to this device.
+    case cloudOnly
+    /// Downloaded and available locally (OS may evict later).
+    case local
+    /// Explicitly pinned to stay downloaded on this device.
+    case keepDownloaded
+
+    var systemImageName: String {
+        switch self {
+        case .cloudOnly:
+            return "icloud"
+        case .local:
+            return "checkmark.icloud"
+        case .keepDownloaded:
+            return "pin.circle.fill"
+        }
+    }
+
+    var accessibilityLabel: String {
+        switch self {
+        case .cloudOnly:
+            return "In iCloud only"
+        case .local:
+            return "Downloaded"
+        case .keepDownloaded:
+            return "Keep downloaded"
+        }
+    }
+}
+
+/// Portable download status for pure sync-state classification (Darwin maps into this).
+nonisolated enum CPSLICloudDownloadStatus: Equatable, Sendable {
+    case notDownloaded
+    case downloaded
+    case current
+}
+
+/// Pure policy for ubiquitous sync badges and bounded small-file prefetch.
+nonisolated enum CPSLICloudSyncPolicy {
+    /// Max number of cloud-only files in one folder eligible for auto-prefetch.
+    static let smallPrefetchMaxFiles = 20
+    /// Max total size (bytes) of cloud-only files in one folder for auto-prefetch.
+    static let smallPrefetchMaxTotalBytes: Int64 = 256 * 1024
+    /// Max size of a single file included in auto-prefetch.
+    static let smallPrefetchMaxFileBytes: Int64 = 64 * 1024
+
+    /// Classify an item from resource values + Herm pin state.
+    static func syncState(
+        isUbiquitous: Bool?,
+        downloadStatus: CPSLICloudDownloadStatus?,
+        isPinned: Bool
+    ) -> CPSLFileSyncState? {
+        guard isUbiquitous == true else {
+            return nil
+        }
+        if isPinned {
+            return .keepDownloaded
+        }
+        switch downloadStatus {
+        case .current, .downloaded:
+            return .local
+        case .notDownloaded, .none:
+            return .cloudOnly
+        }
+    }
+
+    /// Whether a listed folder's cloud-only files are small/few enough to prefetch.
+    static func shouldPrefetchSmallCloudFiles(
+        fileCount: Int,
+        totalBytes: Int64
+    ) -> Bool {
+        fileCount > 0
+            && fileCount <= smallPrefetchMaxFiles
+            && totalBytes > 0
+            && totalBytes <= smallPrefetchMaxTotalBytes
+    }
+
+    static func isSmallPrefetchCandidate(fileBytes: Int64?) -> Bool {
+        guard let fileBytes, fileBytes >= 0 else {
+            return false
+        }
+        return fileBytes <= smallPrefetchMaxFileBytes
+    }
+
+#if canImport(Darwin)
+    static func downloadStatus(
+        from values: URLResourceValues
+    ) -> CPSLICloudDownloadStatus? {
+        guard values.isUbiquitousItem == true else {
+            return nil
+        }
+        switch values.ubiquitousItemDownloadingStatus {
+        case .current:
+            return .current
+        case .downloaded:
+            return .downloaded
+        case .notDownloaded:
+            return .notDownloaded
+        default:
+            return .notDownloaded
+        }
+    }
+#endif
+}
+
 nonisolated enum CPSLICloudFileMaterializer {
     private static let pollInterval: TimeInterval = 0.1
     private static let timeout: TimeInterval = 10 * 60
 
+    /// Whole-tree download used for explicit pin/keep-downloaded of a folder.
+    /// Not used on connect or every agent eval.
     static func materializeDirectory(
         at root: URL,
         materialize: @Sendable (URL) throws -> Void = {

--- a/app/apple/herm/Services/CPSLICloudMountManager.swift
+++ b/app/apple/herm/Services/CPSLICloudMountManager.swift
@@ -140,6 +140,8 @@ nonisolated final class CPSLICloudMountManager: @unchecked Sendable {
     private var storedMounts: [CPSLICloudMount] = []
     private var storedRecords: [CPSLICloudMountRecord] = []
     private var unavailableRecordSlugs: Set<String> = []
+    /// Virtual paths the user asked to keep downloaded (file or folder).
+    private var keepDownloadedPaths: Set<String> = []
     private var updateInProgress = false
     private var activeReaderCount = 0
     private var writerInProgress = false
@@ -209,6 +211,7 @@ nonisolated final class CPSLICloudMountManager: @unchecked Sendable {
         storedMounts = restoredMounts
         storedRecords = refreshedRecords
         unavailableRecordSlugs = unavailableSlugs
+        keepDownloadedPaths = (try? Self.loadKeepDownloadedPaths(from: storageRoot)) ?? []
         isPrepared = true
 
         if didMigrate {
@@ -235,6 +238,7 @@ nonisolated final class CPSLICloudMountManager: @unchecked Sendable {
             }
         }
         try Task.checkCancellation()
+        progress(.preparing)
 
         let scope = try CPSLICloudSecurityScope(url: sourceURL, access: bookmarkAccess)
         defer { scope.stop() }
@@ -242,11 +246,8 @@ nonisolated final class CPSLICloudMountManager: @unchecked Sendable {
         guard !mounts.contains(where: { Self.pathsOverlap($0.hostURL, sourceURL) }) else {
             throw CPSLICloudMountError.alreadyMounted
         }
-
-        try CPSLICloudFileMaterializer.materializeDirectory(
-            at: sourceURL,
-            progress: progress
-        )
+        // Download-on-demand: connect only persists the bookmark. Content is
+        // materialized when a specific path is opened, pinned, or prefetched.
         try Task.checkCancellation()
 
         let values = try sourceURL.resourceValues(forKeys: [.localizedNameKey])
@@ -299,14 +300,114 @@ nonisolated final class CPSLICloudMountManager: @unchecked Sendable {
 
         let updatedRecords = storedRecords.filter { $0.slug != mount.slug }
         let updatedMounts = mounts.filter { $0.slug != mount.slug }
+        let prunedPins = withLock {
+            keepDownloadedPaths.filter {
+                $0 != mount.virtualPath && !$0.hasPrefix("\(mount.virtualPath)/")
+            }
+        }
         try persist(updatedRecords)
+        try Self.saveKeepDownloadedPaths(prunedPins, to: storageRoot)
         withLock {
             storedRecords = updatedRecords
             storedMounts = updatedMounts
             unavailableRecordSlugs.remove(mount.slug)
+            keepDownloadedPaths = prunedPins
             revision &+= 1
         }
         didChangeMounts = true
+    }
+
+    func setAccessMode(
+        _ accessMode: CPSLICloudMountAccessMode,
+        at virtualPath: String
+    ) throws {
+        guard beginUpdate() else {
+            throw CPSLICloudMountError.sessionBusy
+        }
+        var didChangeMounts = false
+        defer {
+            finishUpdate()
+            if didChangeMounts {
+                notifyMountsChanged()
+            }
+        }
+        guard let index = storedMounts.firstIndex(where: { $0.virtualPath == virtualPath }),
+              let recordIndex = storedRecords.firstIndex(where: {
+                  $0.slug == storedMounts[index].slug
+              })
+        else {
+            throw CPSLICloudMountError.mountNotFound
+        }
+        let mount = storedMounts[index]
+        guard mount.accessMode != accessMode else {
+            return
+        }
+        let scope = try CPSLICloudSecurityScope(url: mount.hostURL, access: bookmarkAccess)
+        defer { scope.stop() }
+        try validateSource(mount.hostURL, accessMode: accessMode)
+        let bookmarkData = try bookmarkAccess.create(mount.hostURL, accessMode)
+        var updatedRecords = storedRecords
+        updatedRecords[recordIndex] = CPSLICloudMountRecord(
+            label: mount.label,
+            slug: mount.slug,
+            accessMode: accessMode,
+            bookmarkData: bookmarkData
+        )
+        var updatedMounts = storedMounts
+        updatedMounts[index] = CPSLICloudMount(
+            label: mount.label,
+            slug: mount.slug,
+            hostURL: mount.hostURL,
+            accessMode: accessMode
+        )
+        try persist(updatedRecords)
+        withLock {
+            storedRecords = updatedRecords
+            storedMounts = updatedMounts
+            revision &+= 1
+        }
+        didChangeMounts = true
+    }
+
+    func isKeepDownloaded(_ normalizedVirtualPath: String) -> Bool {
+        withLock {
+            keepDownloadedPaths.contains { pin in
+                normalizedVirtualPath == pin || normalizedVirtualPath.hasPrefix("\(pin)/")
+            }
+        }
+    }
+
+    func setKeepDownloaded(
+        _ keep: Bool,
+        at normalizedVirtualPath: String
+    ) async throws {
+        guard beginUpdate() else {
+            throw CPSLICloudMountError.sessionBusy
+        }
+        defer { finishUpdate() }
+        guard let url = hostURL(for: normalizedVirtualPath) else {
+            throw CPSLICloudMountError.mountNotFound
+        }
+        let scope = try CPSLICloudSecurityScope(url: url, access: bookmarkAccess)
+        defer { scope.stop() }
+
+        var pins = withLock { keepDownloadedPaths }
+        if keep {
+            pins.insert(normalizedVirtualPath)
+            let values = try url.resourceValues(forKeys: [.isDirectoryKey])
+            if values.isDirectory == true {
+                try CPSLICloudFileMaterializer.materializeDirectory(at: url)
+            } else {
+                try CPSLICloudFileMaterializer.materializeUbiquitousFile(url)
+            }
+        } else {
+            pins.remove(normalizedVirtualPath)
+#if canImport(Darwin)
+            try? fileManager.evictUbiquitousItem(at: url)
+#endif
+        }
+        try Self.saveKeepDownloadedPaths(pins, to: storageRoot)
+        withLock { keepDownloadedPaths = pins }
     }
 
     func beginSessionUse() throws -> CPSLICloudMountUseLease? {
@@ -319,10 +420,20 @@ nonisolated final class CPSLICloudMountManager: @unchecked Sendable {
         try beginUse(isReadOnlyUse: true, scopedVirtualPath: scopedVirtualPath)
     }
 
-    func materializeMountsForAccess() async throws {
-        for mount in mounts {
+    /// Materialize only paths the user pinned to keep downloaded (not whole mounts).
+    func materializePinnedContent() async throws {
+        let pins = withLock { keepDownloadedPaths }
+        for path in pins.sorted() {
             try Task.checkCancellation()
-            try CPSLICloudFileMaterializer.materializeDirectory(at: mount.hostURL)
+            guard let url = hostURL(for: path) else {
+                continue
+            }
+            let values = try url.resourceValues(forKeys: [.isDirectoryKey])
+            if values.isDirectory == true {
+                try CPSLICloudFileMaterializer.materializeDirectory(at: url)
+            } else {
+                try CPSLICloudFileMaterializer.materializeUbiquitousFile(url)
+            }
         }
     }
 
@@ -331,6 +442,57 @@ nonisolated final class CPSLICloudMountManager: @unchecked Sendable {
             throw CPSLICloudMountError.mountNotFound
         }
         try CPSLICloudFileMaterializer.materializeUbiquitousFile(url)
+    }
+
+    /// Bounded same-folder prefetch of tiny cloud-only files after a listing.
+    func prefetchSmallCloudFiles(at hostURLs: [URL]) throws {
+        guard !hostURLs.isEmpty else {
+            return
+        }
+        var candidates: [(URL, Int64)] = []
+        var total: Int64 = 0
+        for url in hostURLs {
+#if canImport(Darwin)
+            let values = try url.resourceValues(forKeys: [
+                .isDirectoryKey,
+                .fileSizeKey,
+                .isUbiquitousItemKey,
+                .ubiquitousItemDownloadingStatusKey,
+            ])
+            guard values.isDirectory != true else {
+                continue
+            }
+            let status = CPSLICloudSyncPolicy.downloadStatus(from: values)
+            let state = CPSLICloudSyncPolicy.syncState(
+                isUbiquitous: values.isUbiquitousItem,
+                downloadStatus: status,
+                isPinned: false
+            )
+            guard state == .cloudOnly,
+                  CPSLICloudSyncPolicy.isSmallPrefetchCandidate(
+                      fileBytes: Int64(values.fileSize ?? -1)
+                  )
+            else {
+                continue
+            }
+            let size = Int64(values.fileSize ?? 0)
+            candidates.append((url, size))
+            total += size
+#else
+            _ = url
+#endif
+        }
+#if canImport(Darwin)
+        guard CPSLICloudSyncPolicy.shouldPrefetchSmallCloudFiles(
+            fileCount: candidates.count,
+            totalBytes: total
+        ) else {
+            return
+        }
+        for (url, _) in candidates {
+            try CPSLICloudFileMaterializer.materializeUbiquitousFile(url)
+        }
+#endif
     }
 
     func containsHostURL(_ url: URL) -> Bool {
@@ -453,6 +615,33 @@ nonisolated final class CPSLICloudMountManager: @unchecked Sendable {
             to: storageRoot,
             fileManager: fileManager
         )
+    }
+
+    private static let keepDownloadedFileName = "keep-downloaded.json"
+
+    private static func loadKeepDownloadedPaths(
+        from storageRoot: URL
+    ) throws -> Set<String> {
+        let url = storageRoot.appendingPathComponent(keepDownloadedFileName)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return []
+        }
+        let data = try Data(contentsOf: url)
+        let paths = try JSONDecoder().decode([String].self, from: data)
+        return Set(paths)
+    }
+
+    private static func saveKeepDownloadedPaths(
+        _ paths: Set<String>,
+        to storageRoot: URL
+    ) throws {
+        try FileManager.default.createDirectory(
+            at: storageRoot,
+            withIntermediateDirectories: true
+        )
+        let url = storageRoot.appendingPathComponent(keepDownloadedFileName)
+        let data = try JSONEncoder().encode(paths.sorted())
+        try data.write(to: url, options: .atomic)
     }
 
     private func uniqueMountSlug(for label: String) -> String {

--- a/app/apple/herm/Views/Chat/CPSLConversationDrawerView.swift
+++ b/app/apple/herm/Views/Chat/CPSLConversationDrawerView.swift
@@ -271,34 +271,30 @@ private struct CPSLConversationListView: View {
     @Binding var tagSheetConversationID: String?
     @Binding var renamingConversation: CPSLConversationSummary?
 
-    private var isSearching: Bool {
-        !model.searchText.trimmingCharacters(in: .whitespaces).isEmpty || !model.activeTagIDs.isEmpty
-    }
-
     var body: some View {
         let groups = model.sectionGroups
-        if groups.isEmpty {
-            emptyState
-        } else {
+        switch model.conversationListPresentation {
+        case .populated:
             list(groups)
-        }
-    }
-
-    @ViewBuilder
-    private var emptyState: some View {
-        if isSearching {
+        case .loading:
+            CPSLDrawerEmptyState(
+                art: { ProgressView() },
+                title: CPSLConversationListPresentation.loading.title ?? "Loading conversations",
+                message: "Restoring chats from storage…"
+            )
+        case .emptySearch:
             CPSLDrawerEmptyState(
                 art: { CPSLDrawerEmptyArt.logo },
                 title: "No matches",
                 message: "Try a different search, or clear the filter."
             )
-        } else if model.showingArchived {
+        case .emptyArchived:
             CPSLDrawerEmptyState(
                 art: { CPSLDrawerEmptyArt.symbol("archivebox") },
                 title: "Nothing archived",
                 message: "Conversations you archive will show up here."
             )
-        } else {
+        case .emptyFresh:
             CPSLDrawerEmptyState(
                 art: { CPSLDrawerEmptyArt.logo },
                 title: "No conversations yet",

--- a/app/apple/herm/Views/Files/CPSLFileBrowserView.swift
+++ b/app/apple/herm/Views/Files/CPSLFileBrowserView.swift
@@ -181,9 +181,6 @@ struct CPSLFileBrowserView: View {
     let model: CPSLChatModel
     @State private var isICloudImporterPresented = false
     @State private var isICloudImporterPending = false
-    @State private var isICloudAccessModePickerPresented = false
-    @State private var isICloudAccessModePickerPending = false
-    @State private var selectedICloudDirectory: URL?
     @State private var isSelectingFiles = false
     @State private var selectedEntriesByPath: [String: CPSLFileEntry] = [:]
     @State private var movingEntries: [CPSLFileEntry] = []
@@ -200,36 +197,15 @@ struct CPSLFileBrowserView: View {
                 switch result {
                 case .success(let urls):
                     if let url = urls.first {
-                        selectedICloudDirectory = url
-                        isICloudAccessModePickerPending = true
-                        presentICloudAccessModePickerIfReady()
+                        // Herm policy default: read-write. Mode can be changed on the mount later.
+                        model.importICloudDirectory(url, accessMode: .readWrite)
                     }
                 case .failure(let error):
                     model.reportICloudImportError(error)
                 }
             }
-            .confirmationDialog(
-                "iCloud Folder Access",
-                isPresented: $isICloudAccessModePickerPresented,
-                titleVisibility: .visible
-            ) {
-                Button("Read Only") {
-                    chooseICloudAccessMode(.readOnly)
-                }
-                Button("Read & Write") {
-                    chooseICloudAccessMode(.readWrite)
-                }
-                Button("Cancel", role: .cancel) {
-                    selectedICloudDirectory = nil
-                }
-            } message: {
-                Text(
-                    "Read Only prevents Herm from changing the folder. Read & Write lets Herm add, edit, and delete files in the selected folder; iCloud Drive syncs those changes."
-                )
-            }
             .onChange(of: model.dictation.isActive) { _, isActive in
                 if !isActive {
-                    presentICloudAccessModePickerIfReady()
                     presentICloudImporterIfReady()
                 }
             }
@@ -352,25 +328,6 @@ struct CPSLFileBrowserView: View {
         isICloudImporterPending = true
         model.dictation.finish()
         presentICloudImporterIfReady()
-    }
-
-    private func presentICloudAccessModePickerIfReady() {
-        guard isICloudAccessModePickerPending, !model.dictation.isActive else {
-            return
-        }
-        isICloudAccessModePickerPending = false
-        isICloudAccessModePickerPresented = true
-    }
-
-    private func chooseICloudAccessMode(_ accessMode: CPSLICloudMountAccessMode) {
-        guard let selectedICloudDirectory else {
-            return
-        }
-        self.selectedICloudDirectory = nil
-        model.importICloudDirectory(
-            selectedICloudDirectory,
-            accessMode: accessMode
-        )
     }
 
     private func presentICloudImporterIfReady() {
@@ -662,6 +619,17 @@ private struct CPSLFileBrowserActions {
 
     func removeICloudMount(_ entry: CPSLFileEntry) {
         model.removeICloudMount(entry)
+    }
+
+    func setICloudAccessMode(
+        _ accessMode: CPSLICloudMountAccessMode,
+        at path: String
+    ) {
+        model.setICloudMountAccessMode(accessMode, at: path)
+    }
+
+    func setKeepDownloaded(_ keep: Bool, at path: String) {
+        model.setKeepDownloaded(keep, at: path)
     }
 
     func showComingSoon(_ message: String) {
@@ -1403,7 +1371,9 @@ private struct CPSLFileBrowserRowView: View {
                     onDelete: {
                         actions.requestDelete([entry])
                     },
-                    onRemove: iCloudMountRemoval(for: entry)
+                    onRemove: iCloudMountRemoval(for: entry),
+                    onSetAccessMode: iCloudMountAccessModeSetter(for: entry),
+                    onSetKeepDownloaded: iCloudKeepDownloadedSetter(for: entry)
                 )
             case .loading(_, let depth):
                 CPSLInlineFileLoadingView(depth: depth)
@@ -1429,6 +1399,36 @@ private struct CPSLFileBrowserRowView: View {
     ) -> CPSLICloudMountAccessMode? {
         actions.iCloudMounts.first { $0.virtualPath == entry.path }?.accessMode
     }
+
+    private func iCloudMountAccessModeSetter(
+        for entry: CPSLFileEntry
+    ) -> ((CPSLICloudMountAccessMode) -> Void)? {
+        guard isICloudMountEntry(entry) else {
+            return nil
+        }
+        return { mode in
+            actions.setICloudAccessMode(mode, at: entry.path)
+        }
+    }
+
+    private func iCloudKeepDownloadedSetter(
+        for entry: CPSLFileEntry
+    ) -> ((Bool) -> Void)? {
+        guard !actions.isBusy else {
+            return nil
+        }
+        // Mount roots and any path under a connected mount can be pinned.
+        let underMount = actions.iCloudMounts.contains { mount in
+            entry.path == mount.virtualPath
+                || entry.path.hasPrefix("\(mount.virtualPath)/")
+        }
+        guard underMount else {
+            return nil
+        }
+        return { keep in
+            actions.setKeepDownloaded(keep, at: entry.path)
+        }
+    }
 }
 
 private struct CPSLFileRowView: View {
@@ -1445,6 +1445,8 @@ private struct CPSLFileRowView: View {
     let onMove: () -> Void
     let onDelete: () -> Void
     let onRemove: (() -> Void)?
+    let onSetAccessMode: ((CPSLICloudMountAccessMode) -> Void)?
+    let onSetKeepDownloaded: ((Bool) -> Void)?
 
     var body: some View {
         HStack(spacing: CPSLTheme.small) {
@@ -1473,6 +1475,10 @@ private struct CPSLFileRowView: View {
                         CPSLFileReadOnlyBadge()
                     }
 
+                    if let syncState = entry.syncState {
+                        CPSLFileSyncStateBadge(state: syncState)
+                    }
+
                     Spacer()
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -1483,15 +1489,53 @@ private struct CPSLFileRowView: View {
             .disabled(isMoving && !entry.isDirectory)
 
             if case .browsing = mode, let onRemove {
-                Button(action: onRemove) {
-                    Image(systemName: "eject.fill")
+                Menu {
+                    if let accessMode, let onSetAccessMode {
+                        if accessMode == .readWrite {
+                            Button("Make Read Only") {
+                                onSetAccessMode(.readOnly)
+                            }
+                        } else {
+                            Button("Make Read & Write") {
+                                onSetAccessMode(.readWrite)
+                            }
+                        }
+                    }
+                    if let onSetKeepDownloaded {
+                        if entry.syncState != .keepDownloaded {
+                            Button {
+                                onSetKeepDownloaded(true)
+                            } label: {
+                                Label("Keep Downloaded", systemImage: "pin.circle")
+                            }
+                        }
+                        if entry.syncState == .keepDownloaded {
+                            Button {
+                                onSetKeepDownloaded(false)
+                            } label: {
+                                Label("Remove Download", systemImage: "icloud")
+                            }
+                        }
+                    }
+                    Button(role: .destructive, action: onRemove) {
+                        Label("Disconnect", systemImage: "eject.fill")
+                    }
+                } label: {
+                    Image(systemName: "ellipsis")
                         .font(CPSLTheme.iconSmallFont)
                         .frame(width: CPSLTheme.controlSize, height: CPSLTheme.controlSize)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .foregroundStyle(CPSLTheme.secondaryText)
-                .accessibilityLabel(Text("Unmount iCloud Folder"))
+                .accessibilityLabel(Text("iCloud Folder Actions"))
+            } else if case .browsing = mode, let onSetKeepDownloaded {
+                CPSLFileICloudActionMenu(
+                    syncState: entry.syncState,
+                    onMove: canModify ? onMove : nil,
+                    onDelete: canModify ? onDelete : nil,
+                    onSetKeepDownloaded: onSetKeepDownloaded
+                )
             } else if case .browsing = mode, canModify {
                 CPSLFileActionMenu(onMove: onMove, onDelete: onDelete)
             }
@@ -1559,6 +1603,61 @@ private struct CPSLFileActionMenu: View {
             }
             Button(role: .destructive, action: onDelete) {
                 Label("Delete", systemImage: "trash")
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(CPSLTheme.iconSmallFont)
+                .frame(width: CPSLTheme.controlSize, height: CPSLTheme.controlSize)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(CPSLTheme.secondaryText)
+        .accessibilityLabel("File actions")
+    }
+}
+
+private struct CPSLFileSyncStateBadge: View {
+    let state: CPSLFileSyncState
+
+    var body: some View {
+        Image(systemName: state.systemImageName)
+            .font(CPSLTheme.iconFont(size: CPSLTheme.FontSize.caption, weight: .semibold))
+            .foregroundStyle(CPSLTheme.secondaryText)
+            .accessibilityLabel(Text(state.accessibilityLabel))
+    }
+}
+
+private struct CPSLFileICloudActionMenu: View {
+    let syncState: CPSLFileSyncState?
+    let onMove: (() -> Void)?
+    let onDelete: (() -> Void)?
+    let onSetKeepDownloaded: (Bool) -> Void
+
+    var body: some View {
+        Menu {
+            if syncState != .keepDownloaded {
+                Button {
+                    onSetKeepDownloaded(true)
+                } label: {
+                    Label("Keep Downloaded", systemImage: "pin.circle")
+                }
+            }
+            if syncState == .keepDownloaded || syncState == .local {
+                Button {
+                    onSetKeepDownloaded(false)
+                } label: {
+                    Label("Remove Download", systemImage: "icloud")
+                }
+            }
+            if let onMove {
+                Button(action: onMove) {
+                    Label("Move…", systemImage: "folder")
+                }
+            }
+            if let onDelete {
+                Button(role: .destructive, action: onDelete) {
+                    Label("Delete", systemImage: "trash")
+                }
             }
         } label: {
             Image(systemName: "ellipsis")

--- a/app/apple/hermTests/CPSLConversationBrowsingTests.swift
+++ b/app/apple/hermTests/CPSLConversationBrowsingTests.swift
@@ -58,4 +58,45 @@ struct CPSLConversationBrowsingTests {
         let ids = groups.flatMap { $0.conversations.map(\.id) }
         #expect(ids == ["a"])
     }
+
+    @Test func loadingPresentationAvoidsFalseEmpty() {
+        let loading = CPSLConversationListPresentation.resolve(
+            isLoading: true,
+            isSearching: false,
+            showingArchived: false,
+            hasVisibleConversations: false
+        )
+        #expect(loading == .loading)
+        #expect(loading.title == "Loading conversations")
+        #expect(loading.title != "No conversations yet")
+
+        let readyWithData = CPSLConversationListPresentation.resolve(
+            isLoading: true,
+            isSearching: false,
+            showingArchived: false,
+            hasVisibleConversations: true
+        )
+        #expect(readyWithData == .populated)
+
+        let trueEmpty = CPSLConversationListPresentation.resolve(
+            isLoading: false,
+            isSearching: false,
+            showingArchived: false,
+            hasVisibleConversations: false
+        )
+        #expect(trueEmpty == .emptyFresh)
+        #expect(trueEmpty.title == "No conversations yet")
+    }
+
+    @Test func searchWithZeroVisibleHitsShowsNoMatches() {
+        // Store may have conversations; filtered groups empty → emptySearch.
+        let noMatches = CPSLConversationListPresentation.resolve(
+            isLoading: false,
+            isSearching: true,
+            showingArchived: false,
+            hasVisibleConversations: false
+        )
+        #expect(noMatches == .emptySearch)
+        #expect(noMatches.title == "No matches")
+    }
 }

--- a/docs/BAZEL_EXPERIMENT.md
+++ b/docs/BAZEL_EXPERIMENT.md
@@ -15,6 +15,13 @@ profiles. The Apple wrapper builds it once per requested target platform,
 combines architecture slices where necessary, stages PDFium, and uses
 `xcodebuild -create-xcframework` for the final package.
 
+rules_rust does **not** expand Cargo feature dependencies. The Apple app
+profile therefore lists the full `embedded-agent` feature set on the ffi crate
+(`webbrowser`, `location`, `calendar`, `doc`, `pdfium-render`, …) in addition to
+the core `mod-*` flags on `cpsl_core_apple`. Without those ffi flags, host
+gateways never compile and Luau modules such as `webbrowser` / `location` stay
+unregistered even though core modules are built.
+
 ## Commands
 
 On macOS with full Xcode selected and Bazelisk or Bazel installed:

--- a/docs/apple-agent-storage.md
+++ b/docs/apple-agent-storage.md
@@ -87,6 +87,14 @@ change the agent's HTTP policy, native browser availability, or document
 rendering capability. The agent is instructed to treat mounted content as
 personal data and access it only when the task calls for it.
 
+iCloud mounts are download-on-demand: connecting a folder only saves a security-
+scoped bookmark. Directory listings use local tree metadata (with sync-state
+badges for cloud-only / local / keep-downloaded). File bytes are hydrated when
+a specific path is opened, pinned for keep-downloaded, or covered by a bounded
+same-folder small-file prefetch. New mounts default to Herm read-write policy;
+read-only is a Herm/CPSL mount setting (toggleable on the mount), not an iCloud
+picker requirement.
+
 EventKit exposes an event URL and notes but no public file-attachment API. Herm
 therefore provides `calendar.attach(event_id, paths)` as an app-managed layer:
 it copies files under `/home/herm/calendar-attachments`, records their virtual

--- a/scripts/ensure-cpsl-apple-xcframework.sh
+++ b/scripts/ensure-cpsl-apple-xcframework.sh
@@ -20,6 +20,8 @@ Options:
 
 Environment:
   HERM_CPSL_REBUILD=1  Force a CPSL XCFramework rebuild.
+  CPSL_XCFRAMEWORK_LOCK_MAX_AGE_SECONDS
+                         Max lock hold time before auto-expiry (default: 3600).
   CPSL_ROOT, CPSL_WORK_DIR, OUT_DIR, APPLE_PLATFORMS,
   IOS_DEVICE_TARGETS, IOS_SIMULATOR_TARGETS, MACOS_TARGETS, CONFIGURATION
                          Passed through to build-cpsl-apple-xcframework.sh.
@@ -42,6 +44,62 @@ cpsl_ensure_is_visionos_build() {
 	return 1
 }
 
+# Default max hold: 1 hour. Cold Bazel CPSL builds can take a long time; a hard
+# ceiling still prevents a dead/stuck holder from blocking Xcode forever.
+cpsl_ensure_lock_max_age_seconds() {
+	max_age=${CPSL_XCFRAMEWORK_LOCK_MAX_AGE_SECONDS:-3600}
+	case "$max_age" in
+	'' | *[!0-9]*)
+		max_age=3600
+		;;
+	esac
+	if [ "$max_age" -lt 60 ]; then
+		max_age=60
+	fi
+	printf '%s\n' "$max_age"
+}
+
+cpsl_ensure_lock_poll_seconds() {
+	printf '%s\n' 5
+}
+
+cpsl_ensure_lock_log_interval_seconds() {
+	# Avoid spamming Xcode's build log on every poll.
+	printf '%s\n' 30
+}
+
+cpsl_ensure_format_unix_time() {
+	unix_time=$1
+
+	if formatted=$(date -r "$unix_time" '+%Y-%m-%d %H:%M:%S %Z' 2>/dev/null); then
+		printf '%s\n' "$formatted"
+		return 0
+	fi
+	if formatted=$(date -d "@$unix_time" '+%Y-%m-%d %H:%M:%S %Z' 2>/dev/null); then
+		printf '%s\n' "$formatted"
+		return 0
+	fi
+	printf 'unix:%s\n' "$unix_time"
+}
+
+cpsl_ensure_format_duration() {
+	total_seconds=$1
+
+	if [ "$total_seconds" -lt 0 ]; then
+		total_seconds=0
+	fi
+	hours=$((total_seconds / 3600))
+	minutes=$(((total_seconds % 3600) / 60))
+	seconds=$((total_seconds % 60))
+	if [ "$hours" -gt 0 ]; then
+		printf '%dh%02dm%02ds\n' "$hours" "$minutes" "$seconds"
+	elif [ "$minutes" -gt 0 ]; then
+		printf '%dm%02ds\n' "$minutes" "$seconds"
+	else
+		printf '%ds\n' "$seconds"
+	fi
+}
+
 cpsl_ensure_lock_mtime() {
 	path=$1
 
@@ -53,50 +111,203 @@ cpsl_ensure_lock_mtime() {
 	stat -c %Y "$path"
 }
 
+cpsl_ensure_read_first_numeric_file() {
+	# Reads the first line of the first existing candidate that is all digits.
+	for candidate in "$@"; do
+		[ -f "$candidate" ] || continue
+		value=$(cat "$candidate" 2>/dev/null || printf '')
+		case "$value" in
+		'' | *[!0-9]*)
+			continue
+			;;
+		*)
+			printf '%s\n' "$value"
+			return 0
+			;;
+		esac
+	done
+	return 1
+}
+
+cpsl_ensure_read_lock_pid() {
+	lock_path=$1
+
+	# Prefer the canonical pid file, then tolerate cloud/Finder renames such as
+	# "pid 2" that leave a non-empty lock directory and break rmdir reclaim.
+	if [ -d "$lock_path" ]; then
+		cpsl_ensure_read_first_numeric_file \
+			"$lock_path/pid" \
+			"$lock_path"/pid\ * || true
+		return 0
+	fi
+	if [ -f "$lock_path" ]; then
+		cpsl_ensure_read_first_numeric_file "$lock_path" || true
+	fi
+}
+
+cpsl_ensure_read_lock_started_at() {
+	lock_path=$1
+
+	if [ -d "$lock_path" ]; then
+		if started=$(cpsl_ensure_read_first_numeric_file \
+			"$lock_path/started_at" \
+			"$lock_path"/started_at\ *); then
+			printf '%s\n' "$started"
+			return 0
+		fi
+	fi
+
+	cpsl_ensure_lock_mtime "$lock_path" 2>/dev/null
+}
+
+cpsl_ensure_read_lock_expires_at() {
+	lock_path=$1
+	max_age=$2
+
+	if [ -d "$lock_path" ]; then
+		if expires=$(cpsl_ensure_read_first_numeric_file \
+			"$lock_path/expires_at" \
+			"$lock_path"/expires_at\ *); then
+			printf '%s\n' "$expires"
+			return 0
+		fi
+	fi
+
+	started=$(cpsl_ensure_read_lock_started_at "$lock_path") || return 1
+	printf '%s\n' "$((started + max_age))"
+}
+
+cpsl_ensure_remove_stale_lock() {
+	lock_path=$1
+	reason=${2:-stale}
+
+	# Force-remove the whole lock tree. A plain rmdir fails when iCloud/Finder
+	# renames pid -> "pid 2" (or leaves other stray files), which previously
+	# spun forever in the acquire loop.
+	if [ -d "$lock_path" ] || [ -e "$lock_path" ] || [ -L "$lock_path" ]; then
+		printf 'Removing CPSL XCFramework build lock (%s):\n  path: %s\n' \
+			"$reason" "$lock_path"
+		rm -rf "$lock_path"
+	fi
+}
+
+cpsl_ensure_log_lock_status() {
+	lock_path=$1
+	lock_pid=$2
+	holder_state=$3
+	expires_at=$4
+	now=$5
+	reason=$6
+
+	if [ "$expires_at" -gt "$now" ]; then
+		remaining=$((expires_at - now))
+		expiry_clause=$(printf 'expires at %s (in %s)' \
+			"$(cpsl_ensure_format_unix_time "$expires_at")" \
+			"$(cpsl_ensure_format_duration "$remaining")")
+	else
+		expiry_clause=$(printf 'expired at %s (%s ago)' \
+			"$(cpsl_ensure_format_unix_time "$expires_at")" \
+			"$(cpsl_ensure_format_duration $((now - expires_at)))")
+	fi
+
+	printf 'CPSL XCFramework build lock is held (%s).\n' "$reason"
+	printf '  path:        %s\n' "$lock_path"
+	if [ -n "$lock_pid" ]; then
+		printf '  holder_pid:  %s (%s)\n' "$lock_pid" "$holder_state"
+	else
+		printf '  holder_pid:  unknown\n'
+	fi
+	printf '  status:      %s\n' "$expiry_clause"
+	printf '  auto-expire: locks are reclaimed after expiry or when the holder exits\n'
+	printf '  force unlock: rm -rf %s\n' "$lock_path"
+}
+
 cpsl_ensure_acquire_lock() {
 	lock_path=$1
+	max_age=$(cpsl_ensure_lock_max_age_seconds)
+	poll_seconds=$(cpsl_ensure_lock_poll_seconds)
+	log_interval=$(cpsl_ensure_lock_log_interval_seconds)
+	last_wait_log_at=0
 
 	mkdir -p "$(dirname "$lock_path")"
 
 	while ! mkdir "$lock_path" 2>/dev/null; do
-		lock_pid=
-		if [ -f "$lock_path/pid" ]; then
-			lock_pid=$(cat "$lock_path/pid" 2>/dev/null || printf '')
-		elif [ -f "$lock_path" ]; then
-			lock_pid=$(cat "$lock_path" 2>/dev/null || printf '')
+		now=$(date +%s)
+		lock_pid=$(cpsl_ensure_read_lock_pid "$lock_path" || true)
+		holder_alive=0
+		holder_state=unknown
+		if [ -n "$lock_pid" ]; then
+			if kill -0 "$lock_pid" 2>/dev/null; then
+				holder_alive=1
+				holder_state=alive
+			else
+				holder_state=dead
+			fi
 		fi
-		case "$lock_pid" in
-		'' | *[!0-9]*) lock_pid= ;;
-		esac
-		if [ -n "$lock_pid" ] && kill -0 "$lock_pid" 2>/dev/null; then
-			printf 'Waiting for CPSL XCFramework build lock held by PID %s: %s\n' "$lock_pid" "$lock_path"
-			sleep 5
+
+		expires_at=$(cpsl_ensure_read_lock_expires_at "$lock_path" "$max_age" 2>/dev/null) || expires_at=
+		if [ -z "$expires_at" ]; then
+			cpsl_ensure_remove_stale_lock "$lock_path" "unreadable metadata"
 			continue
 		fi
 
-		lock_mtime=$(cpsl_ensure_lock_mtime "$lock_path" 2>/dev/null) || continue
-		lock_age=$(($(date +%s) - lock_mtime))
-		if [ -n "$lock_pid" ] || [ "$lock_age" -ge 10 ]; then
-			if [ -d "$lock_path" ]; then
-				rm -f "$lock_path/pid"
-				rmdir "$lock_path" 2>/dev/null || true
+		# Dead / missing holder: reclaim immediately (no need to wait for expiry).
+		if [ "$holder_alive" -eq 0 ]; then
+			if [ -n "$lock_pid" ]; then
+				reason="holder pid $lock_pid is not running"
 			else
-				rm -f "$lock_path"
+				reason="no live holder pid"
 			fi
+			cpsl_ensure_log_lock_status \
+				"$lock_path" "$lock_pid" "$holder_state" "$expires_at" "$now" "$reason"
+			cpsl_ensure_remove_stale_lock "$lock_path" "$reason"
 			continue
 		fi
-		printf 'Waiting for CPSL XCFramework build lock: %s\n' "$lock_path"
-		sleep 5
+
+		# Live holder past the hard ceiling: steal so Xcode cannot hang forever.
+		if [ "$now" -ge "$expires_at" ]; then
+			reason="expired while held by live pid $lock_pid"
+			cpsl_ensure_log_lock_status \
+				"$lock_path" "$lock_pid" "$holder_state" "$expires_at" "$now" "$reason"
+			cpsl_ensure_remove_stale_lock "$lock_path" "$reason"
+			continue
+		fi
+
+		# Live holder still within the lease: wait, and re-log periodically.
+		if [ $((now - last_wait_log_at)) -ge "$log_interval" ] || [ "$last_wait_log_at" -eq 0 ]; then
+			cpsl_ensure_log_lock_status \
+				"$lock_path" \
+				"$lock_pid" \
+				"$holder_state" \
+				"$expires_at" \
+				"$now" \
+				"another CPSL build is in progress"
+			last_wait_log_at=$now
+		fi
+		sleep "$poll_seconds"
 	done
 
+	now=$(date +%s)
+	expires_at=$((now + max_age))
 	printf '%s\n' "$$" >"$lock_path/pid"
+	printf '%s\n' "$now" >"$lock_path/started_at"
+	printf '%s\n' "$expires_at" >"$lock_path/expires_at"
+	printf 'Acquired CPSL XCFramework build lock.\n'
+	printf '  path:        %s\n' "$lock_path"
+	printf '  holder_pid:  %s\n' "$$"
+	printf '  expires at:  %s (in %s)\n' \
+		"$(cpsl_ensure_format_unix_time "$expires_at")" \
+		"$(cpsl_ensure_format_duration "$max_age")"
+	printf '  force unlock: rm -rf %s\n' "$lock_path"
 	lock_owned=1
 }
 
 cpsl_ensure_release_lock() {
 	[ "${lock_owned:-0}" -eq 1 ] || return 0
-	rm -f "$lock_file/pid"
-	rmdir "$lock_file" 2>/dev/null || true
+	if [ -n "${lock_file:-}" ]; then
+		printf 'Released CPSL XCFramework build lock: %s\n' "$lock_file"
+		rm -rf "$lock_file"
+	fi
 	lock_owned=0
 }
 

--- a/scripts/test-cpsl-apple-build-integration.sh
+++ b/scripts/test-cpsl-apple-build-integration.sh
@@ -16,6 +16,19 @@ assert_contains() {
 
 script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd -P)
 repo_root=$(CDPATH= cd "$script_dir/.." && pwd -P)
+
+# Bazel rules_rust does not expand Cargo feature deps. The apple-app profile
+# must list every ffi cfg feature that Cargo's `embedded-agent` enables.
+bazel_build="$repo_root/BUILD.bazel"
+assert_contains "Bazel apple profile webbrowser" '"webbrowser"' "$bazel_build"
+assert_contains "Bazel apple profile location" '"location"' "$bazel_build"
+assert_contains "Bazel apple profile calendar" '"calendar"' "$bazel_build"
+assert_contains "Bazel apple profile doc" '"doc"' "$bazel_build"
+assert_contains "Bazel apple profile pdfium-render" '"pdfium-render"' "$bazel_build"
+assert_contains "Bazel apple profile embedded-agent" '"embedded-agent"' "$bazel_build"
+assert_contains "Bazel core apple webbrowser module" '"mod-webbrowser"' "$bazel_build"
+assert_contains "Bazel core apple location module" '"mod-location"' "$bazel_build"
+
 tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/cpsl-apple-build-integration.XXXXXX")
 cleanup() {
 	status=$?

--- a/scripts/vet-apple-agent-integration.sh
+++ b/scripts/vet-apple-agent-integration.sh
@@ -238,7 +238,26 @@ require_match 'activeReaderCount == 0' app/apple/herm/Services/CPSLICloudMountMa
 require_match '!writerInProgress' app/apple/herm/Services/CPSLICloudMountManager.swift
 require_match 'beginSessionUse\(\)' app/apple/herm/Services/CPSLDebugService.swift
 require_match 'beginReadUse\(for:' app/apple/herm/Services/CPSLDebugService.swift
-require_match 'materializeMountsForAccess\(\)' app/apple/herm/Services/CPSLDebugService.swift
+require_match 'materializePinnedContent\(\)' app/apple/herm/Services/CPSLDebugService.swift
+reject_match 'materializeMountsForAccess' \
+  app/apple/herm/Services/CPSLDebugService.swift \
+  app/apple/herm/Services/CPSLICloudMountManager.swift
+require_match 'Download-on-demand' app/apple/herm/Services/CPSLICloudMountManager.swift
+require_match 'materializePinnedContent' app/apple/herm/Services/CPSLICloudMountManager.swift
+require_match 'async let mountsReady' app/apple/herm/Models/CPSLChatModel.swift
+require_match 'async let conversationsReady' app/apple/herm/Models/CPSLChatModel.swift
+require_match 'isLoadingConversations' app/apple/herm/Models/CPSLChatModel.swift
+require_match 'CPSLConversationListPresentation' app/apple/herm/Models/CPSLConversationListPresentation.swift
+require_match 'Loading conversations' app/apple/herm/Views/Chat/CPSLConversationDrawerView.swift
+require_match 'CPSLFileSyncState' app/apple/herm/Services/CPSLICloudFileMaterializer.swift
+require_match 'CPSLFileSyncStateBadge' app/apple/herm/Views/Files/CPSLFileBrowserView.swift
+require_match 'accessMode: \.readWrite' app/apple/herm/Views/Files/CPSLFileBrowserView.swift
+require_match 'Keep Downloaded' app/apple/herm/Views/Files/CPSLFileBrowserView.swift
+require_match 'hasVisibleConversations' app/apple/herm/Models/CPSLConversationListPresentation.swift
+require_match 'hasVisibleConversations: !sectionGroups\.isEmpty' app/apple/herm/Models/CPSLChatModel.swift
+require_match 'prefetchSmallCloudFiles' app/apple/herm/Services/CPSLDebugService.swift
+require_match 'beginReadUse\(for: prefetchPath\)' app/apple/herm/Services/CPSLDebugService.swift
+require_match 'entry\.path == mount\.virtualPath' app/apple/herm/Views/Files/CPSLFileBrowserView.swift
 require_match 'materializeFile\(at:' app/apple/herm/Services/CPSLDebugService.swift
 require_match 'lifetimeToken: mountUseLease' app/apple/herm/Services/CPSLDebugService.swift
 require_match 'withExtendedLifetime\(request\.lifetimeToken\)' app/apple/herm/Services/CPSLDebugService.swift
@@ -420,11 +439,10 @@ require_match 'title: "Cloud Drives"' app/apple/herm/Views/Files/CPSLFileBrowser
 require_match 'actionTitle: "Connect"' app/apple/herm/Views/Files/CPSLFileBrowserView.swift
 require_match 'model\.dictation\.finish\(\)' app/apple/herm/Views/Files/CPSLFileBrowserView.swift
 require_match 'guard isICloudImporterPending, !model\.dictation\.isActive else' app/apple/herm/Views/Files/CPSLFileBrowserView.swift
-require_match 'Button\("Read Only"\)' app/apple/herm/Views/Files/CPSLFileBrowserView.swift
-require_match 'Button\("Read & Write"\)' app/apple/herm/Views/Files/CPSLFileBrowserView.swift
+reject_match 'isICloudAccessModePickerPresented|iCloud Folder Access' app/apple/herm/Views/Files/CPSLFileBrowserView.swift
+require_match 'Make Read Only' app/apple/herm/Views/Files/CPSLFileBrowserView.swift
+require_match 'Make Read & Write' app/apple/herm/Views/Files/CPSLFileBrowserView.swift
 require_match 'CPSLICloudMountAccessBadge' app/apple/herm/Views/Files/CPSLFileBrowserView.swift
-require_match 'add, edit, and delete files' app/apple/herm/Views/Files/CPSLFileBrowserView.swift
-require_match 'iCloud Drive syncs those changes' app/apple/herm/Views/Files/CPSLFileBrowserView.swift
 require_match 'iCloudMount\(containing: preview\.path\).*accessMode' app/apple/herm/Views/Files/CPSLFileBrowserView.swift
 require_match 'iCloudMount\(containing: model\.browserPath\).*accessMode' app/apple/herm/Views/Files/CPSLFileBrowserView.swift
 require_match 'try Task\.checkCancellation\(\)' app/apple/herm/Services/CPSLDictationService.swift
@@ -558,6 +576,24 @@ if command -v swiftc >/dev/null 2>&1; then
     scripts/vet-apple-icloud-mount-manager.swift \
     -o /tmp/herm-vet-icloud-mount-manager
   /tmp/herm-vet-icloud-mount-manager
+  swiftc \
+    app/apple/herm/Models/CPSLConversationListPresentation.swift \
+    scripts/vet-apple-bootstrap-loading.swift \
+    -o /tmp/herm-vet-bootstrap-loading
+  /tmp/herm-vet-bootstrap-loading
+  swiftc \
+    app/apple/herm/Services/CPSLICloudFileMaterializer.swift \
+    scripts/vet-apple-icloud-sync-policy.swift \
+    -o /tmp/herm-vet-icloud-sync-policy
+  /tmp/herm-vet-icloud-sync-policy
+  swiftc \
+    app/apple/herm/Models/CPSLICloudMount.swift \
+    app/apple/herm/Services/CPSLICloudBookmarkAccess.swift \
+    app/apple/herm/Services/CPSLICloudFileMaterializer.swift \
+    app/apple/herm/Services/CPSLICloudMountManager.swift \
+    scripts/vet-apple-icloud-on-demand.swift \
+    -o /tmp/herm-vet-icloud-on-demand
+  /tmp/herm-vet-icloud-on-demand
   if [[ "$(uname -s)" == "Darwin" ]]; then
     swiftc \
       app/apple/herm/Services/Agent/CPSLOpenAIProtocol.swift \

--- a/scripts/vet-apple-bootstrap-loading.swift
+++ b/scripts/vet-apple-bootstrap-loading.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+@main
+private struct CPSLBootstrapLoadingChecks {
+    static func main() throws {
+        try checkLoadingHidesFalseEmpty()
+        try checkSearchEmptyUsesVisibleEmptiness()
+        try checkParallelBootstrapOrderingContract()
+        try checkTrueEmptyAfterLoad()
+        print("vet-apple-bootstrap-loading: ok")
+    }
+
+    /// While conversations are still loading, UI must not claim "No conversations yet".
+    private static func checkLoadingHidesFalseEmpty() throws {
+        let presentation = CPSLConversationListPresentation.resolve(
+            isLoading: true,
+            isSearching: false,
+            showingArchived: false,
+            hasVisibleConversations: false
+        )
+        try require(presentation == .loading, "expected loading presentation")
+        try require(
+            presentation.title == "Loading conversations",
+            "loading title missing"
+        )
+        try require(
+            presentation.title != "No conversations yet",
+            "false empty title shown while loading"
+        )
+    }
+
+    /// Search with zero visible hits must show "No matches" even if the store has data.
+    private static func checkSearchEmptyUsesVisibleEmptiness() throws {
+        let noMatches = CPSLConversationListPresentation.resolve(
+            isLoading: false,
+            isSearching: true,
+            showingArchived: false,
+            hasVisibleConversations: false
+        )
+        try require(noMatches == .emptySearch, "expected emptySearch for zero visible hits")
+        try require(noMatches.title == "No matches", "search empty title wrong")
+        // Store may still have conversations; visible emptiness drives the pane.
+        let stillSearchingWithHits = CPSLConversationListPresentation.resolve(
+            isLoading: false,
+            isSearching: true,
+            showingArchived: false,
+            hasVisibleConversations: true
+        )
+        try require(
+            stillSearchingWithHits == .populated,
+            "search with visible hits must stay populated"
+        )
+    }
+
+    /// Source contract: conversation load is not ordered strictly after mounts.
+    private static func checkParallelBootstrapOrderingContract() throws {
+        let chatModelURL = URL(fileURLWithPath: "app/apple/herm/Models/CPSLChatModel.swift")
+        let source = try String(contentsOf: chatModelURL, encoding: .utf8)
+        try require(
+            source.contains("async let mountsReady"),
+            "mount prepare is not launched as an independent async let"
+        )
+        try require(
+            source.contains("async let conversationsReady"),
+            "conversation load is not launched as an independent async let"
+        )
+        try require(
+            source.contains("loadConversationsAtLaunch"),
+            "launch conversation loader missing"
+        )
+        try require(
+            source.contains("isLoadingConversations = true"),
+            "loading flag not initialized true"
+        )
+        // Conversation load must not sit after a sequential prepareICloudMounts barrier.
+        if let bootstrapRange = source.range(of: "private func bootstrap() async") {
+            let tail = source[bootstrapRange.lowerBound...]
+            let end = tail.range(of: "\n    private func loadStore")?.lowerBound
+                ?? tail.index(bootstrapRange.lowerBound, offsetBy: 1200, limitedBy: tail.endIndex)
+                ?? tail.endIndex
+            let bootstrapBody = String(tail[..<end])
+            try require(
+                bootstrapBody.contains("async let mountsReady")
+                    && bootstrapBody.contains("async let conversationsReady"),
+                "bootstrap does not run mounts and conversations in parallel"
+            )
+            try require(
+                !bootstrapBody.contains("iCloudMounts = try await service.prepareICloudMounts()\n        }\n\n        do {\n            try await service.prepareSandbox()\n        } catch {\n            appendErrorMessage(title: \"Files\""),
+                "bootstrap still sequences conversations after sequential mount+sandbox"
+            )
+        } else {
+            throw CheckFailure("bootstrap() not found")
+        }
+    }
+
+    private static func checkTrueEmptyAfterLoad() throws {
+        let fresh = CPSLConversationListPresentation.resolve(
+            isLoading: false,
+            isSearching: false,
+            showingArchived: false,
+            hasVisibleConversations: false
+        )
+        try require(fresh == .emptyFresh, "expected true empty after load")
+        try require(fresh.title == "No conversations yet", "true empty title wrong")
+
+        let populated = CPSLConversationListPresentation.resolve(
+            isLoading: true,
+            isSearching: false,
+            showingArchived: false,
+            hasVisibleConversations: true
+        )
+        try require(
+            populated == .populated,
+            "loaded conversations must surface even if other work is still pending"
+        )
+        try require(populated.title == nil, "populated list should not show empty title")
+    }
+}
+
+private struct CheckFailure: Error, CustomStringConvertible {
+    let description: String
+    init(_ description: String) { self.description = description }
+}
+
+private func require(_ condition: Bool, _ message: String) throws {
+    if !condition {
+        throw CheckFailure(message)
+    }
+}

--- a/scripts/vet-apple-icloud-mount-manager.swift
+++ b/scripts/vet-apple-icloud-mount-manager.swift
@@ -141,8 +141,12 @@ private struct CPSLICloudMountManagerChecks {
             "connecting a live mount created an app-private staged copy"
         )
         try require(
-            progress.values.first == .preparing && progress.values.last?.fractionCompleted == 1,
-            "connecting did not materialize source files"
+            progress.values.first == .preparing,
+            "connecting did not report prepare progress"
+        )
+        try require(
+            progress.values.allSatisfy { $0.phase == .preparing },
+            "connecting eagerly materialize/downloaded the whole tree"
         )
         try require(
             bookmarkRecorder.startCount == bookmarkRecorder.stopCount,

--- a/scripts/vet-apple-icloud-on-demand.swift
+++ b/scripts/vet-apple-icloud-on-demand.swift
@@ -1,0 +1,245 @@
+import Foundation
+
+nonisolated enum CPSLVirtualPath {
+    static let iCloudRoot = "/icloud"
+}
+
+@main
+private struct CPSLICloudOnDemandChecks {
+    static func main() async throws {
+        let testRoot = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "herm-icloud-on-demand-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: testRoot, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: testRoot) }
+
+        try await checkConnectDoesNotWholeTreeMaterialize(in: testRoot)
+        try checkEvalUsesPinnedOnly()
+        try checkDefaultReadWriteImportPath()
+        try checkMountRootKeepDownloadedUI()
+        print("vet-apple-icloud-on-demand: ok")
+    }
+
+    private static func checkConnectDoesNotWholeTreeMaterialize(in testRoot: URL) async throws {
+        let storageRoot = testRoot.appendingPathComponent("storage", isDirectory: true)
+        let recoveryRoot = testRoot.appendingPathComponent("recovery", isDirectory: true)
+        let sourceRoot = testRoot.appendingPathComponent("Library", isDirectory: true)
+        let nested = sourceRoot.appendingPathComponent("nested", isDirectory: true)
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        let big = nested.appendingPathComponent("big.bin")
+        try Data(repeating: 7, count: 4096).write(to: big)
+        try Data("note".utf8).write(to: sourceRoot.appendingPathComponent("note.txt"))
+
+        let recorder = MaterializeRecorder()
+        let progress = ProgressRecorder()
+        let manager = CPSLICloudMountManager(
+            storageRoot: storageRoot,
+            legacyRecoveryRoot: recoveryRoot,
+            bookmarkAccess: recorder.makeAccess()
+        )
+        try manager.prepare()
+
+        // Install spy by connecting through normal path — connect must not walk the tree.
+        // We detect whole-tree materialize via progress phases (downloading) and by ensuring
+        // connect succeeds without enumerating nested files into progress totals.
+        let mount = try await manager.connectDirectory(
+            from: sourceRoot,
+            accessMode: .readWrite,
+            progress: { progress.append($0) }
+        )
+        try require(mount.accessMode == .readWrite, "default connect lost read-write")
+        try require(
+            progress.values.allSatisfy { $0.phase == .preparing },
+            "connect reported downloading/materialize progress for whole tree"
+        )
+        try require(
+            progress.values.contains(where: { $0.totalItems > 0 }) == false,
+            "connect enumerated tree files for materialize"
+        )
+
+        // Single-path materialize is available for content access.
+        try await manager.materializeFile(at: "\(mount.virtualPath)/note.txt")
+        try require(
+            manager.hostURL(for: "\(mount.virtualPath)/note.txt") != nil,
+            "single-path host resolution failed"
+        )
+    }
+
+    private static func checkEvalUsesPinnedOnly() throws {
+        let debugURL = URL(fileURLWithPath: "app/apple/herm/Services/CPSLDebugService.swift")
+        let source = try String(contentsOf: debugURL, encoding: .utf8)
+        try require(
+            source.contains("materializePinnedContent()"),
+            "eval path does not call materializePinnedContent"
+        )
+        try require(
+            !source.contains("materializeMountsForAccess"),
+            "eval path still whole-tree hydrates mounts"
+        )
+        try require(
+            source.contains("// Metadata listing only"),
+            "listDirectory missing metadata-only contract"
+        )
+        try require(
+            source.contains("beginReadUse(for: prefetchPath)"),
+            "listDirectory prefetch is not fire-and-forget after listing"
+        )
+        try require(
+            source.contains("let prefetchURLs = urls"),
+            "listDirectory does not capture URLs for background prefetch"
+        )
+        // Prefetch must not gate the return of entries (synchronous try? before return).
+        try require(
+            !source.contains("try? manager.prefetchSmallCloudFiles(at: urls)"),
+            "listDirectory still blocking-calls prefetch before return"
+        )
+        let managerURL = URL(fileURLWithPath: "app/apple/herm/Services/CPSLICloudMountManager.swift")
+        let managerSource = try String(contentsOf: managerURL, encoding: .utf8)
+        try require(
+            managerSource.contains("Download-on-demand"),
+            "connect path missing download-on-demand contract"
+        )
+        // connectDirectory body must not call materializeDirectory(at: sourceURL)
+        try require(
+            !managerSource.contains("materializeDirectory(\n            at: sourceURL"),
+            "connect still materializes the selected source tree"
+        )
+        try require(
+            !managerSource.contains("materializeDirectory(\n            at: sourceURL,"),
+            "connect still materializes the selected source tree (comma form)"
+        )
+    }
+
+    private static func checkMountRootKeepDownloadedUI() throws {
+        let browserURL = URL(fileURLWithPath: "app/apple/herm/Views/Files/CPSLFileBrowserView.swift")
+        let source = try String(contentsOf: browserURL, encoding: .utf8)
+        try require(
+            source.contains("underMount"),
+            "keep-downloaded setter does not cover mount roots"
+        )
+        try require(
+            source.contains("entry.path == mount.virtualPath"),
+            "mount root path equality missing from pin eligibility"
+        )
+        // Mount menu (onRemove branch) must offer Keep Downloaded, not only Disconnect.
+        try require(
+            source.contains("Label(\"Keep Downloaded\", systemImage: \"pin.circle\")"),
+            "Keep Downloaded label missing from file browser menus"
+        )
+        // Mount action menu includes pin before Disconnect.
+        let mountMenuHasPin = source.contains("if let onSetKeepDownloaded")
+            && source.contains("Label(\"Disconnect\", systemImage: \"eject.fill\")")
+        try require(mountMenuHasPin, "mount root menu missing keep-downloaded + disconnect")
+    }
+
+    private static func checkDefaultReadWriteImportPath() throws {
+        let browserURL = URL(fileURLWithPath: "app/apple/herm/Views/Files/CPSLFileBrowserView.swift")
+        let source = try String(contentsOf: browserURL, encoding: .utf8)
+        try require(
+            source.contains("accessMode: .readWrite"),
+            "folder pick does not default to read-write"
+        )
+        try require(
+            !source.contains("isICloudAccessModePickerPresented"),
+            "post-pick access-mode dialog still present"
+        )
+        try require(
+            !source.contains("iCloud Folder Access"),
+            "post-pick access-mode confirmation copy still present"
+        )
+        try require(
+            source.contains("Make Read Only"),
+            "in-mount read-only toggle missing"
+        )
+        let modelURL = URL(fileURLWithPath: "app/apple/herm/Models/CPSLChatModel.swift")
+        let modelSource = try String(contentsOf: modelURL, encoding: .utf8)
+        try require(
+            modelSource.contains("accessMode: CPSLICloudMountAccessMode = .readWrite"),
+            "importICloudDirectory default is not read-write"
+        )
+    }
+}
+
+private final class ProgressRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private(set) var values: [CPSLICloudImportProgress] = []
+
+    func append(_ value: CPSLICloudImportProgress) {
+        lock.lock()
+        values.append(value)
+        lock.unlock()
+    }
+}
+
+private final class MaterializeRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var active = 0
+    private(set) var startCount = 0
+    private(set) var stopCount = 0
+    private(set) var createCount = 0
+    private var bookmarks: [Data: URL] = [:]
+
+    var activeScopeCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return active
+    }
+
+    func makeAccess() -> CPSLICloudBookmarkAccess {
+        CPSLICloudBookmarkAccess(
+            create: { [weak self] url, _ in
+                guard let self else { return Data() }
+                self.lock.lock()
+                defer { self.lock.unlock() }
+                self.createCount += 1
+                let data = Data(url.path.utf8)
+                self.bookmarks[data] = url
+                return data
+            },
+            resolve: { [weak self] data in
+                guard let self else {
+                    throw CPSLICloudBookmarkError.cannotResolve
+                }
+                self.lock.lock()
+                defer { self.lock.unlock() }
+                if let resolved = self.bookmarks[data] {
+                    return CPSLICloudBookmarkResolution(url: resolved, isStale: false)
+                }
+                guard let path = String(data: data, encoding: .utf8), !path.isEmpty else {
+                    throw CPSLICloudBookmarkError.cannotResolve
+                }
+                return CPSLICloudBookmarkResolution(
+                    url: URL(fileURLWithPath: path),
+                    isStale: false
+                )
+            },
+            start: { [weak self] _ in
+                guard let self else { return false }
+                self.lock.lock()
+                defer { self.lock.unlock() }
+                self.startCount += 1
+                self.active += 1
+                return true
+            },
+            stop: { [weak self] _ in
+                guard let self else { return }
+                self.lock.lock()
+                defer { self.lock.unlock() }
+                self.stopCount += 1
+                self.active -= 1
+            }
+        )
+    }
+}
+
+private struct CheckFailure: Error, CustomStringConvertible {
+    let description: String
+    init(_ description: String) { self.description = description }
+}
+
+private func require(_ condition: Bool, _ message: String) throws {
+    if !condition {
+        throw CheckFailure(message)
+    }
+}

--- a/scripts/vet-apple-icloud-sync-policy.swift
+++ b/scripts/vet-apple-icloud-sync-policy.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+@main
+private struct CPSLICloudSyncPolicyChecks {
+    static func main() throws {
+        try checkSyncStateMapping()
+        try checkSmallPrefetchBounds()
+        try checkBrowserBindsSyncIcons()
+        print("vet-apple-icloud-sync-policy: ok")
+    }
+
+    private static func checkSyncStateMapping() throws {
+        try require(
+            CPSLICloudSyncPolicy.syncState(
+                isUbiquitous: false,
+                downloadStatus: .notDownloaded,
+                isPinned: false
+            ) == nil,
+            "non-ubiquitous items should have no sync badge"
+        )
+        try require(
+            CPSLICloudSyncPolicy.syncState(
+                isUbiquitous: true,
+                downloadStatus: .notDownloaded,
+                isPinned: false
+            ) == .cloudOnly,
+            "not-downloaded ubiquitous item should be cloudOnly"
+        )
+        try require(
+            CPSLICloudSyncPolicy.syncState(
+                isUbiquitous: true,
+                downloadStatus: .current,
+                isPinned: false
+            ) == .local,
+            "current ubiquitous item should be local"
+        )
+        try require(
+            CPSLICloudSyncPolicy.syncState(
+                isUbiquitous: true,
+                downloadStatus: .downloaded,
+                isPinned: false
+            ) == .local,
+            "downloaded ubiquitous item should be local"
+        )
+        try require(
+            CPSLICloudSyncPolicy.syncState(
+                isUbiquitous: true,
+                downloadStatus: .notDownloaded,
+                isPinned: true
+            ) == .keepDownloaded,
+            "pinned items should report keepDownloaded"
+        )
+        try require(
+            CPSLFileSyncState.cloudOnly.systemImageName == "icloud",
+            "cloud-only icon missing"
+        )
+        try require(
+            CPSLFileSyncState.local.systemImageName == "checkmark.icloud",
+            "local icon missing"
+        )
+        try require(
+            CPSLFileSyncState.keepDownloaded.systemImageName == "pin.circle.fill",
+            "keep-downloaded icon missing"
+        )
+    }
+
+    private static func checkSmallPrefetchBounds() throws {
+        try require(
+            CPSLICloudSyncPolicy.shouldPrefetchSmallCloudFiles(fileCount: 3, totalBytes: 1024),
+            "small folder should prefetch"
+        )
+        try require(
+            !CPSLICloudSyncPolicy.shouldPrefetchSmallCloudFiles(fileCount: 0, totalBytes: 0),
+            "empty folder should not prefetch"
+        )
+        try require(
+            !CPSLICloudSyncPolicy.shouldPrefetchSmallCloudFiles(
+                fileCount: CPSLICloudSyncPolicy.smallPrefetchMaxFiles + 1,
+                totalBytes: 1024
+            ),
+            "too many files should not prefetch"
+        )
+        try require(
+            !CPSLICloudSyncPolicy.shouldPrefetchSmallCloudFiles(
+                fileCount: 2,
+                totalBytes: CPSLICloudSyncPolicy.smallPrefetchMaxTotalBytes + 1
+            ),
+            "too many bytes should not prefetch"
+        )
+        try require(
+            CPSLICloudSyncPolicy.isSmallPrefetchCandidate(
+                fileBytes: CPSLICloudSyncPolicy.smallPrefetchMaxFileBytes
+            ),
+            "boundary file size should qualify"
+        )
+        try require(
+            !CPSLICloudSyncPolicy.isSmallPrefetchCandidate(
+                fileBytes: CPSLICloudSyncPolicy.smallPrefetchMaxFileBytes + 1
+            ),
+            "oversized file should not qualify"
+        )
+    }
+
+    private static func checkBrowserBindsSyncIcons() throws {
+        let browserURL = URL(fileURLWithPath: "app/apple/herm/Views/Files/CPSLFileBrowserView.swift")
+        let source = try String(contentsOf: browserURL, encoding: .utf8)
+        try require(
+            source.contains("CPSLFileSyncStateBadge"),
+            "file browser does not bind sync-state badge"
+        )
+        try require(
+            source.contains("entry.syncState"),
+            "file row does not read entry.syncState"
+        )
+        try require(
+            source.contains("state.systemImageName"),
+            "sync badge does not use systemImageName"
+        )
+    }
+}
+
+private struct CheckFailure: Error, CustomStringConvertible {
+    let description: String
+    init(_ description: String) { self.description = description }
+}
+
+private func require(_ condition: Bool, _ message: String) throws {
+    if !condition {
+        throw CheckFailure(message)
+    }
+}


### PR DESCRIPTION
## Summary
Combines two pending fixes onto one branch:

1. **iCloud + Bazel CPSL features** (`a31df83`)
   - Decouple conversation loading from mount prepare; default iCloud mounts to read-write with download-on-demand sync states.
   - Expand the Bazel `apple-app` FFI `crate_features` so `webbrowser` / `location` / `calendar` / `doc` / `pdfium-render` actually compile in (rules_rust does not expand Cargo feature deps). Without this, host gateways never register under the default Bazel XCFramework build.

2. **Apple actor warnings + CPSL build lock** (cherry-picked from `aduermael/fix-main-actor-warnings`)
   - Mark `CPSLFileEntry` / calendar helpers `nonisolated` (merged with `syncState` from the iCloud work).
   - Harden the CPSL XCFramework build lock: lease metadata, reclaim dead/expired holders, tolerate iCloud/Finder renames, less Xcode log spam.
   - Refresh `MODULE.bazel.lock`.

Supersedes #108.

## Test plan
- [ ] Build the Apple app with default Bazel CPSL and confirm webbrowser / location / calendar modules register (not “built without mod-webbrowser”)
- [ ] Verify iCloud mounts default RW, download-on-demand badges, and conversation list loads without blocking on mount prepare
- [ ] Confirm main-actor / isolation warnings for `CPSLFileEntry` are gone
- [ ] Run a CPSL XCFramework ensure/build; stale lock (dead pid) is reclaimed instead of hanging