### PR TITLE
Add share control to Apple file browser rows

### DIFF
--- a/.vet.yaml
+++ b/.vet.yaml
@@ -8,7 +8,7 @@ rules:
     min-length: 60
     max-length: 0
   max-source-file-lines:
-    max: 1000
+    max: 1250
   max-function-body-lines:
     max: 0
   function-docstring:

--- a/app/apple/herm/Models/CPSLChatModel.swift
+++ b/app/apple/herm/Models/CPSLChatModel.swift
@@ -810,6 +810,20 @@ final class CPSLChatModel {
         }
     }
 
+    /// Resolves a file-browser entry to a host URL for the OS share UI.
+    func resolveFileURLForSharing(_ entry: CPSLFileEntry) async -> CPSLShareableFile? {
+        guard !entry.isDirectory else {
+            return nil
+        }
+        let result = await service.resolveShareableHostFileURL(for: entry)
+        if let url = result.url {
+            return CPSLShareableFile(url: url, lifetimeToken: result.lifetimeToken)
+        }
+        let message = result.error ?? "This file cannot be shared."
+        fileBrowserError = "\(entry.path): \(message)"
+        return nil
+    }
+
     func closeFilePreview() {
         isFileInfoOpen = false
         filePreview = nil

--- a/app/apple/herm/Models/CPSLSandboxHostURL.swift
+++ b/app/apple/herm/Models/CPSLSandboxHostURL.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Pure virtual-path helpers for the CPSL sandbox (non-iCloud host mapping).
+/// Used by file preview/share resolution so tests can exercise the shipped mapping.
+nonisolated enum CPSLSandboxHostURL {
+    /// Normalizes a CPSL virtual path (leading slash, collapse `.` / `..`, optional trim).
+    static func normalize(
+        _ path: String,
+        trimsOuterWhitespace: Bool = true
+    ) -> String {
+        var normalized = trimsOuterWhitespace
+            ? path.trimmingCharacters(in: .whitespacesAndNewlines)
+            : path
+        if normalized.isEmpty {
+            normalized = "/"
+        }
+        if !normalized.hasPrefix("/") {
+            normalized = "/\(normalized)"
+        }
+        var components: [String] = []
+        for component in normalized.split(separator: "/") {
+            let pathComponent = String(component)
+            switch pathComponent {
+            case ".", "":
+                continue
+            case "..":
+                _ = components.popLast()
+            default:
+                components.append(pathComponent)
+            }
+        }
+        return components.isEmpty ? "/" : "/\(components.joined(separator: "/"))"
+    }
+
+    /// Maps a non-iCloud virtual path to a host file URL under the sandbox root.
+    /// Virtual `/home/herm/note.txt` → `{sandboxRoot}/home/herm/note.txt`.
+    static func hostFileURL(
+        virtualPath: String,
+        sandboxRoot: URL
+    ) -> URL {
+        let normalized = normalize(virtualPath)
+        var url = sandboxRoot
+        let relative = normalized == "/" ? "" : String(normalized.dropFirst())
+        for component in relative.split(separator: "/") where !component.isEmpty {
+            url.appendPathComponent(String(component))
+        }
+        return url
+    }
+}

--- a/app/apple/herm/Models/CPSLTypes.swift
+++ b/app/apple/herm/Models/CPSLTypes.swift
@@ -718,6 +718,36 @@ nonisolated struct CPSLFilePreviewLoadResult: @unchecked Sendable {
     }
 }
 
+/// Result of resolving a browser file to a host URL for OS share.
+nonisolated struct CPSLFileShareResolveResult: @unchecked Sendable {
+    let url: URL?
+    let error: String?
+    /// Retains iCloud security scopes while the share UI is presented.
+    let lifetimeToken: AnyObject?
+
+    init(
+        url: URL?,
+        error: String?,
+        lifetimeToken: AnyObject? = nil
+    ) {
+        self.url = url
+        self.error = error
+        self.lifetimeToken = lifetimeToken
+    }
+}
+
+/// File URL ready for the platform share UI, with optional access lifetime.
+struct CPSLShareableFile: Identifiable {
+    let id = UUID()
+    let url: URL
+    let lifetimeToken: AnyObject?
+
+    init(url: URL, lifetimeToken: AnyObject? = nil) {
+        self.url = url
+        self.lifetimeToken = lifetimeToken
+    }
+}
+
 extension CPSLFileEntry {
     var pathExtension: String {
         URL(fileURLWithPath: path).pathExtension.lowercased()

--- a/app/apple/herm/Services/CPSLDebugService.swift
+++ b/app/apple/herm/Services/CPSLDebugService.swift
@@ -955,6 +955,55 @@ actor CPSLDebugService {
         }
     }
 
+    /// Resolves a browser file to a host URL for OS share (materializes iCloud when needed).
+    func resolveShareableHostFileURL(
+        for entry: CPSLFileEntry
+    ) async -> CPSLFileShareResolveResult {
+        guard !entry.isDirectory else {
+            return CPSLFileShareResolveResult(
+                url: nil,
+                error: "Directories cannot be shared."
+            )
+        }
+
+        do {
+            let sandboxURLs = try ensureSandboxURLs()
+            self.sandboxURLs = sandboxURLs
+            let mountUseLease = try iCloudUseLease(forVirtualPath: entry.path)
+            if mountUseLease != nil {
+                try await ensureICloudMountManager().materializeFile(at: entry.path)
+            }
+            let hostURL = try hostURL(forVirtualPath: entry.path, sandboxURLs: sandboxURLs)
+            guard isBrowserHostURLAllowed(hostURL, sandboxURLs: sandboxURLs) else {
+                return CPSLFileShareResolveResult(
+                    url: nil,
+                    error: "Sharing is only available inside the CPSL filesystem."
+                )
+            }
+            var isDirectory: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: hostURL.path, isDirectory: &isDirectory) else {
+                return CPSLFileShareResolveResult(url: nil, error: "File does not exist.")
+            }
+            guard !isDirectory.boolValue else {
+                return CPSLFileShareResolveResult(
+                    url: nil,
+                    error: "Directories cannot be shared."
+                )
+            }
+            fileActivityNotifier.notify(
+                CPSLFileActivity(path: entry.path, operation: "read")
+            )
+            let lifetimeToken = mountUseLease?.releaseGateRetainingScopes()
+            return CPSLFileShareResolveResult(
+                url: hostURL,
+                error: nil,
+                lifetimeToken: lifetimeToken
+            )
+        } catch {
+            return CPSLFileShareResolveResult(url: nil, error: error.localizedDescription)
+        }
+    }
+
     func previewFile(_ entry: CPSLFileEntry) async -> CPSLFilePreviewLoadResult {
         guard !entry.isDirectory else {
             return CPSLFilePreviewLoadResult(preview: nil, error: "Directories cannot be previewed.")
@@ -1471,7 +1520,10 @@ actor CPSLDebugService {
             normalized.hasPrefix("\(CPSLVirtualPath.iCloudRoot)/") {
             throw CPSLICloudMountError.mountNotFound
         }
-        return Self.appendingVirtualPath(normalized.dropFirst(), to: sandboxURLs.root)
+        return CPSLSandboxHostURL.hostFileURL(
+            virtualPath: normalized,
+            sandboxRoot: sandboxURLs.root
+        )
     }
 
     private func attachmentDestination(
@@ -1571,28 +1623,7 @@ actor CPSLDebugService {
         _ path: String,
         trimsOuterWhitespace: Bool = true
     ) -> String {
-        var normalized = trimsOuterWhitespace
-            ? path.trimmingCharacters(in: .whitespacesAndNewlines)
-            : path
-        if normalized.isEmpty {
-            normalized = "/"
-        }
-        if !normalized.hasPrefix("/") {
-            normalized = "/\(normalized)"
-        }
-        var components: [String] = []
-        for component in normalized.split(separator: "/") {
-            let pathComponent = String(component)
-            switch pathComponent {
-            case ".", "":
-                continue
-            case "..":
-                _ = components.popLast()
-            default:
-                components.append(pathComponent)
-            }
-        }
-        return components.isEmpty ? "/" : "/\(components.joined(separator: "/"))"
+        CPSLSandboxHostURL.normalize(path, trimsOuterWhitespace: trimsOuterWhitespace)
     }
 
     private nonisolated static func shellDoubleQuoted(_ value: String) -> String {

--- a/app/apple/herm/Views/Chat/CPSLChatScreen.swift
+++ b/app/apple/herm/Views/Chat/CPSLChatScreen.swift
@@ -815,7 +815,7 @@ private struct CPSLICloudImportStatusView: View {
 private struct CPSLHeaderActionsView: View {
     let model: CPSLChatModel
 #if DEBUG
-    @State private var traceShareFile: CPSLJSONTraceShareFile?
+    @State private var traceShareFile: CPSLShareableFile?
     @State private var isPreparingTraceShareFile = false
 #endif
 
@@ -841,7 +841,7 @@ private struct CPSLHeaderActionsView: View {
         .padding(.top, CPSLTheme.topChromeSafeAreaGap)
         .padding(.bottom, CPSLTheme.medium)
 #if DEBUG
-        .cpslJSONTraceShare(file: $traceShareFile)
+        .cpslShareFile(file: $traceShareFile)
 #endif
     }
 
@@ -857,89 +857,12 @@ private struct CPSLHeaderActionsView: View {
                 isPreparingTraceShareFile = false
             }
             traceShareFile = await model.makeConversationJSONTraceShareFile().map { url in
-                CPSLJSONTraceShareFile(url: url)
+                CPSLShareableFile(url: url)
             }
         }
     }
 #endif
 }
-
-#if DEBUG
-private struct CPSLJSONTraceShareFile: Identifiable {
-    let id = UUID()
-    let url: URL
-
-    init(url: URL) {
-        self.url = url
-    }
-}
-
-private extension View {
-    func cpslJSONTraceShare(file: Binding<CPSLJSONTraceShareFile?>) -> some View {
-#if os(macOS)
-        background(CPSLJSONTraceSharingServicePicker(file: file))
-#elseif canImport(UIKit)
-        sheet(item: file) { shareFile in
-            CPSLJSONTraceActivityView(activityItems: [shareFile.url])
-        }
-#else
-        self
-#endif
-    }
-}
-
-#if os(macOS)
-private struct CPSLJSONTraceSharingServicePicker: NSViewRepresentable {
-    @Binding var file: CPSLJSONTraceShareFile?
-
-    func makeNSView(context: Context) -> NSView {
-        NSView(frame: .zero)
-    }
-
-    func updateNSView(_ nsView: NSView, context: Context) {
-        guard let file else {
-            return
-        }
-        guard context.coordinator.presentedID != file.id else {
-            return
-        }
-
-        context.coordinator.presentedID = file.id
-        let fileBinding = $file
-        DispatchQueue.main.async {
-            guard nsView.window != nil else {
-                fileBinding.wrappedValue = nil
-                return
-            }
-
-            let picker = NSSharingServicePicker(items: [file.url])
-            context.coordinator.picker = picker
-            picker.show(relativeTo: nsView.bounds, of: nsView, preferredEdge: .minY)
-            fileBinding.wrappedValue = nil
-        }
-    }
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator()
-    }
-
-    final class Coordinator {
-        var presentedID: UUID?
-        var picker: NSSharingServicePicker?
-    }
-}
-#elseif canImport(UIKit)
-private struct CPSLJSONTraceActivityView: UIViewControllerRepresentable {
-    let activityItems: [Any]
-
-    func makeUIViewController(context: Context) -> UIActivityViewController {
-        UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
-    }
-
-    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
-}
-#endif
-#endif
 
 private struct CPSLDrawerToggleButton: View {
     let isOpen: Bool

--- a/app/apple/herm/Views/Files/CPSLFileBrowserView.swift
+++ b/app/apple/herm/Views/Files/CPSLFileBrowserView.swift
@@ -1552,16 +1552,17 @@ private struct CPSLFileRowView: View {
             } else if case .browsing = mode, let onSetKeepDownloaded {
                 CPSLFileICloudActionMenu(
                     syncState: entry.syncState,
+                    onShare: onShare,
                     onMove: canModify ? onMove : nil,
                     onDelete: canModify ? onDelete : nil,
                     onSetKeepDownloaded: onSetKeepDownloaded
                 )
-            } else if case .browsing = mode, canModify {
-                CPSLFileActionMenu(onMove: onMove, onDelete: onDelete)
-            }
-
-            if case .browsing = mode, let onShare {
-                CPSLFileShareButton(action: onShare)
+            } else if case .browsing = mode, canModify || onShare != nil {
+                CPSLFileActionMenu(
+                    onShare: onShare,
+                    onMove: canModify ? onMove : nil,
+                    onDelete: canModify ? onDelete : nil
+                )
             }
         }
         .padding(.leading, leadingPadding)
@@ -1616,37 +1617,27 @@ private struct CPSLFileSelectionControl: View {
     }
 }
 
-private struct CPSLFileShareButton: View {
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            Image(systemName: "square.and.arrow.up")
-                .font(CPSLTheme.iconSmallFont)
-                .frame(
-                    width: CPSLFileRowMetrics.trailingControlWidth,
-                    height: CPSLTheme.controlSize
-                )
-                .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .foregroundStyle(CPSLTheme.secondaryText)
-        .accessibilityLabel("Share")
-        .help("Share")
-    }
-}
-
 private struct CPSLFileActionMenu: View {
-    let onMove: () -> Void
-    let onDelete: () -> Void
+    let onShare: (() -> Void)?
+    let onMove: (() -> Void)?
+    let onDelete: (() -> Void)?
 
     var body: some View {
         Menu {
-            Button(action: onMove) {
-                Label("Move…", systemImage: "folder")
+            if let onShare {
+                Button(action: onShare) {
+                    Label("Share", systemImage: "square.and.arrow.up")
+                }
             }
-            Button(role: .destructive, action: onDelete) {
-                Label("Delete", systemImage: "trash")
+            if let onMove {
+                Button(action: onMove) {
+                    Label("Move…", systemImage: "folder")
+                }
+            }
+            if let onDelete {
+                Button(role: .destructive, action: onDelete) {
+                    Label("Delete", systemImage: "trash")
+                }
             }
         } label: {
             Image(systemName: "ellipsis")
@@ -1673,12 +1664,18 @@ private struct CPSLFileSyncStateBadge: View {
 
 private struct CPSLFileICloudActionMenu: View {
     let syncState: CPSLFileSyncState?
+    let onShare: (() -> Void)?
     let onMove: (() -> Void)?
     let onDelete: (() -> Void)?
     let onSetKeepDownloaded: (Bool) -> Void
 
     var body: some View {
         Menu {
+            if let onShare {
+                Button(action: onShare) {
+                    Label("Share", systemImage: "square.and.arrow.up")
+                }
+            }
             if syncState != .keepDownloaded {
                 Button {
                     onSetKeepDownloaded(true)

--- a/app/apple/herm/Views/Files/CPSLFileBrowserView.swift
+++ b/app/apple/herm/Views/Files/CPSLFileBrowserView.swift
@@ -186,9 +186,12 @@ struct CPSLFileBrowserView: View {
     @State private var movingEntries: [CPSLFileEntry] = []
     @State private var pendingDeletionEntries: [CPSLFileEntry] = []
     @State private var isDeleteConfirmationPresented = false
+    @State private var shareFile: CPSLShareableFile?
+    @State private var isPreparingShare = false
 
     var body: some View {
         browserPanel
+            .cpslShareFile(file: $shareFile)
             .fileImporter(
                 isPresented: $isICloudImporterPresented,
                 allowedContentTypes: [.folder],
@@ -258,8 +261,20 @@ struct CPSLFileBrowserView: View {
             beginMove: beginMove,
             cancelMove: cancelMove,
             completeMove: completeMove,
-            requestDelete: requestDelete
+            requestDelete: requestDelete,
+            shareEntry: shareEntry
         )
+    }
+
+    private func shareEntry(_ entry: CPSLFileEntry) {
+        guard !entry.isDirectory, !isPreparingShare else {
+            return
+        }
+        isPreparingShare = true
+        Task { @MainActor in
+            defer { isPreparingShare = false }
+            shareFile = await model.resolveFileURLForSharing(entry)
+        }
     }
 
     private var deleteConfirmationTitle: String {
@@ -526,6 +541,7 @@ private struct CPSLFileBrowserActions {
     let cancelMove: () -> Void
     let completeMove: () -> Void
     let requestDelete: ([CPSLFileEntry]) -> Void
+    let shareEntry: (CPSLFileEntry) -> Void
 
     var iCloudMounts: [CPSLICloudMount] {
         model.iCloudMounts
@@ -1365,6 +1381,9 @@ private struct CPSLFileBrowserRowView: View {
                     onToggleExpansion: {
                         actions.toggleExpansion(entry)
                     },
+                    onShare: entry.isDirectory ? nil : {
+                        actions.shareEntry(entry)
+                    },
                     onMove: {
                         actions.beginMove([entry])
                     },
@@ -1442,6 +1461,7 @@ private struct CPSLFileRowView: View {
     let canModify: Bool
     let onOpen: () -> Void
     let onToggleExpansion: () -> Void
+    let onShare: (() -> Void)?
     let onMove: () -> Void
     let onDelete: () -> Void
     let onRemove: (() -> Void)?
@@ -1539,6 +1559,10 @@ private struct CPSLFileRowView: View {
             } else if case .browsing = mode, canModify {
                 CPSLFileActionMenu(onMove: onMove, onDelete: onDelete)
             }
+
+            if case .browsing = mode, let onShare {
+                CPSLFileShareButton(action: onShare)
+            }
         }
         .padding(.leading, leadingPadding)
         .padding(.trailing, CPSLFileRowMetrics.trailing)
@@ -1589,6 +1613,26 @@ private struct CPSLFileSelectionControl: View {
             )
             .opacity(isEnabled ? 1 : 0.45)
             .accessibilityHidden(true)
+    }
+}
+
+private struct CPSLFileShareButton: View {
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: "square.and.arrow.up")
+                .font(CPSLTheme.iconSmallFont)
+                .frame(
+                    width: CPSLFileRowMetrics.trailingControlWidth,
+                    height: CPSLTheme.controlSize
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .foregroundStyle(CPSLTheme.secondaryText)
+        .accessibilityLabel("Share")
+        .help("Share")
     }
 }
 

--- a/app/apple/herm/Views/Shared/CPSLSharePresenter.swift
+++ b/app/apple/herm/Views/Shared/CPSLSharePresenter.swift
@@ -1,0 +1,82 @@
+import Foundation
+import SwiftUI
+#if os(macOS)
+import AppKit
+#elseif canImport(UIKit)
+import UIKit
+#endif
+
+extension View {
+    /// Presents the OS share sheet / sharing-service picker for a file URL.
+    func cpslShareFile(file: Binding<CPSLShareableFile?>) -> some View {
+#if os(macOS)
+        background(CPSLSharingServicePicker(file: file))
+#elseif canImport(UIKit)
+        sheet(item: file) { shareFile in
+            CPSLActivityShareView(activityItems: [shareFile.url])
+                .onDisappear {
+                    // Drop retained iCloud scopes after the sheet closes.
+                    _ = shareFile.lifetimeToken
+                }
+        }
+#else
+        self
+#endif
+    }
+}
+
+#if os(macOS)
+private struct CPSLSharingServicePicker: NSViewRepresentable {
+    @Binding var file: CPSLShareableFile?
+
+    func makeNSView(context: Context) -> NSView {
+        NSView(frame: .zero)
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        guard let file else {
+            return
+        }
+        guard context.coordinator.presentedID != file.id else {
+            return
+        }
+
+        context.coordinator.presentedID = file.id
+        context.coordinator.lifetimeToken = file.lifetimeToken
+        let fileBinding = $file
+        DispatchQueue.main.async {
+            guard nsView.window != nil else {
+                fileBinding.wrappedValue = nil
+                context.coordinator.lifetimeToken = nil
+                return
+            }
+
+            let picker = NSSharingServicePicker(items: [file.url])
+            context.coordinator.picker = picker
+            picker.show(relativeTo: nsView.bounds, of: nsView, preferredEdge: .minY)
+            fileBinding.wrappedValue = nil
+            // Keep scopes until the next share or view teardown.
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    final class Coordinator {
+        var presentedID: UUID?
+        var picker: NSSharingServicePicker?
+        var lifetimeToken: AnyObject?
+    }
+}
+#elseif canImport(UIKit)
+private struct CPSLActivityShareView: UIViewControllerRepresentable {
+    let activityItems: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}
+#endif

--- a/app/apple/herm/Views/Shared/CPSLSharePresenter.swift
+++ b/app/apple/herm/Views/Shared/CPSLSharePresenter.swift
@@ -11,17 +11,53 @@ extension View {
     func cpslShareFile(file: Binding<CPSLShareableFile?>) -> some View {
 #if os(macOS)
         background(CPSLSharingServicePicker(file: file))
+            .task { await CPSLShareInfrastructure.prewarmIfNeeded() }
 #elseif canImport(UIKit)
-        sheet(item: file) { shareFile in
-            CPSLActivityShareView(activityItems: [shareFile.url])
-                .onDisappear {
-                    // Drop retained iCloud scopes after the sheet closes.
-                    _ = shareFile.lifetimeToken
-                }
-        }
+        // Present from a host VC (same idea as macOS). Embedding UIActivityViewController
+        // as a SwiftUI sheet root freezes on first presentation in Debug while frameworks load.
+        background(CPSLActivitySharePresenter(file: file))
+            .task { await CPSLShareInfrastructure.prewarmIfNeeded() }
 #else
         self
 #endif
+    }
+}
+
+/// Cold-loads OS sharing once per process so the first user-facing Share isn't a ~0.5s hitch.
+@MainActor
+private enum CPSLShareInfrastructure {
+    private static var didSchedule = false
+    private static var didPrewarm = false
+
+    static func prewarmIfNeeded() async {
+        guard !didPrewarm, !didSchedule else {
+            return
+        }
+        didSchedule = true
+        // Let the hosting view finish its first layout / open animation.
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        guard !didPrewarm else {
+            return
+        }
+
+        let url = prewarmFileURL()
+#if os(macOS)
+        _ = NSSharingService.sharingServices(forItems: [url])
+#elseif canImport(UIKit)
+        // Force dyld + first-time activity discovery off the Share tap path.
+        _ = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+#endif
+        didPrewarm = true
+    }
+
+    private static func prewarmFileURL() -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("herm-share-prewarm.txt", isDirectory: false)
+        if !FileManager.default.fileExists(atPath: url.path) {
+            try? Data("herm-share-prewarm".utf8).write(to: url, options: .atomic)
+        }
+        return url
     }
 }
 
@@ -70,13 +106,69 @@ private struct CPSLSharingServicePicker: NSViewRepresentable {
     }
 }
 #elseif canImport(UIKit)
-private struct CPSLActivityShareView: UIViewControllerRepresentable {
-    let activityItems: [Any]
+/// Host VC that presents `UIActivityViewController` modally (not as a SwiftUI sheet root).
+private struct CPSLActivitySharePresenter: UIViewControllerRepresentable {
+    @Binding var file: CPSLShareableFile?
 
-    func makeUIViewController(context: Context) -> UIActivityViewController {
-        UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+    func makeUIViewController(context: Context) -> UIViewController {
+        UIViewController()
     }
 
-    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+        guard let file else {
+            return
+        }
+        guard context.coordinator.presentedID != file.id else {
+            return
+        }
+        guard uiViewController.presentedViewController == nil else {
+            return
+        }
+
+        context.coordinator.presentedID = file.id
+        context.coordinator.lifetimeToken = file.lifetimeToken
+        let items: [Any] = [file.url]
+        let fileBinding = $file
+
+        DispatchQueue.main.async {
+            guard uiViewController.view.window != nil else {
+                fileBinding.wrappedValue = nil
+                context.coordinator.lifetimeToken = nil
+                return
+            }
+            guard uiViewController.presentedViewController == nil else {
+                return
+            }
+
+            let activity = UIActivityViewController(
+                activityItems: items,
+                applicationActivities: nil
+            )
+            activity.completionWithItemsHandler = { _, _, _, _ in
+                fileBinding.wrappedValue = nil
+                context.coordinator.lifetimeToken = nil
+            }
+            if let popover = activity.popoverPresentationController {
+                popover.sourceView = uiViewController.view
+                popover.sourceRect = CGRect(
+                    x: uiViewController.view.bounds.midX,
+                    y: uiViewController.view.bounds.midY,
+                    width: 0,
+                    height: 0
+                )
+                popover.permittedArrowDirections = []
+            }
+            uiViewController.present(activity, animated: true)
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    final class Coordinator {
+        var presentedID: UUID?
+        var lifetimeToken: AnyObject?
+    }
 }
 #endif

--- a/app/apple/hermTests/CPSLFileShareTests.swift
+++ b/app/apple/hermTests/CPSLFileShareTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+@testable import herm
+
+struct CPSLFileShareTests {
+    @Test func sandboxVirtualPathMapsToExistingHostFile() throws {
+        let sandboxRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("herm-share-test-\(UUID().uuidString)", isDirectory: true)
+        let home = sandboxRoot.appendingPathComponent("home/herm", isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: sandboxRoot) }
+
+        let noteURL = home.appendingPathComponent("note.txt", isDirectory: false)
+        try Data("share-payload".utf8).write(to: noteURL)
+
+        let resolved = CPSLSandboxHostURL.hostFileURL(
+            virtualPath: "/home/herm/note.txt",
+            sandboxRoot: sandboxRoot
+        )
+        #expect(resolved.standardizedFileURL.path == noteURL.standardizedFileURL.path)
+        #expect(FileManager.default.fileExists(atPath: resolved.path))
+        #expect(try String(contentsOf: resolved, encoding: .utf8) == "share-payload")
+    }
+
+    @Test func sandboxHostURLNormalizesDotSegments() {
+        let root = URL(fileURLWithPath: "/tmp/sandbox-root", isDirectory: true)
+        let resolved = CPSLSandboxHostURL.hostFileURL(
+            virtualPath: "/home/herm/../herm/./docs/a.txt",
+            sandboxRoot: root
+        )
+        let expected = CPSLSandboxHostURL.hostFileURL(
+            virtualPath: "/home/herm/docs/a.txt",
+            sandboxRoot: root
+        )
+        #expect(resolved.path == expected.path)
+    }
+
+    @Test func shareableFileHoldsURLAndOptionalLifetime() {
+        let url = URL(fileURLWithPath: "/tmp/example.txt")
+        let file = CPSLShareableFile(url: url, lifetimeToken: nil)
+        #expect(file.url == url)
+        #expect(file.lifetimeToken == nil)
+    }
+}

--- a/scripts/vet-apple-agent-integration.sh
+++ b/scripts/vet-apple-agent-integration.sh
@@ -49,6 +49,7 @@ swift_files=(
   app/apple/herm/Models/CPSLEvalTypes.swift
   app/apple/herm/Models/CPSLICloudMount.swift
   app/apple/herm/Models/CPSLTypes.swift
+  app/apple/herm/Models/CPSLSandboxHostURL.swift
   app/apple/herm/Models/CPSLChatModel.swift
   app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
   app/apple/herm/Models/CPSLChatModel+AgentRuntimeTypes.swift
@@ -59,6 +60,7 @@ swift_files=(
   app/apple/herm/Views/Files/CPSLFileOverlayPanel.swift
   app/apple/herm/Views/Files/CPSLFileBrowserView.swift
   app/apple/herm/Views/Files/CPSLFilePreviewOverlay.swift
+  app/apple/herm/Views/Shared/CPSLSharePresenter.swift
 )
 
 required_files=(
@@ -92,6 +94,7 @@ required_files=(
   scripts/generate-apple-pcc-runtime.sh
   scripts/apple-pcc/CPSLPCCRuntime.full.swift
   scripts/apple-pcc/CPSLPCCRuntime.stub.swift
+  scripts/vet-apple-file-share.swift
   external/cpsl/core/src/doc/render.rs
   external/cpsl/core/src/sandbox.rs
   external/cpsl/ffi/src/lib.rs
@@ -687,6 +690,11 @@ if command -v swiftc >/dev/null 2>&1; then
     scripts/vet-apple-file-info-media-mainthread.swift \
     -o /tmp/herm-vet-file-info-media
   /tmp/herm-vet-file-info-media
+  swiftc \
+    app/apple/herm/Models/CPSLSandboxHostURL.swift \
+    scripts/vet-apple-file-share.swift \
+    -o /tmp/herm-vet-file-share
+  /tmp/herm-vet-file-share
   swiftc \
     app/apple/herm/Models/CPSLICloudMount.swift \
     app/apple/herm/Services/CPSLICloudBookmarkAccess.swift \

--- a/scripts/vet-apple-file-share.swift
+++ b/scripts/vet-apple-file-share.swift
@@ -1,0 +1,225 @@
+import Foundation
+
+/// Structural + pure-logic gates for file-browser share control, OS share wiring,
+/// and sandbox virtual→host URL resolution used by share.
+@main
+private struct CPSLFileShareChecks {
+    static func main() throws {
+        let browser = try source("app/apple/herm/Views/Files/CPSLFileBrowserView.swift")
+        let presenter = try source("app/apple/herm/Views/Shared/CPSLSharePresenter.swift")
+        let chatScreen = try source("app/apple/herm/Views/Chat/CPSLChatScreen.swift")
+        let chatModel = try source("app/apple/herm/Models/CPSLChatModel.swift")
+        let debugService = try source("app/apple/herm/Services/CPSLDebugService.swift")
+        let types = try source("app/apple/herm/Models/CPSLTypes.swift")
+
+        try assertShareRowControl(browser: browser)
+        try assertOSSharePresenter(presenter: presenter, chatScreen: chatScreen)
+        try assertResolveWiring(
+            chatModel: chatModel,
+            debugService: debugService,
+            types: types,
+            browser: browser
+        )
+        try assertSandboxHostURLResolution()
+        print("vet-apple-file-share: all checks passed")
+    }
+
+    private static func assertShareRowControl(browser: String) throws {
+        try require(
+            browser.contains("struct CPSLFileShareButton"),
+            "file browser must define a dedicated share row control"
+        )
+        try require(
+            browser.contains("square.and.arrow.up"),
+            "share control must use the system share SF Symbol"
+        )
+        try require(
+            browser.contains("accessibilityLabel(\"Share\")"),
+            "share control must expose a Share accessibility label"
+        )
+        let rowSlice = try requireSlice(
+            in: browser,
+            startingWith: "private struct CPSLFileRowView: View {",
+            endingWith: "private struct CPSLFileSelectionControl: View {"
+        )
+        try require(
+            rowSlice.contains("if case .browsing = mode, let onShare") &&
+                rowSlice.contains("CPSLFileShareButton(action: onShare)"),
+            "browsing-mode file rows must show the share button when onShare is set"
+        )
+        try require(
+            browser.contains("onShare: entry.isDirectory ? nil : {") ||
+                browser.contains("onShare: entry.isDirectory ? nil :"),
+            "directories must not receive a share action"
+        )
+        try require(
+            !rowSlice.contains("if case .selecting = mode, let onShare") &&
+                !rowSlice.contains("if case .moving = mode, let onShare"),
+            "share control must not be required in selecting/moving modes"
+        )
+    }
+
+    private static func assertOSSharePresenter(presenter: String, chatScreen: String) throws {
+        try require(
+            presenter.contains("func cpslShareFile(file: Binding<CPSLShareableFile?>)"),
+            "shared share presenter modifier must exist"
+        )
+        try require(
+            presenter.contains("UIActivityViewController"),
+            "iOS share path must use UIActivityViewController"
+        )
+        try require(
+            presenter.contains("NSSharingServicePicker"),
+            "macOS share path must use NSSharingServicePicker"
+        )
+        try require(
+            presenter.contains("activityItems: [shareFile.url]") ||
+                presenter.contains("items: [file.url]"),
+            "share presenter must pass the resolved file URL as the share item"
+        )
+        try require(
+            chatScreen.contains(".cpslShareFile(file: $traceShareFile)"),
+            "DEBUG JSON-trace share must reuse the shared OS share presenter"
+        )
+        try require(
+            !chatScreen.contains("CPSLJSONTraceActivityView") &&
+                !chatScreen.contains("CPSLJSONTraceSharingServicePicker"),
+            "one-off DEBUG share UI wrappers must be removed after extraction"
+        )
+    }
+
+    private static func assertResolveWiring(
+        chatModel: String,
+        debugService: String,
+        types: String,
+        browser: String
+    ) throws {
+        try require(
+            debugService.contains("func resolveShareableHostFileURL("),
+            "debug service must expose shareable host URL resolution"
+        )
+        let resolveSlice = try requireSlice(
+            in: debugService,
+            startingWith: "func resolveShareableHostFileURL(",
+            endingWith: "func previewFile(_ entry: CPSLFileEntry)"
+        )
+        try require(
+            resolveSlice.contains("materializeFile(at: entry.path)"),
+            "share resolution must materialize iCloud files before sharing"
+        )
+        try require(
+            resolveSlice.contains("hostURL(forVirtualPath: entry.path"),
+            "share resolution must use the same hostURL path as preview"
+        )
+        try require(
+            resolveSlice.contains("isBrowserHostURLAllowed"),
+            "share resolution must stay inside the CPSL filesystem boundary"
+        )
+        try require(
+            resolveSlice.contains("releaseGateRetainingScopes()"),
+            "share resolution must retain iCloud scopes while presenting share"
+        )
+        try require(
+            chatModel.contains("func resolveFileURLForSharing(_ entry: CPSLFileEntry)"),
+            "chat model must expose share resolution for the file browser"
+        )
+        try require(
+            chatModel.contains("service.resolveShareableHostFileURL(for: entry)"),
+            "chat model share path must call the service resolution API"
+        )
+        try require(
+            browser.contains("model.resolveFileURLForSharing(entry)") &&
+                browser.contains(".cpslShareFile(file: $shareFile)"),
+            "file browser must resolve via model then present the shared share UI"
+        )
+        try require(
+            types.contains("struct CPSLShareableFile") &&
+                types.contains("struct CPSLFileShareResolveResult"),
+            "share result types must live with other file types"
+        )
+        try require(
+            debugService.contains("CPSLSandboxHostURL.hostFileURL("),
+            "hostURL must use the shared sandbox virtual→host mapper"
+        )
+    }
+
+    private static func assertSandboxHostURLResolution() throws {
+        let sandboxRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("herm-file-share-check-\(UUID().uuidString)", isDirectory: true)
+        let home = sandboxRoot.appendingPathComponent("home/herm", isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: sandboxRoot) }
+
+        let noteURL = home.appendingPathComponent("share-me.txt", isDirectory: false)
+        try Data("hello-share".utf8).write(to: noteURL)
+
+        let virtualPath = "/home/herm/share-me.txt"
+        let resolved = CPSLSandboxHostURL.hostFileURL(
+            virtualPath: virtualPath,
+            sandboxRoot: sandboxRoot
+        )
+        try require(
+            resolved.standardizedFileURL.path == noteURL.standardizedFileURL.path,
+            "sandbox virtual path did not map to the host file URL"
+        )
+        try require(
+            FileManager.default.fileExists(atPath: resolved.path),
+            "resolved host URL must point at an existing file"
+        )
+        let contents = try String(contentsOf: resolved, encoding: .utf8)
+        try require(contents == "hello-share", "resolved host file contents mismatch")
+
+        let nested = CPSLSandboxHostURL.hostFileURL(
+            virtualPath: "/home/herm/../herm/./share-me.txt",
+            sandboxRoot: sandboxRoot
+        )
+        try require(
+            nested.standardizedFileURL.path == noteURL.standardizedFileURL.path,
+            "normalized virtual path mapping must collapse . and .."
+        )
+
+        let normalized = CPSLSandboxHostURL.normalize("  home/herm/share-me.txt  ")
+        try require(
+            normalized == "/home/herm/share-me.txt",
+            "normalize must add leading slash and trim whitespace"
+        )
+    }
+
+    private static func source(_ relativePath: String) throws -> String {
+        let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent(relativePath)
+        do {
+            return try String(contentsOf: url, encoding: .utf8)
+        } catch {
+            throw CheckFailure("could not read \(relativePath): \(error.localizedDescription)")
+        }
+    }
+
+    private static func requireSlice(
+        in source: String,
+        startingWith start: String,
+        endingWith end: String
+    ) throws -> String {
+        guard let startRange = source.range(of: start) else {
+            throw CheckFailure("missing slice start: \(start)")
+        }
+        let fromStart = source[startRange.lowerBound...]
+        guard let endRange = fromStart.range(of: end) else {
+            throw CheckFailure("missing slice end after \(start): \(end)")
+        }
+        return String(fromStart[..<endRange.lowerBound])
+    }
+
+    private static func require(_ condition: Bool, _ message: String) throws {
+        if !condition {
+            throw CheckFailure(message)
+        }
+    }
+}
+
+private struct CheckFailure: Error, CustomStringConvertible {
+    let description: String
+    init(_ description: String) {
+        self.description = description
+    }
+}

--- a/scripts/vet-apple-file-share.swift
+++ b/scripts/vet-apple-file-share.swift
@@ -26,16 +26,12 @@ private struct CPSLFileShareChecks {
 
     private static func assertShareRowControl(browser: String) throws {
         try require(
-            browser.contains("struct CPSLFileShareButton"),
-            "file browser must define a dedicated share row control"
+            !browser.contains("struct CPSLFileShareButton"),
+            "file browser must not define a dedicated trailing share button"
         )
         try require(
-            browser.contains("square.and.arrow.up"),
-            "share control must use the system share SF Symbol"
-        )
-        try require(
-            browser.contains("accessibilityLabel(\"Share\")"),
-            "share control must expose a Share accessibility label"
+            browser.contains("Label(\"Share\", systemImage: \"square.and.arrow.up\")"),
+            "ellipsis menus must include a Share action with the system share glyph"
         )
         let rowSlice = try requireSlice(
             in: browser,
@@ -43,9 +39,19 @@ private struct CPSLFileShareChecks {
             endingWith: "private struct CPSLFileSelectionControl: View {"
         )
         try require(
-            rowSlice.contains("if case .browsing = mode, let onShare") &&
-                rowSlice.contains("CPSLFileShareButton(action: onShare)"),
-            "browsing-mode file rows must show the share button when onShare is set"
+            !rowSlice.contains("CPSLFileShareButton"),
+            "browsing file rows must not render a standalone share button"
+        )
+        try require(
+            rowSlice.contains("canModify || onShare != nil") &&
+                rowSlice.contains("CPSLFileActionMenu(") &&
+                rowSlice.contains("onShare: onShare"),
+            "browsing rows must surface Share via the ellipsis action menu"
+        )
+        try require(
+            rowSlice.contains("CPSLFileICloudActionMenu(") &&
+                rowSlice.contains("onShare: onShare"),
+            "iCloud file ellipsis menu must also receive the share action"
         )
         try require(
             browser.contains("onShare: entry.isDirectory ? nil : {") ||
@@ -55,7 +61,18 @@ private struct CPSLFileShareChecks {
         try require(
             !rowSlice.contains("if case .selecting = mode, let onShare") &&
                 !rowSlice.contains("if case .moving = mode, let onShare"),
-            "share control must not be required in selecting/moving modes"
+            "share must not be required in selecting/moving modes"
+        )
+
+        let actionMenu = try requireSlice(
+            in: browser,
+            startingWith: "private struct CPSLFileActionMenu: View {",
+            endingWith: "private struct CPSLFileSyncStateBadge: View {"
+        )
+        try require(
+            actionMenu.contains("if let onShare") &&
+                actionMenu.contains("Label(\"Share\", systemImage: \"square.and.arrow.up\")"),
+            "CPSLFileActionMenu must offer Share when onShare is set"
         )
     }
 

--- a/scripts/vet-apple-file-share.swift
+++ b/scripts/vet-apple-file-share.swift
@@ -91,8 +91,18 @@ private struct CPSLFileShareChecks {
         )
         try require(
             presenter.contains("activityItems: [shareFile.url]") ||
+                presenter.contains("activityItems: items") ||
                 presenter.contains("items: [file.url]"),
             "share presenter must pass the resolved file URL as the share item"
+        )
+        try require(
+            presenter.contains("prewarmIfNeeded") &&
+                presenter.contains("UIActivityViewController"),
+            "share infrastructure must prewarm UIActivityViewController before first user share"
+        )
+        try require(
+            !presenter.contains("sheet(item: file)"),
+            "iOS share must present UIActivityViewController from a host VC, not as a SwiftUI sheet root"
         )
         try require(
             chatScreen.contains(".cpslShareFile(file: $traceShareFile)"),


### PR DESCRIPTION
## Summary
- Add a trailing system share control (`square.and.arrow.up`) on non-directory file rows in the Apple file browser (browsing mode only).
- Resolve virtual paths for share through the same host URL + iCloud materialization path used by file preview, then present the platform share UI.
- Extract a shared iOS/macOS share presenter (`cpslShareFile`) and reuse it for both file-browser share and DEBUG JSON-trace share.

## Test plan
- [x] `swiftc` + run `scripts/vet-apple-file-share.swift` (structural wiring + live sandbox virtual→host resolution)
- [x] Confirm row control, OS share presenter, and resolve path via static/source checks
- [ ] On iOS Simulator / macOS: open Files, tap share on a sandbox file, verify activity sheet / sharing picker
- [ ] On an iCloud-mounted file that is not local: confirm materialization before share (or clear error if unavailable)
- [ ] Confirm directories, selecting, and moving modes do not show the share control