### PR TITLE
Add Apple Excel support via cells_xlsx and CPSL xlsx gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,10 @@ tools/edit-file/edit-file
 .herm-cpsl/.cpsl-xcframework-build.lock
 .herm-cpsl/pdfium/
 .herm-cpsl/benchmarks/
+.herm-cells/
 .herm-apple/
+scripts/test-cells-xlsx-luau-eval/target/
+scripts/test-cells-xlsx-luau-eval/Cargo.lock
 .agents/
 
 # Local provider credentials

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -149,6 +149,7 @@ rust_library(
         "mod-ripgrep",
         "mod-url",
         "mod-webbrowser",
+        "mod-xlsx",
         "mod-xml",
         "mod-yaml",
         "pdfium-render",
@@ -179,7 +180,7 @@ rust_shared_library(
     # rules_rust does not expand Cargo feature dependencies. List every
     # cfg(feature = "...") the ffi crate checks — matching the Cargo
     # `embedded-agent` expansion in external/cpsl/ffi/Cargo.toml. Without
-    # webbrowser/location/calendar/doc/pdfium-render here, host gateways never
+    # webbrowser/location/calendar/xlsx/doc/pdfium-render here, host gateways never
     # compile in and those Luau modules stay unregistered.
     crate_features = select({
         ":cpsl_apple_app_profile": [
@@ -190,6 +191,7 @@ rust_shared_library(
             "location",
             "pdfium-render",
             "webbrowser",
+            "xlsx",
         ],
         "//conditions:default": ["ffi-minimal"],
     }),

--- a/app/apple/herm.xcodeproj/project.pbxproj
+++ b/app/apple/herm.xcodeproj/project.pbxproj
@@ -176,6 +176,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 85D75D3E2FE62B6F0095BAB2 /* Build configuration list for PBXNativeTarget "herm" */;
 			buildPhases = (
+				85C100012FFA000000000001 /* Link cells_xlsx */,
 				85A100032FEA000000000003 /* Generate Env Constants */,
 				85D75D2F2FE62B6F0095BAB2 /* Sources */,
 				85D75D302FE62B6F0095BAB2 /* Frameworks */,
@@ -364,6 +365,29 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -euo pipefail\nsrc=\"${SRCROOT}/herm/Skills\"\ndst=\"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/Skills\"\nrm -rf \"$dst\"\nif [ -d \"$src\" ]; then\n  mkdir -p \"$(dirname \"$dst\")\"\n  cp -R \"$src\" \"$dst\"\nfi\n";
+		};
+		85C100012FFA000000000001 /* Link cells_xlsx */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/../../scripts/link-cells-xlsx-for-xcode.sh",
+				"$(SRCROOT)/../../scripts/build-cells-xlsx-apple.sh",
+				"$(SRCROOT)/../../scripts/lib/cells-xlsx-apple.sh",
+			);
+			name = "Link cells_xlsx";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/cells-xlsx-linked.stamp",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/../../scripts/link-cells-xlsx-for-xcode.sh\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -555,6 +579,10 @@
 		85D75D3F2FE62B6F0095BAB2 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/../../.herm-cells/artifacts/apple/$(PLATFORM_NAME)/include";
+				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../../.herm-cells/artifacts/apple/$(PLATFORM_NAME)/lib";
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/../../.herm-cells/artifacts/apple/$(PLATFORM_NAME)/include";
+				OTHER_LDFLAGS = "$(inherited) -lcells_xlsx -lc++";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = herm/herm.entitlements;
@@ -612,6 +640,10 @@
 		85D75D402FE62B6F0095BAB2 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/../../.herm-cells/artifacts/apple/$(PLATFORM_NAME)/include";
+				LIBRARY_SEARCH_PATHS = "$(SRCROOT)/../../.herm-cells/artifacts/apple/$(PLATFORM_NAME)/lib";
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/../../.herm-cells/artifacts/apple/$(PLATFORM_NAME)/include";
+				OTHER_LDFLAGS = "$(inherited) -lcells_xlsx -lc++";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = herm/herm.entitlements;

--- a/app/apple/herm/Services/CPSLDebugService.swift
+++ b/app/apple/herm/Services/CPSLDebugService.swift
@@ -48,6 +48,14 @@ private nonisolated final class CPSLLocationCallbackBox: @unchecked Sendable {
     }
 }
 
+private nonisolated final class CPSLXlsxCallbackBox: @unchecked Sendable {
+    let service: CPSLExcelService
+
+    init(service: CPSLExcelService) {
+        self.service = service
+    }
+}
+
 private nonisolated enum CPSLFileMutationError: LocalizedError {
     case destinationContainsSource
     case destinationExists
@@ -124,6 +132,19 @@ private typealias CPSLLocationUserDataFreeFunction = @convention(c) (
     UnsafeMutableRawPointer?
 ) -> Void
 
+private typealias CPSLXlsxHandleJSONFunction = @convention(c) (
+    UnsafeMutableRawPointer?,
+    UnsafePointer<CChar>?
+) -> UnsafeMutablePointer<CChar>?
+
+private typealias CPSLXlsxStringFreeFunction = @convention(c) (
+    UnsafeMutablePointer<CChar>?
+) -> Void
+
+private typealias CPSLXlsxUserDataFreeFunction = @convention(c) (
+    UnsafeMutableRawPointer?
+) -> Void
+
 private typealias CPSLVisionHandleFunction = @convention(c) (
     UnsafeMutableRawPointer?,
     UnsafeRawPointer?,
@@ -160,6 +181,13 @@ private nonisolated struct CPSLLocationCallbacks {
     var handle_json: CPSLLocationHandleJSONFunction?
     var string_free: CPSLLocationStringFreeFunction?
     var user_data_free: CPSLLocationUserDataFreeFunction?
+}
+
+private nonisolated struct CPSLXlsxCallbacks {
+    var user_data: UnsafeMutableRawPointer?
+    var handle_json: CPSLXlsxHandleJSONFunction?
+    var string_free: CPSLXlsxStringFreeFunction?
+    var user_data_free: CPSLXlsxUserDataFreeFunction?
 }
 
 private nonisolated struct CPSLVisionInputFFI {
@@ -204,6 +232,17 @@ private typealias CPSLSessionNewWithHostCallbacksV3Function = @convention(c) (
     UnsafeRawPointer?,
     UnsafeRawPointer?
 ) -> OpaquePointer?
+
+private typealias CPSLSessionNewWithHostCallbacksV4Function = @convention(c) (
+    UnsafePointer<CChar>?,
+    UnsafePointer<cpsl_webbrowser_callbacks_t>?,
+    UnsafeRawPointer?,
+    UnsafeRawPointer?,
+    UnsafeRawPointer?,
+    UnsafeRawPointer?,
+    UnsafeRawPointer?
+) -> OpaquePointer?
+
 private nonisolated final class CPSLWebBrowserCallbackResponse: @unchecked Sendable {
     private let lock = NSLock()
     private var value: String
@@ -330,6 +369,31 @@ private nonisolated let cpslLocationUserDataFree: CPSLLocationUserDataFreeFuncti
         return
     }
     Unmanaged<CPSLLocationCallbackBox>.fromOpaque(userData).release()
+}
+
+private nonisolated let cpslXlsxHandleJSON: CPSLXlsxHandleJSONFunction = { userData, requestJSON in
+    guard let userData, let requestJSON else {
+        return cpslWebBrowserOwnedErrorCString("xlsx callback received NULL input")
+    }
+    let callbackBox = Unmanaged<CPSLXlsxCallbackBox>
+        .fromOpaque(userData)
+        .takeUnretainedValue()
+    let request = String(cString: requestJSON)
+    // cells_xlsx is pure CPU/file I/O; keep it off the main thread and run
+    // synchronously so CPSL eval threads are not forced onto MainActor.
+    let response = callbackBox.service.handleJSON(request)
+    return cpslWebBrowserOwnedCString(response)
+}
+
+private nonisolated let cpslXlsxStringFree: CPSLXlsxStringFreeFunction = { value in
+    cpslWebBrowserStringFree(value)
+}
+
+private nonisolated let cpslXlsxUserDataFree: CPSLXlsxUserDataFreeFunction = { userData in
+    guard let userData else {
+        return
+    }
+    Unmanaged<CPSLXlsxCallbackBox>.fromOpaque(userData).release()
 }
 
 private nonisolated let cpslFileActivityHandle: CPSLFileActivityHandleFunction = { userData, path, operation in
@@ -534,6 +598,21 @@ private nonisolated func cpslSessionNewWithHostCallbacksV3Function() -> CPSLSess
     return unsafeBitCast(symbol, to: CPSLSessionNewWithHostCallbacksV3Function.self)
 }
 
+private nonisolated func cpslSessionNewWithHostCallbacksV4Function() -> CPSLSessionNewWithHostCallbacksV4Function? {
+#if canImport(Darwin)
+    let lookupHandle = UnsafeMutableRawPointer(bitPattern: -2)
+#else
+    let lookupHandle: UnsafeMutableRawPointer? = nil
+#endif
+    let symbol = "cpsl_session_new_with_host_callbacks_v4".withCString { name in
+        dlsym(lookupHandle, name)
+    }
+    guard let symbol else {
+        return nil
+    }
+    return unsafeBitCast(symbol, to: CPSLSessionNewWithHostCallbacksV4Function.self)
+}
+
 private nonisolated func cpslVisionRespondFunction() -> CPSLVisionRespondFunction? {
 #if canImport(Darwin)
     let lookupHandle = UnsafeMutableRawPointer(bitPattern: -2)
@@ -586,6 +665,7 @@ actor CPSLDebugService {
 
     private let webBrowser: CPSLWebBrowserService
     private let location: CPSLLocationService
+    private let excel: CPSLExcelService
     private let calendarActivityNotifier: CPSLCalendarActivityNotifier
     private let fileActivityNotifier: CPSLFileActivityNotifier
     private var iCloudMountManager: CPSLICloudMountManager?
@@ -601,11 +681,13 @@ actor CPSLDebugService {
     init(
         webBrowser: CPSLWebBrowserService,
         location: CPSLLocationService,
+        excel: CPSLExcelService = CPSLExcelService(),
         calendarActivityNotifier: CPSLCalendarActivityNotifier,
         fileActivityNotifier: CPSLFileActivityNotifier
     ) {
         self.webBrowser = webBrowser
         self.location = location
+        self.excel = excel
         self.calendarActivityNotifier = calendarActivityNotifier
         self.fileActivityNotifier = fileActivityNotifier
     }
@@ -1697,6 +1779,7 @@ actor CPSLDebugService {
         let fileActivityCallbackBox = CPSLFileActivityCallbackBox(notifier: fileActivityNotifier)
         let calendarActivityCallbackBox = CPSLCalendarActivityCallbackBox(notifier: calendarActivityNotifier)
         let locationCallbackBox = CPSLLocationCallbackBox(service: location)
+        let xlsxCallbackBox = CPSLXlsxCallbackBox(service: excel)
         let visionCallbackBox = CPSLVisionCallbackBox()
         let result = await Self.performBlockingSessionInit(
             configJSON: configJSON,
@@ -1704,7 +1787,8 @@ actor CPSLDebugService {
             fileActivityCallbackBox: fileActivityCallbackBox,
             calendarActivityCallbackBox: calendarActivityCallbackBox,
             locationCallbackBox: locationCallbackBox,
-            visionCallbackBox: visionCallbackBox
+            visionCallbackBox: visionCallbackBox,
+            xlsxCallbackBox: xlsxCallbackBox
         )
         guard let newSession = result.pointer else {
             return result.errorMessage ?? "cpsl_session_new returned NULL"
@@ -1999,7 +2083,8 @@ actor CPSLDebugService {
         fileActivityCallbackBox: CPSLFileActivityCallbackBox,
         calendarActivityCallbackBox: CPSLCalendarActivityCallbackBox,
         locationCallbackBox: CPSLLocationCallbackBox,
-        visionCallbackBox: CPSLVisionCallbackBox
+        visionCallbackBox: CPSLVisionCallbackBox,
+        xlsxCallbackBox: CPSLXlsxCallbackBox
     ) async -> CPSLSessionInitResult {
         await withCheckedContinuation { continuation in
             DispatchQueue.global(qos: .default).async {
@@ -2009,7 +2094,8 @@ actor CPSLDebugService {
                     fileActivityCallbackBox: fileActivityCallbackBox,
                     calendarActivityCallbackBox: calendarActivityCallbackBox,
                     locationCallbackBox: locationCallbackBox,
-                    visionCallbackBox: visionCallbackBox
+                    visionCallbackBox: visionCallbackBox,
+                    xlsxCallbackBox: xlsxCallbackBox
                 ))
             }
         }
@@ -2021,7 +2107,8 @@ actor CPSLDebugService {
         fileActivityCallbackBox: CPSLFileActivityCallbackBox,
         calendarActivityCallbackBox: CPSLCalendarActivityCallbackBox,
         locationCallbackBox: CPSLLocationCallbackBox,
-        visionCallbackBox: CPSLVisionCallbackBox
+        visionCallbackBox: CPSLVisionCallbackBox,
+        xlsxCallbackBox: CPSLXlsxCallbackBox
     ) -> CPSLSessionInitResult {
         configureCPSLLibraryDirectory()
         let fileActivityUserData = Unmanaged.passRetained(fileActivityCallbackBox).toOpaque()
@@ -2049,10 +2136,45 @@ actor CPSLDebugService {
             handle: cpslVisionHandle,
             user_data_free: cpslVisionUserDataFree
         )
+        let xlsxUserData = Unmanaged.passRetained(xlsxCallbackBox).toOpaque()
+        var xlsxCallbacks = CPSLXlsxCallbacks(
+            user_data: xlsxUserData,
+            handle_json: cpslXlsxHandleJSON,
+            string_free: cpslXlsxStringFree,
+            user_data_free: cpslXlsxUserDataFree
+        )
 
         func createPointer(
             webBrowserCallbacks: UnsafePointer<cpsl_webbrowser_callbacks_t>?
         ) -> (pointer: OpaquePointer?, fallback: String) {
+            if let sessionNewWithHostCallbacksV4 = cpslSessionNewWithHostCallbacksV4Function(),
+               cpslVisionRespondFunction() != nil {
+                let pointer = configJSON.withCString { configPointer in
+                    withUnsafePointer(to: &fileActivityCallbacks) { fileActivityCallbacksPointer in
+                        withUnsafePointer(to: &calendarActivityCallbacks) { calendarActivityCallbacksPointer in
+                            withUnsafePointer(to: &locationCallbacks) { locationCallbacksPointer in
+                                withUnsafePointer(to: &visionCallbacks) { visionCallbacksPointer in
+                                    withUnsafePointer(to: &xlsxCallbacks) { xlsxCallbacksPointer in
+                                        sessionNewWithHostCallbacksV4(
+                                            configPointer,
+                                            webBrowserCallbacks,
+                                            UnsafeRawPointer(fileActivityCallbacksPointer),
+                                            UnsafeRawPointer(calendarActivityCallbacksPointer),
+                                            UnsafeRawPointer(locationCallbacksPointer),
+                                            UnsafeRawPointer(visionCallbacksPointer),
+                                            UnsafeRawPointer(xlsxCallbacksPointer)
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                return (pointer, "cpsl_session_new_with_host_callbacks_v4 returned NULL")
+            }
+
+            // Older CPSL builds: release xlsx callback context and fall back.
+            cpslXlsxUserDataFree(xlsxUserData)
             if let sessionNewWithHostCallbacksV3 = cpslSessionNewWithHostCallbacksV3Function(),
                cpslVisionRespondFunction() != nil {
                 let pointer = configJSON.withCString { configPointer in

--- a/app/apple/herm/Services/CPSLExcelService.swift
+++ b/app/apple/herm/Services/CPSLExcelService.swift
@@ -1,0 +1,342 @@
+import Foundation
+
+#if canImport(CellsXlsx)
+import CellsXlsx
+#endif
+
+/// Host bridge for the Luau `xlsx` module. Owns workbook handles and calls the
+/// cells `cells_xlsx` C ABI for open/create/read/set/write.
+final class CPSLExcelService: @unchecked Sendable {
+    private let lock = NSLock()
+    private var workbooks: [String: OpaquePointer] = [:]
+    private var nextID: UInt64 = 1
+
+    deinit {
+        lock.lock()
+        let handles = Array(workbooks.values)
+        workbooks.removeAll()
+        lock.unlock()
+        for handle in handles {
+            Self.closeHandle(handle)
+        }
+    }
+
+    /// JSON host-gateway entry point used by CPSL FFI callbacks.
+    func handleJSON(_ requestJSON: String) -> String {
+        do {
+            guard let data = requestJSON.data(using: .utf8),
+                  let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let command = object["command"] as? String
+            else {
+                return Self.errorJSON("xlsx: invalid request JSON")
+            }
+            return try dispatch(command: command, object: object)
+        } catch {
+            return Self.errorJSON("xlsx: \(error.localizedDescription)")
+        }
+    }
+
+    private func dispatch(command: String, object: [String: Any]) throws -> String {
+#if canImport(CellsXlsx)
+        switch command {
+        case "create":
+            guard let wb = cells_xlsx_create() else {
+                return Self.errorJSON(Self.lastErrorMessage(fallback: "create failed"))
+            }
+            let id = store(wb)
+            return Self.successJSON(["workbook": id])
+
+        case "open":
+            guard let path = object["path"] as? String, !path.isEmpty else {
+                return Self.errorJSON("xlsx.open: missing path")
+            }
+            let wb = path.withCString { cells_xlsx_open($0) }
+            guard let wb else {
+                return Self.errorJSON(Self.lastErrorMessage(fallback: "open failed"))
+            }
+            let id = store(wb)
+            return Self.successJSON(["workbook": id])
+
+        case "close":
+            let id = try workbookID(object)
+            if let handle = take(id) {
+                Self.closeHandle(handle)
+            }
+            return Self.successJSON([:])
+
+        case "sheet_count":
+            let handle = try handle(for: object)
+            let count = cells_xlsx_sheet_count(handle)
+            guard count >= 0 else {
+                return Self.errorJSON(Self.lastErrorMessage(fallback: "sheet_count failed"))
+            }
+            return Self.successJSON(["count": count])
+
+        case "sheet_name":
+            let handle = try handle(for: object)
+            let sheet = try intField(object, "sheet")
+            var buffer = [CChar](repeating: 0, count: 512)
+            let written = buffer.withUnsafeMutableBufferPointer { buf in
+                cells_xlsx_sheet_name(handle, Int32(sheet), buf.baseAddress, buf.count)
+            }
+            guard written >= 0 else {
+                return Self.errorJSON(Self.lastErrorMessage(fallback: "sheet_name failed"))
+            }
+            let name = String(cString: buffer)
+            return Self.successJSON(["name": name])
+
+        case "sheets":
+            let handle = try handle(for: object)
+            let count = cells_xlsx_sheet_count(handle)
+            guard count >= 0 else {
+                return Self.errorJSON(Self.lastErrorMessage(fallback: "sheets failed"))
+            }
+            var names: [String] = []
+            names.reserveCapacity(Int(count))
+            for index in 0..<count {
+                var buffer = [CChar](repeating: 0, count: 512)
+                let written = buffer.withUnsafeMutableBufferPointer { buf in
+                    cells_xlsx_sheet_name(handle, index, buf.baseAddress, buf.count)
+                }
+                guard written >= 0 else {
+                    return Self.errorJSON(Self.lastErrorMessage(fallback: "sheets failed"))
+                }
+                names.append(String(cString: buffer))
+            }
+            return Self.successJSON(["sheets": names])
+
+        case "get_type":
+            let handle = try handle(for: object)
+            let sheet = try intField(object, "sheet")
+            let col = try intField(object, "col")
+            let row = try intField(object, "row")
+            let typeCode = cells_xlsx_get_type(handle, Int32(sheet), Int32(col), Int32(row))
+            return Self.successJSON(["type": Self.typeName(typeCode)])
+
+        case "get_number":
+            let handle = try handle(for: object)
+            let sheet = try intField(object, "sheet")
+            let col = try intField(object, "col")
+            let row = try intField(object, "row")
+            let value = cells_xlsx_get_number(handle, Int32(sheet), Int32(col), Int32(row))
+            return Self.successJSON(["value": value])
+
+        case "get_string":
+            let handle = try handle(for: object)
+            let sheet = try intField(object, "sheet")
+            let col = try intField(object, "col")
+            let row = try intField(object, "row")
+            guard let cString = cells_xlsx_get_string(handle, Int32(sheet), Int32(col), Int32(row)) else {
+                return Self.errorJSON(Self.lastErrorMessage(fallback: "get_string failed"))
+            }
+            return Self.successJSON(["value": String(cString: cString)])
+
+        case "get_bool":
+            let handle = try handle(for: object)
+            let sheet = try intField(object, "sheet")
+            let col = try intField(object, "col")
+            let row = try intField(object, "row")
+            let value = cells_xlsx_get_bool(handle, Int32(sheet), Int32(col), Int32(row)) != 0
+            return Self.successJSON(["value": value])
+
+        case "get":
+            let handle = try handle(for: object)
+            let sheet = try intField(object, "sheet")
+            let col = try intField(object, "col")
+            let row = try intField(object, "row")
+            let typeCode = cells_xlsx_get_type(handle, Int32(sheet), Int32(col), Int32(row))
+            let typeName = Self.typeName(typeCode)
+            let value: Any
+            // CellsXlsxValueType: EMPTY=0, NUMBER=1, STRING=2, BOOL=3, OTHER=4
+            switch typeCode {
+            case 1:
+                value = cells_xlsx_get_number(handle, Int32(sheet), Int32(col), Int32(row))
+            case 2:
+                if let cString = cells_xlsx_get_string(handle, Int32(sheet), Int32(col), Int32(row)) {
+                    value = String(cString: cString)
+                } else {
+                    value = NSNull()
+                }
+            case 3:
+                value = cells_xlsx_get_bool(handle, Int32(sheet), Int32(col), Int32(row)) != 0
+            default:
+                value = NSNull()
+            }
+            return Self.successJSON(["type": typeName, "value": value])
+
+        case "set_number":
+            let handle = try handle(for: object)
+            let sheet = try intField(object, "sheet")
+            let col = try intField(object, "col")
+            let row = try intField(object, "row")
+            let value = try doubleField(object, "value")
+            guard cells_xlsx_set_number(handle, Int32(sheet), Int32(col), Int32(row), value) == 0 else {
+                return Self.errorJSON(Self.lastErrorMessage(fallback: "set_number failed"))
+            }
+            return Self.successJSON([:])
+
+        case "set_string":
+            let handle = try handle(for: object)
+            let sheet = try intField(object, "sheet")
+            let col = try intField(object, "col")
+            let row = try intField(object, "row")
+            guard let value = object["value"] as? String else {
+                return Self.errorJSON("xlsx.set_string: value must be a string")
+            }
+            let rc = value.withCString {
+                cells_xlsx_set_string(handle, Int32(sheet), Int32(col), Int32(row), $0)
+            }
+            guard rc == 0 else {
+                return Self.errorJSON(Self.lastErrorMessage(fallback: "set_string failed"))
+            }
+            return Self.successJSON([:])
+
+        case "set_bool":
+            let handle = try handle(for: object)
+            let sheet = try intField(object, "sheet")
+            let col = try intField(object, "col")
+            let row = try intField(object, "row")
+            guard let value = object["value"] as? Bool else {
+                return Self.errorJSON("xlsx.set_bool: value must be a boolean")
+            }
+            guard cells_xlsx_set_bool(handle, Int32(sheet), Int32(col), Int32(row), value ? 1 : 0) == 0 else {
+                return Self.errorJSON(Self.lastErrorMessage(fallback: "set_bool failed"))
+            }
+            return Self.successJSON([:])
+
+        case "write":
+            let handle = try handle(for: object)
+            guard let path = object["path"] as? String, !path.isEmpty else {
+                return Self.errorJSON("xlsx.write: missing path")
+            }
+            let rc = path.withCString { cells_xlsx_write(handle, $0) }
+            guard rc == 0 else {
+                return Self.errorJSON(Self.lastErrorMessage(fallback: "write failed"))
+            }
+            return Self.successJSON([:])
+
+        default:
+            return Self.errorJSON("xlsx: unsupported command \(command)")
+        }
+#else
+        return Self.errorJSON("xlsx: cells_xlsx library was not linked into this build")
+#endif
+    }
+
+    // MARK: - Handle bookkeeping
+
+    private func store(_ handle: OpaquePointer) -> String {
+        lock.lock()
+        defer { lock.unlock() }
+        let id = "wb\(nextID)"
+        nextID += 1
+        workbooks[id] = handle
+        return id
+    }
+
+    private func handle(for object: [String: Any]) throws -> OpaquePointer {
+        let id = try workbookID(object)
+        lock.lock()
+        defer { lock.unlock() }
+        guard let handle = workbooks[id] else {
+            throw ExcelServiceError.message("xlsx: invalid workbook handle")
+        }
+        return handle
+    }
+
+    private func take(_ id: String) -> OpaquePointer? {
+        lock.lock()
+        defer { lock.unlock() }
+        return workbooks.removeValue(forKey: id)
+    }
+
+    private static func closeHandle(_ handle: OpaquePointer) {
+#if canImport(CellsXlsx)
+        cells_xlsx_close(handle)
+#endif
+    }
+
+    private func workbookID(_ object: [String: Any]) throws -> String {
+        guard let id = object["workbook"] as? String, !id.isEmpty else {
+            throw ExcelServiceError.message("xlsx: missing workbook")
+        }
+        return id
+    }
+
+    private func intField(_ object: [String: Any], _ key: String) throws -> Int {
+        if let value = object[key] as? Int {
+            return value
+        }
+        if let value = object[key] as? NSNumber {
+            return value.intValue
+        }
+        throw ExcelServiceError.message("xlsx: missing or invalid \(key)")
+    }
+
+    private func doubleField(_ object: [String: Any], _ key: String) throws -> Double {
+        if let value = object[key] as? Double {
+            return value
+        }
+        if let value = object[key] as? Int {
+            return Double(value)
+        }
+        if let value = object[key] as? NSNumber {
+            return value.doubleValue
+        }
+        throw ExcelServiceError.message("xlsx: missing or invalid \(key)")
+    }
+
+    private static func typeName(_ code: Int32) -> String {
+        // Keep numeric cases so this compiles whether CellsXlsx is imported as
+        // a C module with enum macros or as typed Swift enums.
+        switch code {
+        case 0: return "empty"
+        case 1: return "number"
+        case 2: return "string"
+        case 3: return "bool"
+        default: return "other"
+        }
+    }
+
+    private static func lastErrorMessage(fallback: String) -> String {
+#if canImport(CellsXlsx)
+        if let cString = cells_xlsx_last_error() {
+            let message = String(cString: cString)
+            if !message.isEmpty {
+                return message
+            }
+        }
+#endif
+        return fallback
+    }
+
+    static func successJSON(_ payload: [String: Any]) -> String {
+        var body = payload
+        body["ok"] = true
+        return encode(body)
+    }
+
+    static func errorJSON(_ message: String) -> String {
+        encode(["ok": false, "error": message])
+    }
+
+    private static func encode(_ object: [String: Any]) -> String {
+        guard let data = try? JSONSerialization.data(withJSONObject: object, options: []),
+              let string = String(data: data, encoding: .utf8)
+        else {
+            return #"{"ok":false,"error":"xlsx json encode failed"}"#
+        }
+        return string
+    }
+}
+
+private enum ExcelServiceError: LocalizedError {
+    case message(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .message(let text):
+            return text
+        }
+    }
+}

--- a/app/apple/hermTests/CPSLExcelServiceTests.swift
+++ b/app/apple/hermTests/CPSLExcelServiceTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Testing
+@testable import herm
+
+/// Real cells_xlsx path tests: create → set → write → re-open → read-back
+/// through the shipped CPSLExcelService host bridge (not a re-implementation).
+struct CPSLExcelServiceTests {
+    @Test func createSetWriteReopenReadBack() throws {
+        let service = CPSLExcelService()
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("herm-cells-xlsx-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let outPath = dir.appendingPathComponent("roundtrip.xlsx").path
+
+        let created = try decode(service.handleJSON(#"{"command":"create"}"#))
+        #expect(created["ok"] as? Bool == true)
+        let workbook = try requireString(created, "workbook")
+
+        let setString = try decode(service.handleJSON("""
+        {"command":"set_string","workbook":"\(workbook)","sheet":0,"col":0,"row":0,"value":"hello"}
+        """))
+        #expect(setString["ok"] as? Bool == true)
+
+        let setNumber = try decode(service.handleJSON("""
+        {"command":"set_number","workbook":"\(workbook)","sheet":0,"col":1,"row":0,"value":42.5}
+        """))
+        #expect(setNumber["ok"] as? Bool == true)
+
+        let written = try decode(service.handleJSON("""
+        {"command":"write","workbook":"\(workbook)","path":\(jsonString(outPath))}
+        """))
+        #expect(written["ok"] as? Bool == true, "write failed: \(written)")
+        #expect(FileManager.default.fileExists(atPath: outPath))
+
+        _ = try decode(service.handleJSON("""
+        {"command":"close","workbook":"\(workbook)"}
+        """))
+
+        let reopened = try decode(service.handleJSON("""
+        {"command":"open","path":\(jsonString(outPath))}
+        """))
+        #expect(reopened["ok"] as? Bool == true, "re-open failed: \(reopened)")
+        let wb2 = try requireString(reopened, "workbook")
+
+        let stringCell = try decode(service.handleJSON("""
+        {"command":"get_string","workbook":"\(wb2)","sheet":0,"col":0,"row":0}
+        """))
+        #expect(stringCell["ok"] as? Bool == true)
+        #expect(stringCell["value"] as? String == "hello")
+
+        let numberCell = try decode(service.handleJSON("""
+        {"command":"get_number","workbook":"\(wb2)","sheet":0,"col":1,"row":0}
+        """))
+        #expect(numberCell["ok"] as? Bool == true)
+        let number = numberCell["value"] as? Double ?? (numberCell["value"] as? NSNumber)?.doubleValue
+        #expect(number == 42.5)
+
+        _ = try decode(service.handleJSON("""
+        {"command":"close","workbook":"\(wb2)"}
+        """))
+    }
+
+    @Test func openInvalidPathReturnsError() throws {
+        let service = CPSLExcelService()
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("herm-cells-xlsx-missing-\(UUID().uuidString).xlsx")
+            .path
+        let opened = try decode(service.handleJSON("""
+        {"command":"open","path":\(jsonString(missing))}
+        """))
+        #expect(opened["ok"] as? Bool == false)
+        let error = opened["error"] as? String ?? ""
+        #expect(!error.isEmpty)
+    }
+
+    private func decode(_ json: String) throws -> [String: Any] {
+        guard let data = json.data(using: .utf8),
+              let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            throw TestError("invalid json: \(json)")
+        }
+        return object
+    }
+
+    private func requireString(_ object: [String: Any], _ key: String) throws -> String {
+        guard let value = object[key] as? String else {
+            throw TestError("missing \(key) in \(object)")
+        }
+        return value
+    }
+
+    private func jsonString(_ value: String) -> String {
+        let data = try! JSONSerialization.data(withJSONObject: value, options: [])
+        return String(data: data, encoding: .utf8)!
+    }
+
+    private struct TestError: Error, CustomStringConvertible {
+        let description: String
+        init(_ description: String) { self.description = description }
+    }
+}

--- a/prompts/cpsl/tools.md
+++ b/prompts/cpsl/tools.md
@@ -17,6 +17,7 @@ Use authenticated websites only through their normal browser flow. Do not unhide
 
 If network information is needed, use the sandbox `http` module. Run `http.help()` for usage and `http.policy()` for the current allowed and denied domains.
 If calendar, schedule, availability, current-location, nearby-place, or local-context information is needed, discover and use the sandbox `calendar` and `location` modules when available. Access states are `granted`, `denied`, or `undefined`; undefined access may prompt the user, while denied access must be fixed by the user in iOS Settings or macOS System Settings. Do not request calendar or location access unless it materially helps with the user's request.
+If Excel/spreadsheet work is needed (`.xlsx` create/open/read/write/edit), discover and use the sandbox `xlsx` module when available (`help()` lists it; run `xlsx.help()` for usage). There is no separate `cells` module — spreadsheet support is exposed as `xlsx`.
 
 When `calendar.help()` exposes `calendar.attach`, use it to associate sandbox files with an event in Herm. These are durable Herm-managed attachments, not native Calendar.app attachments.
 

--- a/scripts/build-cells-xlsx-apple.sh
+++ b/scripts/build-cells-xlsx-apple.sh
@@ -1,0 +1,149 @@
+#!/bin/sh
+# Build cells_xlsx static library (+ header/modulemap) for Herm Apple targets.
+set -eu
+
+die() {
+	printf '%s\n' "error: $*" >&2
+	exit 1
+}
+
+usage() {
+	cat <<EOF
+Usage:
+  build-cells-xlsx-apple.sh [--platform iphoneos|iphonesimulator|macosx] [--archs ARCHS]
+
+Builds the aduermael/cells //apps/ios cells_xlsx static library for linking into
+the Herm Apple app. Stages header + lib under:
+  \$OUT_DIR  (default: HERM_ROOT/.herm-cells/artifacts/apple/\$platform)
+
+Environment:
+  CELLS_ROOT   Path to cells checkout (default: sibling ../cells)
+  OUT_DIR      Staging directory override
+  BAZEL        Bazel executable (default: bazelisk or bazel)
+  CONFIGURATION  Debug|Release (affects compilation_mode)
+EOF
+}
+
+platform=
+archs=
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+	--platform)
+		platform=${2:-}
+		[ -n "$platform" ] || die "--platform requires a value"
+		shift 2
+		;;
+	--archs)
+		archs=${2:-}
+		[ -n "$archs" ] || die "--archs requires a value"
+		shift 2
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		die "unknown argument: $1"
+		;;
+	esac
+done
+
+script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd -P)
+herm_root=$(CDPATH= cd "$script_dir/.." && pwd -P)
+. "$script_dir/lib/host-path.sh"
+. "$script_dir/lib/cells-xlsx-apple.sh"
+
+# Xcode run-script phases use a minimal PATH without Homebrew; ensure
+# bazelisk/bazel from /opt/homebrew/bin or /usr/local/bin are visible.
+herm_ensure_host_tools_path
+
+cells_root=$(cells_xlsx_resolve_root "$herm_root")
+bazel=${BAZEL:-}
+if [ -z "$bazel" ]; then
+	if command -v bazelisk >/dev/null 2>&1; then
+		bazel=bazelisk
+	elif command -v bazel >/dev/null 2>&1; then
+		bazel=bazel
+	else
+		die "bazel or bazelisk is required to build cells_xlsx (install via: brew install bazelisk)"
+	fi
+fi
+
+if [ -z "$platform" ]; then
+	platform=$(cells_xlsx_platform_from_xcode "${PLATFORM_NAME:-}" "${SDK_NAME:-}")
+fi
+if [ -z "$archs" ]; then
+	archs=$(cells_xlsx_archs_from_xcode "${ARCHS:-}" "${CURRENT_ARCH:-}")
+fi
+
+configuration=${CONFIGURATION:-Release}
+case "$configuration" in
+Debug | debug)
+	compilation_mode=dbg
+	;;
+*)
+	compilation_mode=opt
+	;;
+esac
+
+work_dir=${CELLS_WORK_DIR:-"$herm_root/.herm-cells"}
+out_dir=${OUT_DIR:-"$work_dir/artifacts/apple/$platform"}
+mkdir -p "$out_dir"
+out_dir=$(CDPATH= cd "$out_dir" && pwd -P)
+
+printf 'Building cells_xlsx for platform=%s archs=%s mode=%s\n' \
+	"$platform" "$archs" "$compilation_mode"
+printf '  cells root: %s\n' "$cells_root"
+printf '  out dir:    %s\n' "$out_dir"
+
+cd "$cells_root"
+
+case "$platform" in
+macosx)
+	cpus=
+	for arch in $archs; do
+		case "$arch" in
+		arm64 | x86_64) ;;
+		*) die "unsupported macOS arch for cells_xlsx: $arch" ;;
+		esac
+		if [ -z "$cpus" ]; then
+			cpus=$arch
+		else
+			cpus="$cpus,$arch"
+		fi
+	done
+	"$bazel" build //apps/ios:cells_xlsx_macos \
+		--compilation_mode="$compilation_mode" \
+		--macos_cpus="$cpus"
+	src_lib=$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' \
+		"$cells_root/bazel-bin/apps/ios/cells_xlsx_macos_lipo.a")
+	;;
+iphoneos | iphonesimulator)
+	cpus=
+	for arch in $archs; do
+		cpu=$(cells_xlsx_ios_cpu_for_arch "$platform" "$arch")
+		if [ -z "$cpus" ]; then
+			cpus=$cpu
+		else
+			cpus="$cpus,$cpu"
+		fi
+	done
+	"$bazel" build //apps/ios:cells_xlsx_ios \
+		--compilation_mode="$compilation_mode" \
+		--apple_platform_type=ios \
+		--ios_multi_cpus="$cpus"
+	src_lib=$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' \
+		"$cells_root/bazel-bin/apps/ios/cells_xlsx_ios_lipo.a")
+	;;
+*)
+	die "unsupported platform: $platform"
+	;;
+esac
+
+cells_xlsx_stage_header "$cells_root" "$out_dir"
+cells_xlsx_stage_static_lib "$src_lib" "$out_dir"
+
+printf 'Staged cells_xlsx:\n'
+printf '  %s\n' "$out_dir/include/cells_xlsx.h"
+printf '  %s\n' "$out_dir/lib/libcells_xlsx.a"
+printf '  %s\n' "$out_dir/include/module.modulemap"

--- a/scripts/lib/cells-xlsx-apple.sh
+++ b/scripts/lib/cells-xlsx-apple.sh
@@ -1,0 +1,125 @@
+# Shared helpers for building/linking cells_xlsx into the Herm Apple app.
+# Source this file; do not execute directly.
+
+cells_xlsx_die() {
+	printf '%s\n' "error: $*" >&2
+	exit 1
+}
+
+cells_xlsx_resolve_root() {
+	herm_root=$1
+	explicit=${CELLS_ROOT:-}
+
+	if [ -n "$explicit" ]; then
+		[ -d "$explicit" ] || cells_xlsx_die "CELLS_ROOT is not a directory: $explicit"
+		[ -f "$explicit/apps/ios/cells_xlsx.h" ] || \
+			cells_xlsx_die "CELLS_ROOT missing apps/ios/cells_xlsx.h: $explicit"
+		CDPATH= cd "$explicit" && pwd -P
+		return 0
+	fi
+
+	sibling=$(CDPATH= cd "$herm_root/../cells" 2>/dev/null && pwd -P) || sibling=
+	if [ -n "$sibling" ] && [ -f "$sibling/apps/ios/cells_xlsx.h" ]; then
+		printf '%s\n' "$sibling"
+		return 0
+	fi
+
+	cells_xlsx_die "cells checkout not found; set CELLS_ROOT or clone aduermael/cells next to herm"
+}
+
+cells_xlsx_platform_from_xcode() {
+	platform_name=${1:-}
+	sdk_name=${2:-}
+
+	case "$platform_name" in
+	iphoneos | iphonesimulator | macosx)
+		printf '%s\n' "$platform_name"
+		return 0
+		;;
+	"")
+		;;
+	*)
+		cells_xlsx_die "unsupported Apple platform for cells_xlsx: $platform_name"
+		;;
+	esac
+
+	case "$sdk_name" in
+	iphoneos*)
+		printf '%s\n' iphoneos
+		;;
+	iphonesimulator*)
+		printf '%s\n' iphonesimulator
+		;;
+	macosx*)
+		printf '%s\n' macosx
+		;;
+	*)
+		cells_xlsx_die "unsupported Apple SDK for cells_xlsx: ${sdk_name:-unknown}"
+		;;
+	esac
+}
+
+cells_xlsx_archs_from_xcode() {
+	archs=${1:-}
+	current_arch=${2:-}
+
+	if [ -n "$archs" ]; then
+		printf '%s\n' "$archs"
+		return 0
+	fi
+	if [ -n "$current_arch" ]; then
+		printf '%s\n' "$current_arch"
+		return 0
+	fi
+	uname -m
+}
+
+cells_xlsx_ios_cpu_for_arch() {
+	platform=$1
+	arch=$2
+
+	case "$platform/$arch" in
+	iphoneos/arm64)
+		printf '%s\n' arm64
+		;;
+	iphonesimulator/arm64)
+		printf '%s\n' sim_arm64
+		;;
+	iphonesimulator/x86_64)
+		printf '%s\n' sim_x86_64
+		;;
+	*)
+		cells_xlsx_die "unsupported iOS cells_xlsx arch: platform=$platform arch=$arch"
+		;;
+	esac
+}
+
+cells_xlsx_stage_header() {
+	cells_root=$1
+	stage_dir=$2
+
+	mkdir -p "$stage_dir/include"
+	cp "$cells_root/apps/ios/cells_xlsx.h" "$stage_dir/include/cells_xlsx.h"
+	cat >"$stage_dir/include/module.modulemap" <<'EOF'
+module CellsXlsx {
+    header "cells_xlsx.h"
+    export *
+}
+EOF
+}
+
+cells_xlsx_stage_static_lib() {
+	src_lib=$1
+	stage_dir=$2
+
+	[ -f "$src_lib" ] || cells_xlsx_die "cells_xlsx static library missing: $src_lib"
+	mkdir -p "$stage_dir/lib"
+	# Resolve symlinks from Bazel into a real file Xcode can cache.
+	# Bazel outputs are often mode 0555; replace atomically so re-stage works.
+	dst="$stage_dir/lib/libcells_xlsx.a"
+	tmp="$dst.tmp.$$"
+	cp -L "$src_lib" "$tmp"
+	chmod u+w "$tmp" 2>/dev/null || true
+	mv -f "$tmp" "$dst"
+	chmod u+w "$dst" 2>/dev/null || true
+}

--- a/scripts/link-cells-xlsx-for-xcode.sh
+++ b/scripts/link-cells-xlsx-for-xcode.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Xcode run-script phase: build cells_xlsx for the active SDK and expose paths.
+set -eu
+
+script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd -P)
+herm_root=$(CDPATH= cd "$script_dir/.." && pwd -P)
+. "$script_dir/lib/cells-xlsx-apple.sh"
+
+platform=$(cells_xlsx_platform_from_xcode "${PLATFORM_NAME:-}" "${SDK_NAME:-}")
+archs=$(cells_xlsx_archs_from_xcode "${ARCHS:-}" "${CURRENT_ARCH:-}")
+work_dir=${CELLS_WORK_DIR:-"$herm_root/.herm-cells"}
+out_dir=${OUT_DIR:-"$work_dir/artifacts/apple/$platform"}
+
+"$script_dir/build-cells-xlsx-apple.sh" --platform "$platform" --archs "$archs"
+
+# Ensure Xcode picks up the staged library even when only the stamp is listed
+# as an output. The app target already points HEADER/LIBRARY search paths here.
+stamp_path=${SCRIPT_OUTPUT_FILE_0:-}
+if [ -n "$stamp_path" ]; then
+	mkdir -p "$(dirname "$stamp_path")"
+	printf 'linked %s platform=%s archs=%s\n' \
+		"$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$platform" "$archs" >"$stamp_path"
+fi
+
+printf 'cells_xlsx ready for Xcode (%s)\n' "$out_dir"

--- a/scripts/test-cells-xlsx-c-api.sh
+++ b/scripts/test-cells-xlsx-c-api.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+# Host smoke test: link real cells_xlsx and exercise create→set→write→reopen→read.
+set -eu
+
+script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd -P)
+herm_root=$(CDPATH= cd "$script_dir/.." && pwd -P)
+. "$script_dir/lib/cells-xlsx-apple.sh"
+
+scratch=${1:-}
+if [ -z "$scratch" ]; then
+	scratch=${HERM_CELLS_XLSX_SCRATCH:-"$herm_root/.herm-cells/smoke"}
+fi
+mkdir -p "$scratch"
+scratch=$(CDPATH= cd "$scratch" && pwd -P)
+
+"$script_dir/build-cells-xlsx-apple.sh" --platform macosx --archs "$(uname -m)"
+
+stage="$herm_root/.herm-cells/artifacts/apple/macosx"
+include="$stage/include"
+libdir="$stage/lib"
+[ -f "$include/cells_xlsx.h" ] || cells_xlsx_die "missing staged header"
+[ -f "$libdir/libcells_xlsx.a" ] || cells_xlsx_die "missing staged static lib"
+
+src="$scratch/cells_xlsx_smoke.c"
+bin="$scratch/cells_xlsx_smoke"
+out_xlsx="$scratch/roundtrip.xlsx"
+
+cat >"$src" <<'EOF'
+#include "cells_xlsx.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(int argc, char **argv) {
+    const char *out_path = argc > 1 ? argv[1] : "/tmp/cells_xlsx_roundtrip.xlsx";
+    CellsXlsxWorkbook *wb = cells_xlsx_create();
+    if (!wb) {
+        fprintf(stderr, "create failed: %s\n", cells_xlsx_last_error());
+        return 1;
+    }
+    if (cells_xlsx_set_string(wb, 0, 0, 0, "hello") != 0) {
+        fprintf(stderr, "set_string failed: %s\n", cells_xlsx_last_error());
+        return 1;
+    }
+    if (cells_xlsx_set_number(wb, 0, 1, 0, 42.5) != 0) {
+        fprintf(stderr, "set_number failed: %s\n", cells_xlsx_last_error());
+        return 1;
+    }
+    if (cells_xlsx_write(wb, out_path) != 0) {
+        fprintf(stderr, "write failed: %s\n", cells_xlsx_last_error());
+        return 1;
+    }
+    cells_xlsx_close(wb);
+
+    wb = cells_xlsx_open(out_path);
+    if (!wb) {
+        fprintf(stderr, "open failed: %s\n", cells_xlsx_last_error());
+        return 1;
+    }
+    const char *s = cells_xlsx_get_string(wb, 0, 0, 0);
+    double n = cells_xlsx_get_number(wb, 0, 1, 0);
+    if (!s || strcmp(s, "hello") != 0) {
+        fprintf(stderr, "string mismatch: %s\n", s ? s : "(null)");
+        return 1;
+    }
+    if (n != 42.5) {
+        fprintf(stderr, "number mismatch: %g\n", n);
+        return 1;
+    }
+    printf("PASS create/set/write/reopen A1=%s B1=%g\n", s, n);
+    cells_xlsx_close(wb);
+
+    /* invalid open */
+    CellsXlsxWorkbook *missing = cells_xlsx_open("/no/such/path/does_not_exist.xlsx");
+    if (missing != NULL) {
+        fprintf(stderr, "expected open failure for missing file\n");
+        return 1;
+    }
+    const char *err = cells_xlsx_last_error();
+    if (!err || err[0] == '\0') {
+        fprintf(stderr, "expected non-empty last_error after failed open\n");
+        return 1;
+    }
+    printf("PASS invalid open error: %s\n", err);
+    return 0;
+}
+EOF
+
+clang -std=c11 \
+	-I"$include" \
+	"$src" \
+	"$libdir/libcells_xlsx.a" \
+	-lc++ \
+	-o "$bin"
+
+"$bin" "$out_xlsx"
+printf 'cells_xlsx C smoke OK (%s)\n' "$out_xlsx"

--- a/scripts/test-cells-xlsx-host-gateway-eval.c
+++ b/scripts/test-cells-xlsx-host-gateway-eval.c
@@ -1,0 +1,412 @@
+/*
+ * Product-path proof: rebuilt libcpsl.dylib host_callbacks_v4 + real cells_xlsx.
+ * Mirrors the Swift CPSLExcelService JSON protocol used by the Apple app.
+ */
+#include "cells_xlsx.h"
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct cpsl_session cpsl_session_t;
+
+typedef char *(*xlsx_handle_json_fn)(void *user_data, const char *request_json);
+typedef void (*xlsx_string_free_fn)(char *value);
+typedef void (*xlsx_user_data_free_fn)(void *user_data);
+
+typedef struct cpsl_xlsx_callbacks {
+    void *user_data;
+    xlsx_handle_json_fn handle_json;
+    xlsx_string_free_fn string_free;
+    xlsx_user_data_free_fn user_data_free;
+} cpsl_xlsx_callbacks_t;
+
+typedef cpsl_session_t *(*session_new_v4_fn)(
+    const char *config_json,
+    const void *webbrowser_callbacks,
+    const void *file_activity_callbacks,
+    const void *calendar_activity_callbacks,
+    const void *location_callbacks,
+    const void *vision_callbacks,
+    const cpsl_xlsx_callbacks_t *xlsx_callbacks);
+typedef void (*session_free_fn)(cpsl_session_t *session);
+typedef char *(*eval_fn)(cpsl_session_t *session, const char *request_json);
+typedef void (*string_free_fn)(char *value);
+typedef const char *(*last_error_fn)(void);
+
+typedef struct {
+    CellsXlsxWorkbook *books[64];
+    char ids[64][32];
+    int count;
+    int next_id;
+} HostState;
+
+static char *owned_strdup(const char *s) {
+    size_t n = strlen(s) + 1;
+    char *p = (char *)malloc(n);
+    if (p) {
+        memcpy(p, s, n);
+    }
+    return p;
+}
+
+static char *json_ok_workbook(const char *id) {
+    char buf[256];
+    snprintf(buf, sizeof(buf), "{\"ok\":true,\"workbook\":\"%s\"}", id);
+    return owned_strdup(buf);
+}
+
+static char *json_ok_empty(void) { return owned_strdup("{\"ok\":true}"); }
+
+static char *json_ok_value_string(const char *v) {
+    /* escape is unnecessary for our fixed test values */
+    char buf[512];
+    snprintf(buf, sizeof(buf), "{\"ok\":true,\"value\":\"%s\"}", v);
+    return owned_strdup(buf);
+}
+
+static char *json_ok_value_number(double n) {
+    char buf[256];
+    snprintf(buf, sizeof(buf), "{\"ok\":true,\"value\":%.17g}", n);
+    return owned_strdup(buf);
+}
+
+static char *json_err(const char *msg) {
+    char buf[512];
+    snprintf(buf, sizeof(buf), "{\"ok\":false,\"error\":\"%s\"}", msg);
+    return owned_strdup(buf);
+}
+
+static const char *json_get_string(const char *json, const char *key, char *out, size_t out_sz) {
+    char pattern[128];
+    snprintf(pattern, sizeof(pattern), "\"%s\":\"", key);
+    const char *p = strstr(json, pattern);
+    if (!p) {
+        return NULL;
+    }
+    p += strlen(pattern);
+    size_t i = 0;
+    while (*p && *p != '"' && i + 1 < out_sz) {
+        out[i++] = *p++;
+    }
+    out[i] = '\0';
+    return out;
+}
+
+static int json_get_int(const char *json, const char *key, int *out) {
+    char pattern[128];
+    snprintf(pattern, sizeof(pattern), "\"%s\":", key);
+    const char *p = strstr(json, pattern);
+    if (!p) {
+        return -1;
+    }
+    p += strlen(pattern);
+    *out = (int)strtol(p, NULL, 10);
+    return 0;
+}
+
+static double json_get_double(const char *json, const char *key, int *ok) {
+    char pattern[128];
+    snprintf(pattern, sizeof(pattern), "\"%s\":", key);
+    const char *p = strstr(json, pattern);
+    if (!p) {
+        *ok = 0;
+        return 0;
+    }
+    p += strlen(pattern);
+    *ok = 1;
+    return strtod(p, NULL);
+}
+
+static CellsXlsxWorkbook *lookup(HostState *st, const char *id) {
+    for (int i = 0; i < st->count; i++) {
+        if (strcmp(st->ids[i], id) == 0) {
+            return st->books[i];
+        }
+    }
+    return NULL;
+}
+
+static char *store(HostState *st, CellsXlsxWorkbook *wb) {
+    if (st->count >= 64) {
+        return json_err("too many workbooks");
+    }
+    char id[32];
+    snprintf(id, sizeof(id), "wb%d", st->next_id++);
+    strcpy(st->ids[st->count], id);
+    st->books[st->count] = wb;
+    st->count++;
+    return json_ok_workbook(id);
+}
+
+static char *host_handle_json(void *user_data, const char *request_json) {
+    HostState *st = (HostState *)user_data;
+    if (!request_json) {
+        return json_err("null request");
+    }
+
+    char command[64] = {0};
+    if (!json_get_string(request_json, "command", command, sizeof(command))) {
+        return json_err("missing command");
+    }
+
+    if (strcmp(command, "create") == 0) {
+        CellsXlsxWorkbook *wb = cells_xlsx_create();
+        if (!wb) {
+            return json_err(cells_xlsx_last_error());
+        }
+        return store(st, wb);
+    }
+
+    if (strcmp(command, "open") == 0) {
+        char path[1024] = {0};
+        if (!json_get_string(request_json, "path", path, sizeof(path))) {
+            return json_err("open: missing path");
+        }
+        CellsXlsxWorkbook *wb = cells_xlsx_open(path);
+        if (!wb) {
+            return json_err(cells_xlsx_last_error());
+        }
+        return store(st, wb);
+    }
+
+    if (strcmp(command, "close") == 0) {
+        char id[64] = {0};
+        if (!json_get_string(request_json, "workbook", id, sizeof(id))) {
+            return json_err("missing workbook");
+        }
+        for (int i = 0; i < st->count; i++) {
+            if (strcmp(st->ids[i], id) == 0) {
+                cells_xlsx_close(st->books[i]);
+                int last = st->count - 1;
+                if (i != last) {
+                    st->books[i] = st->books[last];
+                    memcpy(st->ids[i], st->ids[last], sizeof(st->ids[i]));
+                }
+                st->books[last] = NULL;
+                st->ids[last][0] = '\0';
+                st->count--;
+                break;
+            }
+        }
+        return json_ok_empty();
+    }
+
+    char id[64] = {0};
+    if (!json_get_string(request_json, "workbook", id, sizeof(id))) {
+        return json_err("missing workbook");
+    }
+    CellsXlsxWorkbook *wb = lookup(st, id);
+    if (!wb) {
+        return json_err("invalid workbook");
+    }
+
+    if (strcmp(command, "set_string") == 0) {
+        int sheet = 0, col = 0, row = 0;
+        json_get_int(request_json, "sheet", &sheet);
+        json_get_int(request_json, "col", &col);
+        json_get_int(request_json, "row", &row);
+        char value[512] = {0};
+        if (!json_get_string(request_json, "value", value, sizeof(value))) {
+            return json_err("set_string: missing value");
+        }
+        if (cells_xlsx_set_string(wb, sheet, col, row, value) != 0) {
+            return json_err(cells_xlsx_last_error());
+        }
+        return json_ok_empty();
+    }
+
+    if (strcmp(command, "set_number") == 0) {
+        int sheet = 0, col = 0, row = 0, ok = 0;
+        json_get_int(request_json, "sheet", &sheet);
+        json_get_int(request_json, "col", &col);
+        json_get_int(request_json, "row", &row);
+        double value = json_get_double(request_json, "value", &ok);
+        if (!ok) {
+            return json_err("set_number: missing value");
+        }
+        if (cells_xlsx_set_number(wb, sheet, col, row, value) != 0) {
+            return json_err(cells_xlsx_last_error());
+        }
+        return json_ok_empty();
+    }
+
+    if (strcmp(command, "write") == 0) {
+        char path[1024] = {0};
+        if (!json_get_string(request_json, "path", path, sizeof(path))) {
+            return json_err("write: missing path");
+        }
+        if (cells_xlsx_write(wb, path) != 0) {
+            return json_err(cells_xlsx_last_error());
+        }
+        return json_ok_empty();
+    }
+
+    if (strcmp(command, "get_string") == 0) {
+        int sheet = 0, col = 0, row = 0;
+        json_get_int(request_json, "sheet", &sheet);
+        json_get_int(request_json, "col", &col);
+        json_get_int(request_json, "row", &row);
+        const char *s = cells_xlsx_get_string(wb, sheet, col, row);
+        if (!s) {
+            return json_err(cells_xlsx_last_error());
+        }
+        return json_ok_value_string(s);
+    }
+
+    if (strcmp(command, "get_number") == 0) {
+        int sheet = 0, col = 0, row = 0;
+        json_get_int(request_json, "sheet", &sheet);
+        json_get_int(request_json, "col", &col);
+        json_get_int(request_json, "row", &row);
+        double n = cells_xlsx_get_number(wb, sheet, col, row);
+        return json_ok_value_number(n);
+    }
+
+    return json_err("unsupported command");
+}
+
+static void host_string_free(char *value) { free(value); }
+
+static void host_user_data_free(void *user_data) {
+    HostState *st = (HostState *)user_data;
+    if (!st) {
+        return;
+    }
+    for (int i = 0; i < st->count; i++) {
+        cells_xlsx_close(st->books[i]);
+    }
+    free(st);
+}
+
+int main(int argc, char **argv) {
+    if (argc < 3) {
+        fprintf(stderr, "usage: %s <libcpsl.dylib> <workdir>\n", argv[0]);
+        return 2;
+    }
+    const char *dylib_path = argv[1];
+    const char *workdir = argv[2];
+
+    void *lib = dlopen(dylib_path, RTLD_NOW | RTLD_LOCAL);
+    if (!lib) {
+        fprintf(stderr, "dlopen failed: %s\n", dlerror());
+        return 1;
+    }
+
+    session_new_v4_fn session_new_v4 =
+        (session_new_v4_fn)dlsym(lib, "cpsl_session_new_with_host_callbacks_v4");
+    session_free_fn session_free = (session_free_fn)dlsym(lib, "cpsl_session_free");
+    eval_fn eval = (eval_fn)dlsym(lib, "cpsl_eval");
+    string_free_fn string_free = (string_free_fn)dlsym(lib, "cpsl_string_free");
+    last_error_fn last_error = (last_error_fn)dlsym(lib, "cpsl_last_error");
+
+    if (!session_new_v4 || !session_free || !eval || !string_free) {
+        fprintf(stderr, "missing CPSL symbols (v4=%p eval=%p)\n", (void *)session_new_v4,
+                (void *)eval);
+        return 1;
+    }
+    printf("SYMBOL_OK cpsl_session_new_with_host_callbacks_v4\n");
+
+    HostState *st = (HostState *)calloc(1, sizeof(HostState));
+    st->next_id = 1;
+    cpsl_xlsx_callbacks_t xlsx_cb = {
+        .user_data = st,
+        .handle_json = host_handle_json,
+        .string_free = host_string_free,
+        .user_data_free = host_user_data_free,
+    };
+
+    char config[2048];
+    snprintf(config, sizeof(config),
+             "{"
+             "\"language\":\"luau\","
+             "\"initial_cwd\":\"/workdir\","
+             "\"mounts\":[{\"host\":\"%s\",\"virtual\":\"/workdir\",\"mode\":\"rw\"}],"
+             "\"http\":{\"mode\":\"policy\",\"allow_domains\":[],\"deny_domains\":[]}"
+             "}",
+             workdir);
+
+    cpsl_session_t *session =
+        session_new_v4(config, NULL, NULL, NULL, NULL, NULL, &xlsx_cb);
+    if (!session) {
+        fprintf(stderr, "session_new_v4 failed: %s\n",
+                last_error ? last_error() : "(no last_error)");
+        return 1;
+    }
+    printf("SESSION_OK\n");
+
+    const char *script =
+        "local created = xlsx.create()\n"
+        "local wb = created.workbook\n"
+        "xlsx.set_string(wb, 0, 0, 0, \"hello\")\n"
+        "xlsx.set_number(wb, 0, 1, 0, 42.5)\n"
+        "xlsx.write(wb, \"/workdir/out.xlsx\")\n"
+        "xlsx.close(wb)\n"
+        "local reopened = xlsx.open(\"/workdir/out.xlsx\")\n"
+        "local wb2 = reopened.workbook\n"
+        "local s = xlsx.get_string(wb2, 0, 0, 0).value\n"
+        "local n = xlsx.get_number(wb2, 0, 1, 0).value\n"
+        "xlsx.close(wb2)\n"
+        "return s .. \"|\" .. tostring(n)\n";
+
+    char request[4096];
+    /* Escape newlines into JSON string */
+    {
+        char escaped[3500];
+        size_t j = 0;
+        for (size_t i = 0; script[i] && j + 2 < sizeof(escaped); i++) {
+            char c = script[i];
+            if (c == '\\' || c == '"') {
+                escaped[j++] = '\\';
+                escaped[j++] = c;
+            } else if (c == '\n') {
+                escaped[j++] = '\\';
+                escaped[j++] = 'n';
+            } else if (c == '\r') {
+                /* skip */
+            } else {
+                escaped[j++] = c;
+            }
+        }
+        escaped[j] = '\0';
+        snprintf(request, sizeof(request),
+                 "{\"language\":\"luau\",\"input\":\"%s\",\"timeout_ms\":60000}", escaped);
+    }
+
+    char *response = eval(session, request);
+    if (!response) {
+        fprintf(stderr, "eval failed: %s\n", last_error ? last_error() : "(no last_error)");
+        session_free(session);
+        return 1;
+    }
+    printf("EVAL_RAW=%s\n", response);
+
+    /* Prefer result field if present */
+    char result_buf[256] = {0};
+    if (json_get_string(response, "result", result_buf, sizeof(result_buf)) ||
+        json_get_string(response, "value", result_buf, sizeof(result_buf)) ||
+        strstr(response, "hello|42.5")) {
+        if (strstr(response, "hello|42.5")) {
+            printf("RESULT=hello|42.5\n");
+        } else {
+            printf("RESULT=%s\n", result_buf);
+        }
+    } else {
+        fprintf(stderr, "unexpected eval response (no hello|42.5): %s\n", response);
+        string_free(response);
+        session_free(session);
+        return 1;
+    }
+
+    if (!strstr(response, "hello|42.5") && !strstr(result_buf, "hello|42.5")) {
+        fprintf(stderr, "RESULT mismatch\n");
+        string_free(response);
+        session_free(session);
+        return 1;
+    }
+
+    string_free(response);
+    session_free(session);
+    printf("PASS product host_callbacks_v4 + cells_xlsx Luau round-trip\n");
+    return 0;
+}

--- a/scripts/test-cells-xlsx-host-gateway-eval.sh
+++ b/scripts/test-cells-xlsx-host-gateway-eval.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Product-path: rebuilt libcpsl.dylib host_callbacks_v4 + real cells_xlsx Luau eval.
+set -eu
+
+script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd -P)
+herm_root=$(CDPATH= cd "$script_dir/.." && pwd -P)
+scratch=${1:-}
+if [ -z "$scratch" ]; then
+	scratch=${HERM_CELLS_XLSX_SCRATCH:-"$herm_root/.herm-cells/host-gateway-eval"}
+fi
+mkdir -p "$scratch"
+scratch=$(CDPATH= cd "$scratch" && pwd -P)
+
+"$script_dir/build-cells-xlsx-apple.sh" --platform macosx --archs "$(uname -m)"
+
+stage="$herm_root/.herm-cells/artifacts/apple/macosx"
+include="$stage/include"
+libdir="$stage/lib"
+
+# Prefer freshly rebuilt Debug XCFramework macos slice (bazel apple-app + xlsx).
+dylib=""
+for candidate in \
+	"$herm_root/.herm-cpsl/artifacts/apple/Debug/cpsl.xcframework/macos-arm64_x86_64/libcpsl.dylib" \
+	"$herm_root/.herm-cpsl/artifacts/apple/Debug/slices/macos/libcpsl.dylib" \
+	"$herm_root/.herm-cpsl/artifacts/apple/Debug/slices/aarch64-apple-darwin/libcpsl.dylib"
+do
+	if [ -f "$candidate" ] && nm "$candidate" 2>/dev/null | grep -q 'cpsl_session_new_with_host_callbacks_v4'; then
+		dylib=$candidate
+		break
+	fi
+done
+
+if [ -z "$dylib" ]; then
+	printf '%s\n' "error: no rebuilt libcpsl.dylib with host_callbacks_v4 found under .herm-cpsl" >&2
+	exit 1
+fi
+
+printf 'Using CPSL dylib: %s\n' "$dylib"
+nm "$dylib" | grep 'cpsl_session_new_with_host_callbacks_v4' || true
+
+workdir="$scratch/workdir"
+mkdir -p "$workdir"
+bin="$scratch/host_gateway_eval"
+src="$script_dir/test-cells-xlsx-host-gateway-eval.c"
+
+clang -std=c11 \
+	-I"$include" \
+	"$src" \
+	"$libdir/libcells_xlsx.a" \
+	-lc++ \
+	-o "$bin"
+
+"$bin" "$dylib" "$workdir"
+printf 'host-gateway product path OK\n'

--- a/scripts/test-cells-xlsx-luau-eval.sh
+++ b/scripts/test-cells-xlsx-luau-eval.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Run Luau create→set→write→reopen against the real cells_xlsx C ABI via CPSL.
+set -eu
+
+script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd -P)
+herm_root=$(CDPATH= cd "$script_dir/.." && pwd -P)
+
+"$script_dir/build-cells-xlsx-apple.sh" --platform macosx --archs "$(uname -m)"
+
+stage="$herm_root/.herm-cells/artifacts/apple/macosx"
+libdir="$stage/lib"
+[ -f "$libdir/libcells_xlsx.a" ] || {
+	printf '%s\n' "error: missing $libdir/libcells_xlsx.a" >&2
+	exit 1
+}
+
+export RUSTFLAGS="${RUSTFLAGS:-} -L${libdir} -lcells_xlsx -lc++"
+cd "$script_dir/test-cells-xlsx-luau-eval"
+cargo run --quiet

--- a/scripts/test-cells-xlsx-luau-eval/Cargo.toml
+++ b/scripts/test-cells-xlsx-luau-eval/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "cells-xlsx-luau-eval"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+cpsl-core = { path = "../../external/cpsl/core", default-features = false, features = ["mod-xlsx", "mod-fs", "mod-json"] }
+serde_json = "1"
+tempfile = "3"
+
+[profile.dev]
+# Link the staged cells_xlsx static library (set LIBRARY_PATH / RUSTFLAGS from the shell script).

--- a/scripts/test-cells-xlsx-luau-eval/src/main.rs
+++ b/scripts/test-cells-xlsx-luau-eval/src/main.rs
@@ -1,0 +1,312 @@
+//! Luau create→set→write→reopen→read-back via CPSL sandbox + real cells_xlsx C ABI.
+
+use cpsl_core::{MountPermission, MountTable, Sandbox, XlsxGateway};
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use std::ffi::{CStr, CString};
+use std::os::raw::{c_char, c_double, c_int};
+use std::sync::Arc;
+use std::sync::Mutex;
+
+#[repr(C)]
+struct CellsXlsxWorkbook {
+    _private: [u8; 0],
+}
+
+extern "C" {
+    fn cells_xlsx_last_error() -> *const c_char;
+    fn cells_xlsx_open(path: *const c_char) -> *mut CellsXlsxWorkbook;
+    fn cells_xlsx_create() -> *mut CellsXlsxWorkbook;
+    fn cells_xlsx_close(wb: *mut CellsXlsxWorkbook);
+    fn cells_xlsx_sheet_count(wb: *const CellsXlsxWorkbook) -> c_int;
+    fn cells_xlsx_sheet_name(
+        wb: *const CellsXlsxWorkbook,
+        sheet_index: c_int,
+        buf: *mut c_char,
+        buf_size: usize,
+    ) -> c_int;
+    fn cells_xlsx_get_type(
+        wb: *const CellsXlsxWorkbook,
+        sheet_index: c_int,
+        col: c_int,
+        row: c_int,
+    ) -> c_int;
+    fn cells_xlsx_get_number(
+        wb: *const CellsXlsxWorkbook,
+        sheet_index: c_int,
+        col: c_int,
+        row: c_int,
+    ) -> c_double;
+    fn cells_xlsx_get_bool(
+        wb: *const CellsXlsxWorkbook,
+        sheet_index: c_int,
+        col: c_int,
+        row: c_int,
+    ) -> c_int;
+    fn cells_xlsx_get_string(
+        wb: *mut CellsXlsxWorkbook,
+        sheet_index: c_int,
+        col: c_int,
+        row: c_int,
+    ) -> *const c_char;
+    fn cells_xlsx_set_number(
+        wb: *mut CellsXlsxWorkbook,
+        sheet_index: c_int,
+        col: c_int,
+        row: c_int,
+        value: c_double,
+    ) -> c_int;
+    fn cells_xlsx_set_string(
+        wb: *mut CellsXlsxWorkbook,
+        sheet_index: c_int,
+        col: c_int,
+        row: c_int,
+        value: *const c_char,
+    ) -> c_int;
+    fn cells_xlsx_set_bool(
+        wb: *mut CellsXlsxWorkbook,
+        sheet_index: c_int,
+        col: c_int,
+        row: c_int,
+        value: c_int,
+    ) -> c_int;
+    fn cells_xlsx_write(wb: *const CellsXlsxWorkbook, path: *const c_char) -> c_int;
+}
+
+struct NativeCellsGateway {
+    next_id: Mutex<u64>,
+    books: Mutex<HashMap<String, *mut CellsXlsxWorkbook>>,
+}
+
+// cells_xlsx workbook handles are used from a single-threaded gateway lock in practice.
+unsafe impl Send for NativeCellsGateway {}
+unsafe impl Sync for NativeCellsGateway {}
+
+impl NativeCellsGateway {
+    fn new() -> Self {
+        Self {
+            next_id: Mutex::new(1),
+            books: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn last_error() -> String {
+        unsafe {
+            let p = cells_xlsx_last_error();
+            if p.is_null() {
+                return "unknown cells_xlsx error".into();
+            }
+            CStr::from_ptr(p).to_string_lossy().into_owned()
+        }
+    }
+
+    fn store(&self, wb: *mut CellsXlsxWorkbook) -> String {
+        let mut id = self.next_id.lock().unwrap();
+        let key = format!("wb{id}");
+        *id += 1;
+        self.books.lock().unwrap().insert(key.clone(), wb);
+        key
+    }
+
+    fn handle(&self, id: &str) -> Result<*mut CellsXlsxWorkbook, String> {
+        self.books
+            .lock()
+            .unwrap()
+            .get(id)
+            .copied()
+            .ok_or_else(|| "invalid workbook handle".into())
+    }
+}
+
+impl Drop for NativeCellsGateway {
+    fn drop(&mut self) {
+        let books = std::mem::take(&mut *self.books.lock().unwrap());
+        for (_, wb) in books {
+            unsafe { cells_xlsx_close(wb) };
+        }
+    }
+}
+
+impl XlsxGateway for NativeCellsGateway {
+    fn handle_json(&self, request_json: &str) -> Result<String, String> {
+        let req: Value = serde_json::from_str(request_json).map_err(|e| e.to_string())?;
+        let command = req
+            .get("command")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| "missing command".to_string())?;
+
+        match command {
+            "create" => {
+                let wb = unsafe { cells_xlsx_create() };
+                if wb.is_null() {
+                    return Ok(json!({"ok":false,"error": Self::last_error()}).to_string());
+                }
+                let id = self.store(wb);
+                Ok(json!({"ok":true,"workbook": id}).to_string())
+            }
+            "open" => {
+                let path = req
+                    .get("path")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| "open: missing path".to_string())?;
+                let c_path = CString::new(path).map_err(|e| e.to_string())?;
+                let wb = unsafe { cells_xlsx_open(c_path.as_ptr()) };
+                if wb.is_null() {
+                    return Ok(json!({"ok":false,"error": Self::last_error()}).to_string());
+                }
+                let id = self.store(wb);
+                Ok(json!({"ok":true,"workbook": id}).to_string())
+            }
+            "close" => {
+                let id = workbook_id(&req)?;
+                if let Some(wb) = self.books.lock().unwrap().remove(&id) {
+                    unsafe { cells_xlsx_close(wb) };
+                }
+                Ok(json!({"ok":true}).to_string())
+            }
+            "sheet_count" => {
+                let wb = self.handle(&workbook_id(&req)?)?;
+                let count = unsafe { cells_xlsx_sheet_count(wb) };
+                if count < 0 {
+                    return Ok(json!({"ok":false,"error": Self::last_error()}).to_string());
+                }
+                Ok(json!({"ok":true,"count": count}).to_string())
+            }
+            "get_string" => {
+                let wb = self.handle(&workbook_id(&req)?)?;
+                let sheet = int_field(&req, "sheet")? as c_int;
+                let col = int_field(&req, "col")? as c_int;
+                let row = int_field(&req, "row")? as c_int;
+                let p = unsafe { cells_xlsx_get_string(wb, sheet, col, row) };
+                if p.is_null() {
+                    return Ok(json!({"ok":false,"error": Self::last_error()}).to_string());
+                }
+                let s = unsafe { CStr::from_ptr(p) }.to_string_lossy().into_owned();
+                Ok(json!({"ok":true,"value": s}).to_string())
+            }
+            "get_number" => {
+                let wb = self.handle(&workbook_id(&req)?)?;
+                let sheet = int_field(&req, "sheet")? as c_int;
+                let col = int_field(&req, "col")? as c_int;
+                let row = int_field(&req, "row")? as c_int;
+                let n = unsafe { cells_xlsx_get_number(wb, sheet, col, row) };
+                Ok(json!({"ok":true,"value": n}).to_string())
+            }
+            "set_string" => {
+                let wb = self.handle(&workbook_id(&req)?)?;
+                let sheet = int_field(&req, "sheet")? as c_int;
+                let col = int_field(&req, "col")? as c_int;
+                let row = int_field(&req, "row")? as c_int;
+                let value = req
+                    .get("value")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| "set_string: missing value".to_string())?;
+                let c_value = CString::new(value).map_err(|e| e.to_string())?;
+                let rc = unsafe { cells_xlsx_set_string(wb, sheet, col, row, c_value.as_ptr()) };
+                if rc != 0 {
+                    return Ok(json!({"ok":false,"error": Self::last_error()}).to_string());
+                }
+                Ok(json!({"ok":true}).to_string())
+            }
+            "set_number" => {
+                let wb = self.handle(&workbook_id(&req)?)?;
+                let sheet = int_field(&req, "sheet")? as c_int;
+                let col = int_field(&req, "col")? as c_int;
+                let row = int_field(&req, "row")? as c_int;
+                let value = req
+                    .get("value")
+                    .and_then(|v| v.as_f64())
+                    .ok_or_else(|| "set_number: missing value".to_string())?;
+                let rc = unsafe { cells_xlsx_set_number(wb, sheet, col, row, value) };
+                if rc != 0 {
+                    return Ok(json!({"ok":false,"error": Self::last_error()}).to_string());
+                }
+                Ok(json!({"ok":true}).to_string())
+            }
+            "write" => {
+                let wb = self.handle(&workbook_id(&req)?)?;
+                let path = req
+                    .get("path")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| "write: missing path".to_string())?;
+                let c_path = CString::new(path).map_err(|e| e.to_string())?;
+                let rc = unsafe { cells_xlsx_write(wb, c_path.as_ptr()) };
+                if rc != 0 {
+                    return Ok(json!({"ok":false,"error": Self::last_error()}).to_string());
+                }
+                Ok(json!({"ok":true}).to_string())
+            }
+            other => Err(format!("unsupported command {other}")),
+        }
+    }
+}
+
+fn workbook_id(req: &Value) -> Result<String, String> {
+    req.get("workbook")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| "missing workbook".to_string())
+}
+
+fn int_field(req: &Value, name: &str) -> Result<i64, String> {
+    req.get(name)
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| format!("missing {name}"))
+}
+
+fn main() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let mut mounts = MountTable::new();
+    mounts
+        .add_mount(
+            tmp.path().to_path_buf(),
+            "/workdir",
+            MountPermission::ReadWrite,
+        )
+        .unwrap();
+
+    let gateway: Arc<dyn XlsxGateway> = Arc::new(NativeCellsGateway::new());
+    let sandbox = Sandbox::builder()
+        .mounts(mounts)
+        .auto_tmp(false)
+        .xlsx_gateway(gateway)
+        .build()
+        .expect("sandbox");
+
+    let help = sandbox.exec("return xlsx.help()").expect("help");
+    assert!(
+        help.contains("open") && help.contains("write") && help.contains("create"),
+        "help missing expected APIs: {help}"
+    );
+    println!("----- xlsx.help() -----");
+    println!("{help}");
+    println!("----- end help -----");
+    println!("HELP_OK");
+
+    let script = r#"
+        local created = xlsx.create()
+        local wb = created.workbook
+        xlsx.set_string(wb, 0, 0, 0, "hello")
+        xlsx.set_number(wb, 0, 1, 0, 42.5)
+        xlsx.write(wb, "/workdir/out.xlsx")
+        xlsx.close(wb)
+        local reopened = xlsx.open("/workdir/out.xlsx")
+        local wb2 = reopened.workbook
+        local s = xlsx.get_string(wb2, 0, 0, 0).value
+        local n = xlsx.get_number(wb2, 0, 1, 0).value
+        xlsx.close(wb2)
+        return s .. "|" .. tostring(n)
+    "#;
+    let result = sandbox.exec(script).expect("luau eval");
+    println!("RESULT={result}");
+    assert!(
+        result.contains("hello") && result.contains("42.5"),
+        "unexpected result: {result}"
+    );
+
+    let err = sandbox
+        .exec(r#"return xlsx.open("/workdir/does_not_exist.xlsx")"#)
+        .expect_err("invalid open should fail");
+    println!("INVALID_OPEN={err}");
+    println!("PASS luau create/set/write/reopen via real cells_xlsx");
+}

--- a/scripts/test-cpsl-apple-build-integration.sh
+++ b/scripts/test-cpsl-apple-build-integration.sh
@@ -22,12 +22,14 @@ repo_root=$(CDPATH= cd "$script_dir/.." && pwd -P)
 bazel_build="$repo_root/BUILD.bazel"
 assert_contains "Bazel apple profile webbrowser" '"webbrowser"' "$bazel_build"
 assert_contains "Bazel apple profile location" '"location"' "$bazel_build"
+assert_contains "Bazel apple profile xlsx" '"xlsx"' "$bazel_build"
 assert_contains "Bazel apple profile calendar" '"calendar"' "$bazel_build"
 assert_contains "Bazel apple profile doc" '"doc"' "$bazel_build"
 assert_contains "Bazel apple profile pdfium-render" '"pdfium-render"' "$bazel_build"
 assert_contains "Bazel apple profile embedded-agent" '"embedded-agent"' "$bazel_build"
 assert_contains "Bazel core apple webbrowser module" '"mod-webbrowser"' "$bazel_build"
 assert_contains "Bazel core apple location module" '"mod-location"' "$bazel_build"
+assert_contains "Bazel core apple xlsx module" '"mod-xlsx"' "$bazel_build"
 
 tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/cpsl-apple-build-integration.XXXXXX")
 cleanup() {


### PR DESCRIPTION
## Summary

- Wire the Luau `xlsx` module into the iOS/macOS app by linking `cells_xlsx` through Xcode build scripts and a host bridge (`CPSLExcelService`).
- Enable CPSL `mod-xlsx` / `host_callbacks_v4`, point the `cpsl` submodule at the xlsx host-gateway changes, and teach agent prompts to discover `xlsx` for spreadsheet work.
- Add integration/debug hooks in `CPSLDebugService`, unit tests for the Swift host bridge, and C/Rust/shell eval tests for the cells_xlsx C API and host gateway.

## Test plan

- [ ] Run Apple/unit coverage for the new bridge (`CPSLExcelServiceTests`)
- [ ] Run `scripts/test-cells-xlsx-c-api.sh` and host-gateway / Luau eval scripts
- [ ] Build the Apple app and confirm `cells_xlsx` links via the Xcode scripts
- [ ] In-app: open/create/edit a `.xlsx` via the sandbox `xlsx` module (`xlsx.help()`)
- [ ] Confirm agent prompt path surfaces `xlsx` for spreadsheet tasks