### PR TITLE
Carry agent requests to completion with goal clarification

### DIFF
--- a/app/apple/herm/Models/CPSLAttachmentPrompt.swift
+++ b/app/apple/herm/Models/CPSLAttachmentPrompt.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 nonisolated struct CPSLAttachmentPrompt: Equatable, Sendable {
-    private static let heading = "Attached files:"
+    static let attachedFilesHeading = "Attached files:"
 
     let displayText: String
     let providerText: String
@@ -10,16 +10,34 @@ nonisolated struct CPSLAttachmentPrompt: Equatable, Sendable {
     init(displayText: String, attachments: [CPSLAttachment]) {
         self.displayText = displayText
         self.attachments = attachments
-        guard !attachments.isEmpty else {
-            providerText = displayText
-            return
-        }
+        providerText = Self.makeProviderText(
+            displayText: displayText,
+            attachments: attachments
+        )
+    }
 
-        let paths = attachments.map { "- \($0.path)" }.joined(separator: "\n")
-        let attachmentSection = "\(Self.heading)\n\(paths)"
-        providerText = displayText.isEmpty
-            ? attachmentSection
-            : "\(displayText)\n\n\(attachmentSection)"
+    /// Full constructor used when provider text has been adjusted (e.g. clarified end goal).
+    init(displayText: String, providerText: String, attachments: [CPSLAttachment]) {
+        self.displayText = displayText
+        self.providerText = providerText
+        self.attachments = attachments
+    }
+
+    /// Returns a copy whose provider-facing content embeds a clarified end goal.
+    /// Display text (timeline body) is unchanged.
+    func embeddingClarifiedGoal(_ goal: String?) -> CPSLAttachmentPrompt {
+        let nextProvider = CPSLGoalClarification.providerText(
+            baseProviderText: providerText,
+            clarifiedGoal: goal
+        )
+        guard nextProvider != providerText else {
+            return self
+        }
+        return CPSLAttachmentPrompt(
+            displayText: displayText,
+            providerText: nextProvider,
+            attachments: attachments
+        )
     }
 
     static func parse(_ text: String?) -> (displayText: String, attachments: [CPSLAttachment]) {
@@ -27,6 +45,7 @@ nonisolated struct CPSLAttachmentPrompt: Equatable, Sendable {
             return ("", [])
         }
 
+        let heading = attachedFilesHeading
         let sectionPrefix = "\n\n\(heading)\n"
         let displayText: String
         let pathText: Substring
@@ -65,6 +84,30 @@ nonisolated struct CPSLAttachmentPrompt: Equatable, Sendable {
         else {
             return (text, [])
         }
-        return (displayText, attachments)
+        // Provider text may include an End goal block before attachments; display is body only.
+        let cleanedDisplay = stripTrailingEndGoal(from: displayText)
+        return (cleanedDisplay, attachments)
+    }
+
+    private static func makeProviderText(
+        displayText: String,
+        attachments: [CPSLAttachment]
+    ) -> String {
+        guard !attachments.isEmpty else {
+            return displayText
+        }
+        let paths = attachments.map { "- \($0.path)" }.joined(separator: "\n")
+        let attachmentSection = "\(attachedFilesHeading)\n\(paths)"
+        return displayText.isEmpty
+            ? attachmentSection
+            : "\(displayText)\n\n\(attachmentSection)"
+    }
+
+    private static func stripTrailingEndGoal(from text: String) -> String {
+        let marker = "\n\n\(CPSLGoalClarification.endGoalHeading)\n"
+        guard let range = text.range(of: marker, options: .backwards) else {
+            return text
+        }
+        return String(text[..<range.lowerBound])
     }
 }

--- a/app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
+++ b/app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
@@ -1044,6 +1044,7 @@ extension CPSLChatModel {
         let basePrompt = """
         You are a Herm sub-agent running inside the same iOS/macOS app.
         Complete the assigned task, then return a concise result. Do not ask questions.
+        Return the outcome the parent needs (findings, extracted facts, or produced artifacts)—not process-only status such as only reporting that a page or search was opened when content can still be read and summarized. Domain procedures live in skills when relevant.
         Start collecting useful findings immediately and preserve them in your response. Do not spend the whole budget on discovery. For browser research, reuse one browser across queries and return the best verified result you have before the final turn.
         Mode: \(mode.rawValue). Turn budget: \(maxTurns). Agent depth: \(context.agentDepth)/\(context.config.maxAgentDepth).
         Your execution environment is a Unix-like local sandbox with Luau as the command interface instead of Bash. Luau is the only supported execution language.

--- a/app/apple/herm/Models/CPSLChatModel.swift
+++ b/app/apple/herm/Models/CPSLChatModel.swift
@@ -132,6 +132,7 @@ final class CPSLChatModel {
     Your execution environment is a Unix-like local sandbox with a filesystem, current directory, and command-style capabilities exposed through Luau APIs. Luau is the interface instead of Bash, and it is the only supported execution language.
     Use /home/herm as the default home for durable user-created files and /tmp for temporary files. Files added by the user are listed in their message and remain available under /attachments/<conversation-id> so they can be referenced again later in that conversation. Read those files with fs or doc as appropriate. The sandbox also exposes a Unix-like root with system directories such as /etc, /usr, and /var when needed.
     Your client-side tools are local_sandbox_exec and agent. Use tools only when they materially help with the user's request.
+    \(CPSLGoalClarification.mainAgentCompletionContract)
     Before claiming that you cannot perform a requested action, inspect the available sandbox modules and relevant skills for plausible ways to complete it. The absence of a dedicated service integration does not mean the action is unavailable when the service has a website the browser can use.
     For tasks involving a website or online service—including search, browsing, account actions, private messages, posts, forms, and file uploads or downloads—the webbrowser skill is required: load it into context with local_sandbox_exec and print(fs.read("/skills/webbrowser/SKILL.md")) before the first webbrowser call. Then use the global webbrowser module (never require). Capture open/create return values, read pages with webbrowser.page(browser) while staying in the background, and call webbrowser.show(browser) only for real user handoff (login, CAPTCHA, payment, or the user asked to see the window). Browsers default to mobile layout; use webbrowser.set_layout(browser, "desktop") on the same browser only when needed. The native browser uses persistent WebKit state, so the user may already be signed in. When the user explicitly requests a specific action, try to complete it through the site's normal browser interface on their behalf.
     Use authenticated websites only through their normal browser flow. Do not unhide, relabel, restyle, or inject page controls to manufacture an interaction target. Do not replace normal browser typing with stacked JavaScript input, paste, or synthetic keyboard-event strategies. After a consequential action is confirmed, do not repeat it or send a corrective follow-up unless the user explicitly asks; report every side effect accurately. Never extract, print, copy, or reuse authentication tokens, cookies, or other session secrets from browser storage or page JavaScript, and never use those secrets to call a site's private API.
@@ -1477,6 +1478,15 @@ final class CPSLChatModel {
             let promptForConversation = systemPrompt(with: availableSkills)
             currentSystemPrompt = promptForConversation
 
+            let config = try CPSLAgentConfig.load()
+            let client = CPSLAgentChatClient(config: config)
+            let modelID = await client.modelID
+            activeModel = modelID
+
+            // Internal goal clarify: timeline keeps displayText; provider text may gain End goal.
+            let effectivePrompt = await clarifyingUserPrompt(prompt, using: client)
+            try Task.checkCancellation()
+
             if let selectedConversationID, let currentNodeID {
                 conversationID = selectedConversationID
                 let node = try await store.appendNode(
@@ -1485,9 +1495,9 @@ final class CPSLChatModel {
                     draft: CPSLNodeAppendDraft(
                         role: .user,
                         title: nil,
-                        body: prompt.displayText,
+                        body: effectivePrompt.displayText,
                         model: nil,
-                        providerMessage: .user(prompt.providerText)
+                        providerMessage: .user(effectivePrompt.providerText)
                     )
                 )
                 parentID = node.id
@@ -1500,8 +1510,8 @@ final class CPSLChatModel {
             } else {
                 let created = try await store.createConversation(
                     id: draftConversationID,
-                    userText: prompt.displayText,
-                    providerText: prompt.providerText,
+                    userText: effectivePrompt.displayText,
+                    providerText: effectivePrompt.providerText,
                     model: nil,
                     systemPrompt: promptForConversation
                 )
@@ -1519,10 +1529,6 @@ final class CPSLChatModel {
             await reloadConversations()
             try Task.checkCancellation()
 
-            let config = try CPSLAgentConfig.load()
-            let client = CPSLAgentChatClient(config: config)
-            let modelID = await client.modelID
-            activeModel = modelID
             try await store.updateConversationModelIfMissing(conversationID: conversationID, model: modelID)
             let providerMessages = try await store.providerMessages(conversationID: conversationID)
             let replaySystemPrompt = addingICloudMountContext(to: promptForConversation)
@@ -1580,6 +1586,71 @@ final class CPSLChatModel {
         streamingAssistantMessageID = nil
     }
 
+    /// Tools-free pre-turn clarify: restates end goal for the provider; fails open.
+    /// Timeline continues to use `prompt.displayText` only.
+    private func clarifyingUserPrompt(
+        _ prompt: CPSLAttachmentPrompt,
+        using client: CPSLAgentChatClient
+    ) async -> CPSLAttachmentPrompt {
+        guard CPSLGoalClarification.shouldClarify(displayText: prompt.displayText) else {
+            return prompt
+        }
+        if Task.isCancelled {
+            return prompt
+        }
+        let goal = await clarifyEndGoal(displayText: prompt.displayText, client: client)
+        return CPSLGoalClarification.applyingClarifiedGoal(goal, to: prompt)
+    }
+
+    private func clarifyEndGoal(
+        displayText: String,
+        client: CPSLAgentChatClient
+    ) async -> String? {
+        enum Race: Sendable {
+            case completed(String?)
+            case timedOut
+        }
+
+        return await withTaskGroup(of: Race.self) { group in
+            group.addTask {
+                do {
+                    let request = CPSLOpenAIStreamRequest(
+                        messages: [
+                            .system(CPSLGoalClarification.clarifyInstructions),
+                            .user(displayText)
+                        ],
+                        tools: [],
+                        maxTokens: CPSLGoalClarification.maxOutputTokens
+                    )
+                    let completion = try await client.streamChat(request) { _ in }
+                    let normalized = CPSLGoalClarification.normalizedClarifiedGoal(
+                        completion.text,
+                        originalDisplayText: displayText
+                    )
+                    return .completed(normalized)
+                } catch {
+                    return .completed(nil)
+                }
+            }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: CPSLGoalClarification.timeoutNanoseconds)
+                return .timedOut
+            }
+            var result: String?
+            while let event = await group.next() {
+                switch event {
+                case .completed(let goal):
+                    result = goal
+                    group.cancelAll()
+                case .timedOut:
+                    result = nil
+                    group.cancelAll()
+                }
+                break
+            }
+            return result
+        }
+    }
 
     private func runCommand(_ command: String) {
         let message = CPSLChatMessage(role: .command, title: nil, body: commandBlockBody(command: command))

--- a/app/apple/herm/Models/CPSLChatModel.swift
+++ b/app/apple/herm/Models/CPSLChatModel.swift
@@ -1478,15 +1478,8 @@ final class CPSLChatModel {
             let promptForConversation = systemPrompt(with: availableSkills)
             currentSystemPrompt = promptForConversation
 
-            let config = try CPSLAgentConfig.load()
-            let client = CPSLAgentChatClient(config: config)
-            let modelID = await client.modelID
-            activeModel = modelID
-
-            // Internal goal clarify: timeline keeps displayText; provider text may gain End goal.
-            let effectivePrompt = await clarifyingUserPrompt(prompt, using: client)
-            try Task.checkCancellation()
-
+            // Persist the user turn first so Stop/config failure cannot discard the submit
+            // (composer is already cleared in submitPrompt). Clarify runs after write.
             if let selectedConversationID, let currentNodeID {
                 conversationID = selectedConversationID
                 let node = try await store.appendNode(
@@ -1495,9 +1488,9 @@ final class CPSLChatModel {
                     draft: CPSLNodeAppendDraft(
                         role: .user,
                         title: nil,
-                        body: effectivePrompt.displayText,
+                        body: prompt.displayText,
                         model: nil,
-                        providerMessage: .user(effectivePrompt.providerText)
+                        providerMessage: .user(prompt.providerText)
                     )
                 )
                 parentID = node.id
@@ -1510,8 +1503,8 @@ final class CPSLChatModel {
             } else {
                 let created = try await store.createConversation(
                     id: draftConversationID,
-                    userText: effectivePrompt.displayText,
-                    providerText: effectivePrompt.providerText,
+                    userText: prompt.displayText,
+                    providerText: prompt.providerText,
                     model: nil,
                     systemPrompt: promptForConversation
                 )
@@ -1527,6 +1520,23 @@ final class CPSLChatModel {
                 activeParentID = parentID
             }
             await reloadConversations()
+            try Task.checkCancellation()
+
+            let config = try CPSLAgentConfig.load()
+            let client = CPSLAgentChatClient(config: config)
+            let modelID = await client.modelID
+            activeModel = modelID
+
+            // Internal goal clarify after the timeline write: display body stays original;
+            // provider message may gain End goal. Fail open leaves the stored provider text.
+            let effectivePrompt = await clarifyingUserPrompt(prompt, using: client)
+            if effectivePrompt.providerText != prompt.providerText {
+                try await store.updateNodeProviderMessage(
+                    conversationID: conversationID,
+                    id: parentID,
+                    providerMessage: .user(effectivePrompt.providerText)
+                )
+            }
             try Task.checkCancellation()
 
             try await store.updateConversationModelIfMissing(conversationID: conversationID, model: modelID)

--- a/app/apple/herm/Models/CPSLGoalClarification.swift
+++ b/app/apple/herm/Models/CPSLGoalClarification.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+/// Domain-agnostic completion guidance and internal goal-clarification helpers.
+/// Skills own domain procedures; this type never branches on task categories.
+nonisolated enum CPSLGoalClarification {
+    /// Injected into the main-agent system prompt (generic carry-through-end contract).
+    static let mainAgentCompletionContract = """
+    Carry each user request through to a finished result in your assistant reply whenever tools and permissions allow. Do not treat intermediate process status alone as completion when you can still obtain and present the outcome yourself (for example only reporting that you opened a page, started a search, or began work). User handoff is appropriate only when the user must act—authentication, CAPTCHA, payment, consent, or they asked to take over—or when a hard limitation blocks further progress. Domain-specific procedures live in skills: load and follow relevant skills instead of inventing category-specific workflows.
+    """
+
+    /// Tools-free clarify-step instructions. Restates end goal only; no domain recipes.
+    static let clarifyInstructions = """
+    You prepare a brief end-goal restatement for another agent. Given the user's message, state what a successful finished assistant reply should deliver. Be concrete about the deliverable when the request implies one. Do not answer the request. Do not invent tools, brands, places, or domain-specific steps. Do not mention skills, sandbox, code, or implementation. Output plain text only: one short paragraph or a few short bullets.
+    """
+
+    static let endGoalHeading = "End goal:"
+    static let maxOutputTokens = 256
+    static let timeoutNanoseconds: UInt64 = 5_000_000_000
+
+    static func shouldClarify(displayText: String) -> Bool {
+        !displayText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    /// Normalize model clarify output; returns nil to fail open (use original provider text).
+    static func normalizedClarifiedGoal(
+        _ raw: String,
+        originalDisplayText: String
+    ) -> String? {
+        var text = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else {
+            return nil
+        }
+        if text.hasPrefix("```") {
+            text = stripFence(text)
+        }
+        text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty else {
+            return nil
+        }
+        if text.count > 800 {
+            text = String(text.prefix(797)) + "..."
+        }
+        let original = originalDisplayText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if text.caseInsensitiveCompare(original) == .orderedSame {
+            return nil
+        }
+        return text
+    }
+
+    /// Merge an optional clarified goal into provider-facing user content.
+    /// Keeps attachment sections intact; never changes user-visible display text.
+    static func providerText(
+        baseProviderText: String,
+        clarifiedGoal: String?
+    ) -> String {
+        guard let goal = clarifiedGoal?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !goal.isEmpty
+        else {
+            return baseProviderText
+        }
+
+        let goalBlock = "\(endGoalHeading)\n\(goal)"
+        let attachmentPrefix = "\n\n\(CPSLAttachmentPrompt.attachedFilesHeading)\n"
+        if let range = baseProviderText.range(of: attachmentPrefix, options: .backwards) {
+            let before = String(baseProviderText[..<range.lowerBound])
+            let after = String(baseProviderText[range.lowerBound...])
+            if before.isEmpty {
+                return "\(goalBlock)\(after)"
+            }
+            return "\(before)\n\n\(goalBlock)\(after)"
+        }
+        if baseProviderText.hasPrefix("\(CPSLAttachmentPrompt.attachedFilesHeading)\n") {
+            return "\(goalBlock)\n\n\(baseProviderText)"
+        }
+        if baseProviderText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return goalBlock
+        }
+        return "\(baseProviderText)\n\n\(goalBlock)"
+    }
+
+    static func applyingClarifiedGoal(
+        _ goal: String?,
+        to prompt: CPSLAttachmentPrompt
+    ) -> CPSLAttachmentPrompt {
+        prompt.embeddingClarifiedGoal(goal)
+    }
+
+    /// Source/gating check: prompt includes the generic completion contract.
+    static func systemPromptContainsCompletionContract(_ systemPrompt: String) -> Bool {
+        let haystack = systemPrompt.lowercased()
+        let hasCarryThrough = haystack.contains("finished result")
+            || haystack.contains("carry each user request")
+        let hasHandoffBoundary = haystack.contains("user handoff")
+            || haystack.contains("authentication")
+        let hasSkillsDeferral = haystack.contains("skills")
+        let hasNoCategoryCookbook = !haystack.contains("barber shop")
+            && !haystack.contains("restaurant nearby")
+            && !haystack.contains("for nearby places:")
+        return hasCarryThrough && hasHandoffBoundary && hasSkillsDeferral && hasNoCategoryCookbook
+    }
+
+    private static func stripFence(_ text: String) -> String {
+        var lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        if lines.first?.hasPrefix("```") == true {
+            lines.removeFirst()
+        }
+        if lines.last?.hasPrefix("```") == true {
+            lines.removeLast()
+        }
+        return lines.joined(separator: "\n")
+    }
+}

--- a/app/apple/herm/Models/CPSLGoalClarification.swift
+++ b/app/apple/herm/Models/CPSLGoalClarification.swift
@@ -17,6 +17,40 @@ nonisolated enum CPSLGoalClarification {
     static let maxOutputTokens = 256
     static let timeoutNanoseconds: UInt64 = 5_000_000_000
 
+    /// Documented submit pipeline for the main agent. Write the user turn first so
+    /// cancel/config failure cannot drop the submit after the composer is cleared.
+    enum SubmitPhase: String, CaseIterable, Sendable {
+        case persistUserTurn
+        case loadProvider
+        case clarifyEndGoal
+        case updateProviderMessageIfNeeded
+        case runAgentLoop
+    }
+
+    static let submitPhaseOrder: [SubmitPhase] = [
+        .persistUserTurn,
+        .loadProvider,
+        .clarifyEndGoal,
+        .updateProviderMessageIfNeeded,
+        .runAgentLoop
+    ]
+
+    /// Source-order check: user write must precede clarify; clarify precedes provider patch.
+    static func runAgentSourcePersistsUserBeforeClarify(_ source: String) -> Bool {
+        let persistMarkers = ["body: prompt.displayText", "userText: prompt.displayText"]
+        let clarifyMarker = "clarifyingUserPrompt"
+        let patchMarker = "updateNodeProviderMessage"
+        guard let clarifyRange = source.range(of: clarifyMarker) else {
+            return false
+        }
+        let beforeClarify = source[..<clarifyRange.lowerBound]
+        let persistsBefore = persistMarkers.contains { beforeClarify.contains($0) }
+        guard let patchRange = source.range(of: patchMarker) else {
+            return false
+        }
+        return persistsBefore && clarifyRange.lowerBound < patchRange.lowerBound
+    }
+
     static func shouldClarify(displayText: String) -> Bool {
         !displayText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }

--- a/app/apple/herm/Services/Agent/CPSLConversationStore.swift
+++ b/app/apple/herm/Services/Agent/CPSLConversationStore.swift
@@ -210,6 +210,23 @@ actor CPSLConversationStore {
         )
     }
 
+    /// Updates provider-facing content for a node without changing the visible body.
+    /// Used after internal goal clarification so the timeline keeps the original user text.
+    func updateNodeProviderMessage(
+        conversationID: String,
+        id: String,
+        providerMessage: CPSLOpenAIMessage
+    ) throws {
+        try appendConversationEvent(
+            CPSLConversationLogEvent(
+                kind: .nodeProviderMessageUpdated,
+                conversationID: conversationID,
+                nodeID: id,
+                providerMessage: providerMessage
+            )
+        )
+    }
+
     func updateConversationModelIfMissing(conversationID: String, model: String) throws {
         guard let conversation = try loadState().conversations[conversationID] else {
             throw CPSLConversationStoreError.conversationNotFound
@@ -475,6 +492,16 @@ actor CPSLConversationStore {
                 conversation.nodes[index].body = body
                 conversation.updatedAt = event.timestamp
                 state.conversations[conversationID] = conversation
+            case .nodeProviderMessageUpdated:
+                guard let conversationID = event.conversationID,
+                      let nodeID = event.nodeID,
+                      let providerMessage = event.providerMessage,
+                      var conversation = state.conversations[conversationID],
+                      let index = conversation.nodes.firstIndex(where: { $0.id == nodeID })
+                else { continue }
+                conversation.nodes[index].providerMessage = providerMessage
+                conversation.updatedAt = event.timestamp
+                state.conversations[conversationID] = conversation
             case .conversationModelSet:
                 guard let conversationID = event.conversationID,
                       let model = event.model,
@@ -710,7 +737,7 @@ nonisolated struct CPSLStoredNode: Identifiable, Equatable, Sendable, Codable {
     let title: String?
     var body: String
     let model: String?
-    let providerMessage: CPSLOpenAIMessage?
+    var providerMessage: CPSLOpenAIMessage?
     let sequence: Int
     let createdAt: Date
 
@@ -820,6 +847,7 @@ private nonisolated enum CPSLConversationLogEventKind: String, Codable {
     case conversationCreated = "conversation.created"
     case nodesAppended = "nodes.appended"
     case nodeBodyUpdated = "node.body_updated"
+    case nodeProviderMessageUpdated = "node.provider_message_updated"
     case conversationModelSet = "conversation.model_set"
     case conversationDeleted = "conversation.deleted"
     case conversationPinned = "conversation.pinned"
@@ -841,6 +869,7 @@ private nonisolated struct CPSLConversationLogEvent: Codable {
     let nodes: [CPSLStoredNode]?
     let nodeID: String?
     let body: String?
+    let providerMessage: CPSLOpenAIMessage?
     let model: String?
     let flag: Bool?
     let title: String?
@@ -856,6 +885,7 @@ private nonisolated struct CPSLConversationLogEvent: Codable {
         nodes: [CPSLStoredNode]? = nil,
         nodeID: String? = nil,
         body: String? = nil,
+        providerMessage: CPSLOpenAIMessage? = nil,
         model: String? = nil,
         flag: Bool? = nil,
         title: String? = nil,
@@ -872,6 +902,7 @@ private nonisolated struct CPSLConversationLogEvent: Codable {
         self.nodes = nodes
         self.nodeID = nodeID
         self.body = body
+        self.providerMessage = providerMessage
         self.model = model
         self.flag = flag
         self.title = title

--- a/app/apple/hermTests/CPSLGoalClarificationTests.swift
+++ b/app/apple/hermTests/CPSLGoalClarificationTests.swift
@@ -116,6 +116,47 @@ struct CPSLGoalClarificationTests {
         let b = prompt.embeddingClarifiedGoal(goal)
         #expect(a == b)
     }
+
+    @Test func runAgentSourcePersistsUserBeforeClarify() throws {
+        let source = try SystemPromptSource.chatModelSource()
+        #expect(CPSLGoalClarification.runAgentSourcePersistsUserBeforeClarify(source))
+        #expect(source.contains("updateNodeProviderMessage"))
+        // Config load after the user write so missing env cannot drop the submit.
+        let createIdx = try #require(source.range(of: "createConversation(")?.lowerBound)
+        let configIdx = try #require(source.range(of: "CPSLAgentConfig.load()")?.lowerBound)
+        #expect(createIdx < configIdx)
+        #expect(CPSLGoalClarification.submitPhaseOrder.first == .persistUserTurn)
+    }
+
+    @Test func providerMessageUpdateKeepsDisplayBody() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("herm-clarify-\(UUID().uuidString).jsonl")
+        let store = try CPSLConversationStore(logURL: url, usesICloudContainer: false)
+        let original = "Find options for me"
+        let created = try await store.createConversation(
+            userText: original,
+            providerText: original,
+            model: nil,
+            systemPrompt: "test"
+        )
+        let clarified = CPSLGoalClarification.providerText(
+            baseProviderText: original,
+            clarifiedGoal: "Deliver finished options in the assistant reply."
+        )
+        try await store.updateNodeProviderMessage(
+            conversationID: created.summary.id,
+            id: created.userNode.id,
+            providerMessage: .user(clarified)
+        )
+        let providerMessages = try await store.providerMessages(conversationID: created.summary.id)
+        #expect(providerMessages.last?.content == clarified)
+        #expect(providerMessages.last?.content?.contains(CPSLGoalClarification.endGoalHeading) == true)
+
+        let loaded = try await store.loadConversation(id: created.summary.id)
+        let userNode = try #require(loaded?.nodes.first { $0.role == .user })
+        #expect(userNode.body == original)
+        #expect(userNode.chatMessage?.body == original)
+    }
 }
 
 /// Locates shipped ChatModel source so tests assert real wiring, not a reimplementation.

--- a/app/apple/hermTests/CPSLGoalClarificationTests.swift
+++ b/app/apple/hermTests/CPSLGoalClarificationTests.swift
@@ -1,0 +1,144 @@
+import Testing
+@testable import herm
+
+struct CPSLGoalClarificationTests {
+    @Test func completionContractIsDomainAgnosticAndCompleteThroughEnd() {
+        let contract = CPSLGoalClarification.mainAgentCompletionContract
+        #expect(CPSLGoalClarification.systemPromptContainsCompletionContract(contract))
+        #expect(contract.localizedCaseInsensitiveContains("finished result"))
+        #expect(contract.localizedCaseInsensitiveContains("skills"))
+        #expect(!contract.localizedCaseInsensitiveContains("barber"))
+        #expect(!contract.localizedCaseInsensitiveContains("restaurant"))
+        #expect(!contract.localizedCaseInsensitiveContains("nearby places"))
+    }
+
+    @Test func mainSystemPromptSourceIncludesCompletionContract() throws {
+        // The shipped ChatModel source must embed the generic contract constant.
+        let source = try SystemPromptSource.chatModelSource()
+        #expect(source.contains("CPSLGoalClarification.mainAgentCompletionContract"))
+        #expect(source.contains("clarifyingUserPrompt"))
+        #expect(CPSLGoalClarification.systemPromptContainsCompletionContract(
+            CPSLGoalClarification.mainAgentCompletionContract
+        ))
+        // No category-specific cookbooks introduced for this feature.
+        #expect(!source.contains("for nearby places:"))
+        #expect(!source.contains("barber shop options"))
+        #expect(!source.contains("restaurant nearby"))
+    }
+
+    @Test func displayTextUnchangedWhenEmbeddingClarifiedGoal() {
+        let original = "Can you find a barber shop nearby?"
+        let prompt = CPSLAttachmentPrompt(displayText: original, attachments: [])
+        let clarified = "Deliver a finished list of options the user can act on from the chat reply."
+        let next = prompt.embeddingClarifiedGoal(clarified)
+
+        #expect(next.displayText == original)
+        #expect(next.providerText.contains(original))
+        #expect(next.providerText.contains(CPSLGoalClarification.endGoalHeading))
+        #expect(next.providerText.contains(clarified))
+        #expect(next.providerText != original)
+    }
+
+    @Test func failOpenLeavesProviderTextUnchanged() {
+        let original = "Summarize the open document"
+        let prompt = CPSLAttachmentPrompt(displayText: original, attachments: [])
+        #expect(prompt.embeddingClarifiedGoal(nil).providerText == original)
+        #expect(prompt.embeddingClarifiedGoal("   ").providerText == original)
+        let echo = CPSLGoalClarification.normalizedClarifiedGoal(
+            original,
+            originalDisplayText: original
+        )
+        #expect(echo == nil)
+        #expect(
+            CPSLGoalClarification.applyingClarifiedGoal(echo, to: prompt).providerText == original
+        )
+    }
+
+    @Test func normalizeRejectsEmptyAndEchoes() {
+        #expect(
+            CPSLGoalClarification.normalizedClarifiedGoal(
+                "  \n",
+                originalDisplayText: "hello"
+            ) == nil
+        )
+        #expect(
+            CPSLGoalClarification.normalizedClarifiedGoal(
+                "hello",
+                originalDisplayText: "Hello"
+            ) == nil
+        )
+        #expect(
+            CPSLGoalClarification.normalizedClarifiedGoal(
+                "Deliver the finished answer in chat.",
+                originalDisplayText: "hello"
+            ) == "Deliver the finished answer in chat."
+        )
+        #expect(
+            CPSLGoalClarification.normalizedClarifiedGoal(
+                "```\nUse a concise finished reply.\n```",
+                originalDisplayText: "do the thing"
+            ) == "Use a concise finished reply."
+        )
+    }
+
+    @Test func providerTextInsertsGoalBeforeAttachments() {
+        let path = "\(CPSLVirtualPath.attachments)/conv/file.txt"
+        let prompt = CPSLAttachmentPrompt(
+            displayText: "Please review this",
+            attachments: [CPSLAttachment(name: "file.txt", path: path)]
+        )
+        let goal = "Return a finished review of the attached file."
+        let next = prompt.embeddingClarifiedGoal(goal)
+        #expect(next.displayText == "Please review this")
+        #expect(next.providerText.contains("Please review this"))
+        #expect(next.providerText.contains(CPSLGoalClarification.endGoalHeading))
+        #expect(next.providerText.contains(goal))
+        #expect(next.providerText.contains(CPSLAttachmentPrompt.attachedFilesHeading))
+        #expect(next.providerText.contains(path))
+
+        let goalRange = next.providerText.range(of: goal)!
+        let attachRange = next.providerText.range(of: CPSLAttachmentPrompt.attachedFilesHeading)!
+        #expect(goalRange.lowerBound < attachRange.lowerBound)
+
+        let parsed = CPSLAttachmentPrompt.parse(next.providerText)
+        #expect(parsed.attachments.map(\.path) == [path])
+    }
+
+    @Test func shouldClarifySkipsEmptyDisplay() {
+        #expect(CPSLGoalClarification.shouldClarify(displayText: "  ") == false)
+        #expect(CPSLGoalClarification.shouldClarify(displayText: "Go") == true)
+    }
+
+    @Test func applyingClarifiedGoalHelperMatchesEmbedding() {
+        let prompt = CPSLAttachmentPrompt(displayText: "Ship the report", attachments: [])
+        let goal = "Produce the finished report content in the reply."
+        let a = CPSLGoalClarification.applyingClarifiedGoal(goal, to: prompt)
+        let b = prompt.embeddingClarifiedGoal(goal)
+        #expect(a == b)
+    }
+}
+
+/// Locates shipped ChatModel source so tests assert real wiring, not a reimplementation.
+private enum SystemPromptSource {
+    static func chatModelSource() throws -> String {
+        let fileManager = FileManager.default
+        let cwd = URL(fileURLWithPath: fileManager.currentDirectoryPath, isDirectory: true)
+        let candidates = [
+            cwd.appendingPathComponent("app/apple/herm/Models/CPSLChatModel.swift"),
+            cwd.appendingPathComponent("Models/CPSLChatModel.swift"),
+            cwd.deletingLastPathComponent().appendingPathComponent("Models/CPSLChatModel.swift"),
+            URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent("herm/Models/CPSLChatModel.swift")
+        ]
+        for url in candidates where fileManager.fileExists(atPath: url.path) {
+            return try String(contentsOf: url, encoding: .utf8)
+        }
+        throw SourceLookupError.missingChatModel
+    }
+
+    private enum SourceLookupError: Error {
+        case missingChatModel
+    }
+}

--- a/scripts/vet-apple-agent-integration.sh
+++ b/scripts/vet-apple-agent-integration.sh
@@ -89,6 +89,7 @@ required_files=(
   scripts/vet-apple-conversation-store.swift
   scripts/vet-apple-openai-protocol.swift
   scripts/vet-apple-agent-pcc.swift
+  scripts/vet-apple-goal-clarification.swift
   scripts/generate-apple-pcc-runtime.sh
   scripts/apple-pcc/CPSLPCCRuntime.full.swift
   scripts/apple-pcc/CPSLPCCRuntime.stub.swift
@@ -456,6 +457,12 @@ require_match '"language": language' app/apple/herm/Services/CPSLDebugService.sw
 require_match 'CPSLAgentToolFormatting\.providerContent' app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
 require_match 'CPSLAgentToolFormatting\.displayBody' app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
 require_match 'CPSLAgentToolFormatting\.agentInput' app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
+require_match 'CPSLGoalClarification\.mainAgentCompletionContract' app/apple/herm/Models/CPSLChatModel.swift
+require_match 'clarifyingUserPrompt' app/apple/herm/Models/CPSLChatModel.swift
+require_match 'Carry each user request through to a finished result' app/apple/herm/Models/CPSLGoalClarification.swift
+require_match 'endGoalHeading' app/apple/herm/Models/CPSLGoalClarification.swift
+require_match 'embeddingClarifiedGoal' app/apple/herm/Models/CPSLAttachmentPrompt.swift
+require_match 'vet-apple-goal-clarification: ok' scripts/vet-apple-goal-clarification.swift
 require_match 'nonNegativeIntValue' app/apple/herm/Services/Agent/CPSLAgentConfig.swift
 require_match 'Set\(object\.keys\)\.isSubset\(of: \["source", "intent"\]\)' app/apple/herm/Services/Agent/CPSLAgentToolFormatting.swift
 require_match 'unknown fields should not decode' scripts/vet-apple-agent-tool-formatting.swift
@@ -661,6 +668,12 @@ if command -v swiftc >/dev/null 2>&1; then
     scripts/vet-apple-agent-pcc.swift \
     -o /tmp/herm-vet-agent-pcc
   /tmp/herm-vet-agent-pcc
+  swiftc \
+    app/apple/herm/Models/CPSLGoalClarification.swift \
+    app/apple/herm/Models/CPSLAttachmentPrompt.swift \
+    scripts/vet-apple-goal-clarification.swift \
+    -o /tmp/herm-vet-goal-clarification
+  /tmp/herm-vet-goal-clarification
   swiftc -parse-as-library scripts/vet-apple-agent-concurrency-ui.swift -o /tmp/herm-vet-agent-concurrency-ui
   /tmp/herm-vet-agent-concurrency-ui
   swiftc \

--- a/scripts/vet-apple-agent-integration.sh
+++ b/scripts/vet-apple-agent-integration.sh
@@ -459,8 +459,11 @@ require_match 'CPSLAgentToolFormatting\.displayBody' app/apple/herm/Models/CPSLC
 require_match 'CPSLAgentToolFormatting\.agentInput' app/apple/herm/Models/CPSLChatModel+AgentRuntime.swift
 require_match 'CPSLGoalClarification\.mainAgentCompletionContract' app/apple/herm/Models/CPSLChatModel.swift
 require_match 'clarifyingUserPrompt' app/apple/herm/Models/CPSLChatModel.swift
+require_match 'updateNodeProviderMessage' app/apple/herm/Models/CPSLChatModel.swift
+require_match 'node\.provider_message_updated' app/apple/herm/Services/Agent/CPSLConversationStore.swift
 require_match 'Carry each user request through to a finished result' app/apple/herm/Models/CPSLGoalClarification.swift
 require_match 'endGoalHeading' app/apple/herm/Models/CPSLGoalClarification.swift
+require_match 'runAgentSourcePersistsUserBeforeClarify' app/apple/herm/Models/CPSLGoalClarification.swift
 require_match 'embeddingClarifiedGoal' app/apple/herm/Models/CPSLAttachmentPrompt.swift
 require_match 'vet-apple-goal-clarification: ok' scripts/vet-apple-goal-clarification.swift
 require_match 'nonNegativeIntValue' app/apple/herm/Services/Agent/CPSLAgentConfig.swift

--- a/scripts/vet-apple-goal-clarification.swift
+++ b/scripts/vet-apple-goal-clarification.swift
@@ -18,6 +18,7 @@ private struct CPSLGoalClarificationChecks {
         try assertDisplayVsProviderSplit()
         try assertProviderTextKeepsAttachments()
         try assertShippedChatModelWiresHelpers()
+        try assertWriteBeforeClarifyOrder()
         print("vet-apple-goal-clarification: ok")
     }
 
@@ -110,7 +111,8 @@ private struct CPSLGoalClarificationChecks {
         for needle in [
             "CPSLGoalClarification.mainAgentCompletionContract",
             "clarifyingUserPrompt",
-            "clarifyEndGoal"
+            "clarifyEndGoal",
+            "updateNodeProviderMessage"
         ] {
             guard source.contains(needle) else {
                 throw CheckFailure("CPSLChatModel.swift must wire \(needle)")
@@ -120,6 +122,27 @@ private struct CPSLGoalClarificationChecks {
             guard !source.contains(banned) else {
                 throw CheckFailure("ChatModel must not hard-code task category \(banned)")
             }
+        }
+    }
+
+    private static func assertWriteBeforeClarifyOrder() throws {
+        let source = try loadChatModelSource()
+        guard CPSLGoalClarification.runAgentSourcePersistsUserBeforeClarify(source) else {
+            throw CheckFailure(
+                "runAgent must persist user turn (prompt.displayText) before clarifyingUserPrompt, then updateNodeProviderMessage"
+            )
+        }
+        // Config load must not gate the user write.
+        guard let createRange = source.range(of: "createConversation("),
+              let configRange = source.range(of: "CPSLAgentConfig.load()"),
+              createRange.lowerBound < configRange.lowerBound
+        else {
+            throw CheckFailure("createConversation must run before CPSLAgentConfig.load()")
+        }
+        guard CPSLGoalClarification.submitPhaseOrder.first == .persistUserTurn,
+              CPSLGoalClarification.submitPhaseOrder.contains(.clarifyEndGoal)
+        else {
+            throw CheckFailure("submit phase order must start with persistUserTurn")
         }
     }
 

--- a/scripts/vet-apple-goal-clarification.swift
+++ b/scripts/vet-apple-goal-clarification.swift
@@ -1,0 +1,142 @@
+import Foundation
+
+// Minimal host types so this vet compiles without SwiftUI (CPSLTypes.swift).
+nonisolated enum CPSLVirtualPath {
+    static let attachments = "/attachments"
+}
+
+nonisolated struct CPSLAttachment: Equatable, Sendable {
+    let name: String
+    let path: String
+}
+
+@main
+private struct CPSLGoalClarificationChecks {
+    static func main() throws {
+        try assertCompletionContractDomainAgnostic()
+        try assertNormalizeAndFailOpen()
+        try assertDisplayVsProviderSplit()
+        try assertProviderTextKeepsAttachments()
+        try assertShippedChatModelWiresHelpers()
+        print("vet-apple-goal-clarification: ok")
+    }
+
+    private static func assertCompletionContractDomainAgnostic() throws {
+        let contract = CPSLGoalClarification.mainAgentCompletionContract
+        guard CPSLGoalClarification.systemPromptContainsCompletionContract(contract) else {
+            throw CheckFailure("completion contract missing carry-through / handoff / skills guidance")
+        }
+        let lower = contract.lowercased()
+        for banned in ["barber", "restaurant nearby", "for nearby places:"] {
+            guard !lower.contains(banned) else {
+                throw CheckFailure("completion contract must not hard-code task types (\(banned))")
+            }
+        }
+    }
+
+    private static func assertNormalizeAndFailOpen() throws {
+        guard CPSLGoalClarification.normalizedClarifiedGoal(
+            "  \n",
+            originalDisplayText: "hello"
+        ) == nil else {
+            throw CheckFailure("empty clarify output should fail open")
+        }
+        guard CPSLGoalClarification.normalizedClarifiedGoal(
+            "hello",
+            originalDisplayText: "Hello"
+        ) == nil else {
+            throw CheckFailure("echo of original should fail open")
+        }
+        let goal = CPSLGoalClarification.normalizedClarifiedGoal(
+            "```\nDeliver a finished answer in the reply.\n```",
+            originalDisplayText: "do it"
+        )
+        guard goal == "Deliver a finished answer in the reply." else {
+            throw CheckFailure("fenced clarify output was not normalized: \(goal ?? "nil")")
+        }
+        guard CPSLGoalClarification.shouldClarify(displayText: "  ") == false else {
+            throw CheckFailure("blank display text should skip clarify")
+        }
+        guard CPSLGoalClarification.shouldClarify(displayText: "Go") else {
+            throw CheckFailure("non-empty display text should allow clarify")
+        }
+    }
+
+    private static func assertDisplayVsProviderSplit() throws {
+        let original = "Please handle this request"
+        let prompt = CPSLAttachmentPrompt(displayText: original, attachments: [])
+        let clarified = "Return the finished result in the assistant reply."
+        let next = prompt.embeddingClarifiedGoal(clarified)
+        guard next.displayText == original else {
+            throw CheckFailure("display text must stay the user's original message")
+        }
+        guard next.providerText.contains(original),
+              next.providerText.contains(CPSLGoalClarification.endGoalHeading),
+              next.providerText.contains(clarified)
+        else {
+            throw CheckFailure("provider text must embed original + end goal")
+        }
+        let failed = CPSLGoalClarification.applyingClarifiedGoal(nil, to: prompt)
+        guard failed.providerText == original, failed.displayText == original else {
+            throw CheckFailure("fail-open must leave display and provider as original")
+        }
+    }
+
+    private static func assertProviderTextKeepsAttachments() throws {
+        let path = "\(CPSLVirtualPath.attachments)/conv/note.txt"
+        let prompt = CPSLAttachmentPrompt(
+            displayText: "Review this",
+            attachments: [CPSLAttachment(name: "note.txt", path: path)]
+        )
+        let goal = "Provide a finished review in the reply."
+        let next = prompt.embeddingClarifiedGoal(goal)
+        guard next.displayText == "Review this" else {
+            throw CheckFailure("attachment prompt display text changed")
+        }
+        guard let goalRange = next.providerText.range(of: goal),
+              let attachRange = next.providerText.range(of: CPSLAttachmentPrompt.attachedFilesHeading),
+              goalRange.lowerBound < attachRange.lowerBound
+        else {
+            throw CheckFailure("end goal must appear before attached files section")
+        }
+        let parsed = CPSLAttachmentPrompt.parse(next.providerText)
+        guard parsed.attachments.map(\.path) == [path] else {
+            throw CheckFailure("attachment parse lost paths after end-goal embed")
+        }
+    }
+
+    private static func assertShippedChatModelWiresHelpers() throws {
+        let source = try loadChatModelSource()
+        for needle in [
+            "CPSLGoalClarification.mainAgentCompletionContract",
+            "clarifyingUserPrompt",
+            "clarifyEndGoal"
+        ] {
+            guard source.contains(needle) else {
+                throw CheckFailure("CPSLChatModel.swift must wire \(needle)")
+            }
+        }
+        for banned in ["for nearby places:", "barber shop options", "restaurant nearby"] {
+            guard !source.contains(banned) else {
+                throw CheckFailure("ChatModel must not hard-code task category \(banned)")
+            }
+        }
+    }
+
+    private static func loadChatModelSource() throws -> String {
+        let fileManager = FileManager.default
+        let cwd = URL(fileURLWithPath: fileManager.currentDirectoryPath, isDirectory: true)
+        let url = cwd.appendingPathComponent("app/apple/herm/Models/CPSLChatModel.swift")
+        guard fileManager.fileExists(atPath: url.path) else {
+            throw CheckFailure("could not find CPSLChatModel.swift from \(cwd.path)")
+        }
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+}
+
+private struct CheckFailure: Error, CustomStringConvertible {
+    let description: String
+    init(_ description: String) {
+        self.description = description
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a **domain-agnostic complete-through-end contract** to the main Herm agent system prompt (and a lighter line for sub-agents). Skills still own domain procedures; no task-type hardcoding (no barber/restaurant/nearby branches).
- Adds an **internal tools-free goal clarification** step on each user submit: the timeline keeps the user's original text, while the provider-facing user message may include an `End goal:` restatement so weaker models (e.g. PCC) get an explicit success criterion. Errors/timeouts **fail open** to the original provider text.
- Pure helpers + vet + hermTests cover the completion-contract text, display-vs-provider split, attachment placement, and fail-open behavior.

## Test plan
- [x] `swiftc` + `scripts/vet-apple-goal-clarification.swift` (drives shipped `CPSLGoalClarification` / `CPSLAttachmentPrompt`)
- [x] Source gating: `CPSLChatModel` embeds `mainAgentCompletionContract` + `clarifyingUserPrompt`
- [ ] Manual: iOS/macOS PCC run of "find a barber nearby" should aim for a finished chat answer without requiring a second "search yourself" turn (device-only)
- [ ] hermTests `CPSLGoalClarificationTests` when running Xcode test target